### PR TITLE
feat: adiciona hub do Portal de RH e tela de Meus Documentos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -49,6 +49,8 @@ import { DocumentosComponent } from './components/auth/documentos/documentos.com
 import { NotificacoesComponent } from './components/auth/notificacoes/notificacoes.component';
 import { PerfilComponent } from './components/auth/perfil/perfil.component';
 import { HoleritesComponent } from './components/auth/holerites/holerites.component';
+import { HrHubComponent } from './components/auth/hr-hub/hr-hub.component';
+import { HrDocumentsComponent } from './components/auth/hr-documents/hr-documents.component';
 import {FirstAccessComponent} from "./components/public/first-access/first-access.component";
 
 
@@ -106,6 +108,8 @@ export const routes: Routes = [
       { path: 'documentos', component: DocumentosComponent },
       { path: 'documentos/logos', component: BrandingComponent },
       { path: 'documentos/holerites', component: HoleritesComponent },
+      { path: 'documentos/rh', component: HrHubComponent },
+      { path: 'documentos/rh/documents', component: HrDocumentsComponent },
       { path: 'notificacoes', component: NotificacoesComponent },
       { path: 'perfil', component: PerfilComponent },
     ]

--- a/src/app/components/auth/documentos/documentos.component.ts
+++ b/src/app/components/auth/documentos/documentos.component.ts
@@ -21,7 +21,7 @@ export class DocumentosComponent {
     { titulo: 'Apresentações', descricao: 'Materiais institucionais e de vendas',   icon: 'pi pi-desktop' },
     { titulo: 'Logos',         descricao: 'Identidade visual e arquivos da marca',   icon: 'pi pi-palette',  rota: '/documentos/logos' },
     { titulo: 'Holerites',     descricao: 'Seus demonstrativos de pagamento',        icon: 'pi pi-receipt',  rota: '/documentos/holerites' },
-    { titulo: 'Pessoal',       descricao: 'Documentos de RH e pessoais',             icon: 'pi pi-id-card' },
+    { titulo: 'Pessoal',       descricao: 'Documentos de RH e pessoais',             icon: 'pi pi-id-card',  rota: '/documentos/rh' },
     { titulo: 'Propostas',     descricao: 'Modelos e propostas comerciais',          icon: 'pi pi-file-edit' },
   ];
 

--- a/src/app/components/auth/hr-documents/hr-documents.component.html
+++ b/src/app/components/auth/hr-documents/hr-documents.component.html
@@ -1,0 +1,33 @@
+<section class="hrd-page">
+  <header class="hrd-header">
+    <h1>Meus Documentos</h1>
+    <p>Documentos vinculados pelo RH ao seu cadastro.</p>
+  </header>
+
+  @if (loading()) {
+    <div class="hrd-state"><i class="pi pi-spin pi-spinner"></i> Carregando...</div>
+  } @else if (erro()) {
+    <div class="hrd-state">Não foi possível carregar seus documentos. Tente novamente mais tarde.</div>
+  } @else if (documents().length === 0) {
+    <div class="hrd-empty">
+      <span class="hrd-empty-icon"><i class="pi pi-id-card"></i></span>
+      <p>Nenhum documento disponível ainda</p>
+      <small>Quando o RH vincular um documento ao seu cadastro, ele aparece aqui automaticamente.</small>
+    </div>
+  } @else {
+    <div class="hrd-grid">
+      @for (doc of documents(); track doc.id) {
+        <div class="hrd-card">
+          <span class="hrd-card__icon"><i class="pi pi-file"></i></span>
+          <div class="hrd-card__info">
+            <span class="hrd-card__title">{{ doc.title }}</span>
+            <span class="hrd-card__meta">{{ formatDate(doc.uploadedAt) }}</span>
+          </div>
+          <button class="hrd-card__btn" (click)="baixar(doc)" [disabled]="baixandoId() === doc.id" aria-label="Baixar documento">
+            <i class="pi" [ngClass]="baixandoId() === doc.id ? 'pi-spin pi-spinner' : 'pi-download'"></i>
+          </button>
+        </div>
+      }
+    </div>
+  }
+</section>

--- a/src/app/components/auth/hr-documents/hr-documents.component.scss
+++ b/src/app/components/auth/hr-documents/hr-documents.component.scss
@@ -1,0 +1,137 @@
+@use 'variables' as v;
+
+.hrd-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.hrd-header {
+  margin-bottom: 28px;
+
+  h1 {
+    font-family: v.$font-heading;
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: v.$primary;
+    margin: 0 0 6px;
+  }
+
+  p {
+    color: #6b7492;
+    font-size: 0.98rem;
+    margin: 0;
+  }
+}
+
+.hrd-state {
+  padding: 40px 0;
+  color: #6b7492;
+  text-align: center;
+}
+
+.hrd-empty {
+  text-align: center;
+  color: #9aa6bd;
+  padding: 56px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  .hrd-empty-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    i { font-size: 2.2rem; }
+  }
+
+  p { margin: 0; font-weight: 700; color: #6b7492; }
+  small { font-size: 0.85rem; max-width: 260px; line-height: 1.5; }
+}
+
+.hrd-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hrd-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 18px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: rgba(87, 193, 171, 0.5);
+    box-shadow: 0 8px 24px rgba(35, 46, 97, 0.07);
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(35, 46, 97, 0.08);
+    color: v.$primary;
+    i { font-size: 1.4rem; }
+  }
+
+  &__info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: v.$primary;
+  }
+
+  &__meta {
+    font-size: 0.82rem;
+    color: #8a93a8;
+  }
+
+  &__btn {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    background: linear-gradient(135deg, v.$primary, v.$secondary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    box-shadow: 0 6px 16px rgba(35, 46, 97, 0.22);
+
+    i { font-size: 1.05rem; }
+
+    &:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 10px 22px rgba(35, 46, 97, 0.30); }
+    &:disabled { opacity: 0.6; cursor: default; }
+  }
+}
+
+@media (max-width: 600px) {
+  .hrd-page { padding: 24px 16px 40px; }
+  .hrd-header h1 { font-size: 1.6rem; }
+}

--- a/src/app/components/auth/hr-documents/hr-documents.component.ts
+++ b/src/app/components/auth/hr-documents/hr-documents.component.ts
@@ -1,0 +1,53 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EmployeeDocumentService } from '../../../infrastructure/services/hr/employee-document.service';
+import { EmployeeDocument } from '../../../domain/models/hr/employee-document.model';
+
+@Component({
+  selector: 'app-hr-documents',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './hr-documents.component.html',
+  styleUrl: './hr-documents.component.scss',
+})
+export class HrDocumentsComponent implements OnInit {
+  documents = signal<EmployeeDocument[]>([]);
+  loading = signal(true);
+  erro = signal(false);
+  baixandoId = signal<string | null>(null);
+
+  constructor(private service: EmployeeDocumentService) {}
+
+  ngOnInit(): void {
+    this.service.getMine().subscribe({
+      next: (data) => {
+        this.documents.set(data ?? []);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.erro.set(true);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  baixar(doc: EmployeeDocument): void {
+    this.baixandoId.set(doc.id);
+    this.service.download(doc.id).subscribe({
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = doc.originalFilename;
+        a.click();
+        URL.revokeObjectURL(url);
+        this.baixandoId.set(null);
+      },
+      error: () => this.baixandoId.set(null),
+    });
+  }
+}

--- a/src/app/components/auth/hr-hub/hr-hub.component.html
+++ b/src/app/components/auth/hr-hub/hr-hub.component.html
@@ -1,0 +1,23 @@
+<section class="hrh-page">
+  <header class="hrh-header">
+    <h1>Portal de RH</h1>
+    <p>Seus atendimentos e solicitações junto ao RH.</p>
+  </header>
+
+  <div class="hrh-grid">
+    @for (cat of categorias; track cat.titulo) {
+      <button type="button" class="hrh-card" (click)="abrir(cat)" [class.hrh-card--disabled]="!cat.rota">
+        <span class="hrh-card__icon"><i [class]="cat.icon"></i></span>
+        <span class="hrh-card__body">
+          <span class="hrh-card__title">{{ cat.titulo }}</span>
+          <span class="hrh-card__desc">{{ cat.descricao }}</span>
+        </span>
+        @if (cat.rota) {
+          <i class="pi pi-chevron-right hrh-card__arrow"></i>
+        } @else {
+          <span class="hrh-card__soon">em breve</span>
+        }
+      </button>
+    }
+  </div>
+</section>

--- a/src/app/components/auth/hr-hub/hr-hub.component.scss
+++ b/src/app/components/auth/hr-hub/hr-hub.component.scss
@@ -1,0 +1,138 @@
+@use 'variables' as v;
+
+.hrh-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.hrh-header {
+  margin-bottom: 28px;
+
+  h1 {
+    font-family: v.$font-heading;
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: v.$primary;
+    margin: 0 0 6px;
+  }
+
+  p {
+    color: #6b7492;
+    font-size: 0.98rem;
+    margin: 0;
+  }
+}
+
+.hrh-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.hrh-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  text-align: left;
+  padding: 22px 20px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 18px;
+  cursor: pointer;
+  transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+
+  &__icon {
+    flex-shrink: 0;
+    width: 56px;
+    height: 56px;
+    border-radius: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    transition: background 0.3s ease, color 0.3s ease;
+
+    i { font-size: 1.5rem; }
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    flex: 1;
+  }
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: v.$primary;
+  }
+
+  &__desc {
+    font-size: 0.85rem;
+    color: #6b7492;
+    line-height: 1.4;
+  }
+
+  &__arrow {
+    flex-shrink: 0;
+    color: #b8c2d4;
+    font-size: 0.9rem;
+    transition: transform 0.22s ease, color 0.22s ease;
+  }
+
+  &__soon {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #9aa6bd;
+    background: #f1f3f8;
+    padding: 4px 10px;
+    border-radius: 999px;
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+    border-color: rgba(87, 193, 171, 0.5);
+    box-shadow: 0 16px 40px rgba(35, 46, 97, 0.10);
+
+    .hrh-card__icon {
+      background: linear-gradient(135deg, v.$primary, v.$secondary);
+      color: #ffffff;
+    }
+
+    .hrh-card__arrow {
+      color: v.$secondary-dark;
+      transform: translateX(3px);
+    }
+  }
+
+  &:active { transform: translateY(-1px); }
+
+  &--disabled {
+    cursor: default;
+
+    &:hover {
+      transform: none;
+      border-color: #e6e9f0;
+      box-shadow: none;
+
+      .hrh-card__icon {
+        background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+        color: v.$primary;
+      }
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .hrh-page { padding: 24px 16px 40px; }
+  .hrh-grid { grid-template-columns: 1fr; }
+  .hrh-header h1 { font-size: 1.6rem; }
+}

--- a/src/app/components/auth/hr-hub/hr-hub.component.ts
+++ b/src/app/components/auth/hr-hub/hr-hub.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+interface HrCategoria {
+  titulo: string;
+  descricao: string;
+  icon: string;
+  rota?: string;   // quando definida, o card navega; senão, é placeholder
+}
+
+@Component({
+  selector: 'app-hr-hub',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './hr-hub.component.html',
+  styleUrl: './hr-hub.component.scss',
+})
+export class HrHubComponent {
+  categorias: HrCategoria[] = [
+    { titulo: 'Meus Documentos', descricao: 'Documentos vinculados pelo RH ao seu cadastro',       icon: 'pi pi-id-card', rota: '/documentos/rh/documents' },
+    { titulo: 'Atestados',       descricao: 'Envie atestados e acompanhe seu histórico',            icon: 'pi pi-heart' },
+    { titulo: 'Reembolsos',      descricao: 'Solicite reembolsos e acompanhe o status',              icon: 'pi pi-wallet' },
+    { titulo: 'Férias',          descricao: 'Solicite férias e acompanhe seu saldo',                 icon: 'pi pi-sun' },
+  ];
+
+  constructor(private router: Router) {}
+
+  abrir(cat: HrCategoria): void {
+    if (cat.rota) {
+      this.router.navigate([cat.rota]);
+    }
+    // sem rota → ainda não disponível
+  }
+}

--- a/src/app/domain/models/hr/employee-document.model.ts
+++ b/src/app/domain/models/hr/employee-document.model.ts
@@ -1,0 +1,7 @@
+export interface EmployeeDocument {
+  id: string;
+  employeeId: string;
+  title: string;
+  originalFilename: string;
+  uploadedAt: string;
+}

--- a/src/app/infrastructure/services/hr/employee-document.service.ts
+++ b/src/app/infrastructure/services/hr/employee-document.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { EmployeeDocument } from '../../../domain/models/hr/employee-document.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class EmployeeDocumentService {
+
+  constructor(private http: HttpClient) {}
+
+  getMine(): Observable<EmployeeDocument[]> {
+    return this.http.get<EmployeeDocument[]>(`${environment.apiUrl}/hr/employee-documents/me`);
+  }
+
+  download(id: string): Observable<Blob> {
+    return this.http.get(`${environment.apiUrl}/hr/employee-documents/${id}/arquivo`, {
+      responseType: 'blob'
+    });
+  }
+}


### PR DESCRIPTION
  Liga o card 'Pessoal' do hub de Documentos (que não tinha rota) a um
  hub novo com 4 categorias — Documentos, Atestados, Reembolsos e
  Férias. Só Documentos está funcional por enquanto (as outras 3 ficam
  com 'em breve' até serem construídas). HrDocumentsComponent espelha o
  HoleritesComponent (signals, GET /me, download por blob) contra os
  novos endpoints /api/hr/employee-documents.
