### PR TITLE
feat: adiciona tela de envio de atestados com confirmação de legibilidade

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -51,6 +51,7 @@ import { PerfilComponent } from './components/auth/perfil/perfil.component';
 import { HoleritesComponent } from './components/auth/holerites/holerites.component';
 import { HrHubComponent } from './components/auth/hr-hub/hr-hub.component';
 import { HrDocumentsComponent } from './components/auth/hr-documents/hr-documents.component';
+import { HrMedicalCertificatesComponent } from './components/auth/hr-medical-certificates/hr-medical-certificates.component';
 import {FirstAccessComponent} from "./components/public/first-access/first-access.component";
 
 
@@ -110,6 +111,7 @@ export const routes: Routes = [
       { path: 'documentos/holerites', component: HoleritesComponent },
       { path: 'documentos/rh', component: HrHubComponent },
       { path: 'documentos/rh/documents', component: HrDocumentsComponent },
+      { path: 'documentos/rh/medical-certificates', component: HrMedicalCertificatesComponent },
       { path: 'notificacoes', component: NotificacoesComponent },
       { path: 'perfil', component: PerfilComponent },
     ]

--- a/src/app/components/auth/hr-hub/hr-hub.component.ts
+++ b/src/app/components/auth/hr-hub/hr-hub.component.ts
@@ -19,7 +19,7 @@ interface HrCategoria {
 export class HrHubComponent {
   categorias: HrCategoria[] = [
     { titulo: 'Meus Documentos', descricao: 'Documentos vinculados pelo RH ao seu cadastro',       icon: 'pi pi-id-card', rota: '/documentos/rh/documents' },
-    { titulo: 'Atestados',       descricao: 'Envie atestados e acompanhe seu histórico',            icon: 'pi pi-heart' },
+    { titulo: 'Atestados',       descricao: 'Envie atestados e acompanhe seu histórico',            icon: 'pi pi-heart', rota: '/documentos/rh/medical-certificates' },
     { titulo: 'Reembolsos',      descricao: 'Solicite reembolsos e acompanhe o status',              icon: 'pi pi-wallet' },
     { titulo: 'Férias',          descricao: 'Solicite férias e acompanhe seu saldo',                 icon: 'pi pi-sun' },
   ];

--- a/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.html
+++ b/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.html
@@ -1,0 +1,120 @@
+<section class="hrmc-page">
+  <header class="hrmc-header">
+    <h1>Atestados</h1>
+    <p>Envie seus atestados médicos e acompanhe o histórico.</p>
+  </header>
+
+  <div class="hrmc-form-card">
+    <h2 class="hrmc-form-card__title"><i class="pi pi-plus-circle"></i> Novo atestado</h2>
+
+    <form [formGroup]="form">
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="startDate">Data inicial <span class="required">*</span></label>
+          <p-datepicker
+            id="startDate"
+            formControlName="startDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+        <div class="form-field">
+          <label for="endDate">Data final <span class="required">*</span></label>
+          <p-datepicker
+            id="endDate"
+            formControlName="endDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+        <div class="form-field">
+          <label for="submissionType">Como vai enviar? <span class="required">*</span></label>
+          <p-select
+            id="submissionType"
+            [options]="submissionTypes"
+            formControlName="submissionType"
+            optionLabel="label"
+            optionValue="value"
+            appendTo="body"
+            styleClass="select-field"
+            (onChange)="onSubmissionTypeChange()">
+          </p-select>
+        </div>
+      </div>
+
+      <div class="hrmc-upload">
+        @if (isPhoto) {
+          <label class="hrmc-upload__label" for="fileInput">
+            <i class="pi pi-camera"></i> Tirar foto ou escolher da galeria
+          </label>
+          <input id="fileInput" type="file" accept="image/*" capture="environment" (change)="onFileSelected($event)" />
+        } @else {
+          <label class="hrmc-upload__label" for="fileInput">
+            <i class="pi pi-upload"></i> Escolher arquivo
+          </label>
+          <input id="fileInput" type="file" accept=".pdf,.jpg,.jpeg,.png" (change)="onFileSelected($event)" />
+        }
+
+        @if (selectedFile) {
+          <span class="hrmc-upload__filename"><i class="pi pi-file"></i> {{ selectedFile.name }}</span>
+        }
+      </div>
+
+      @if (isPhoto && selectedFile) {
+        <div class="hrmc-legibility">
+          <pk-checkbox
+            inputId="legibility"
+            label="Confirmo que os dados da foto estão legíveis"
+            description="Confira se as informações do atestado estão nítidas antes de enviar"
+            [(ngModel)]="legibilityConfirmed"
+            [ngModelOptions]="{ standalone: true }">
+          </pk-checkbox>
+        </div>
+      }
+
+      <div class="hrmc-form-actions">
+        <pk-button
+          pkType="save"
+          pkLabel="Enviar atestado"
+          pkSize="sm"
+          [pkDisabled]="!podeEnviar || enviando()"
+          (clicked)="enviar()">
+        </pk-button>
+      </div>
+    </form>
+  </div>
+
+  <h2 class="hrmc-history-title">Meus atestados</h2>
+
+  @if (loading()) {
+    <div class="hrmc-state"><i class="pi pi-spin pi-spinner"></i> Carregando...</div>
+  } @else if (erro()) {
+    <div class="hrmc-state">Não foi possível carregar seus atestados. Tente novamente mais tarde.</div>
+  } @else if (certificates().length === 0) {
+    <div class="hrmc-empty">
+      <span class="hrmc-empty-icon"><i class="pi pi-heart"></i></span>
+      <p>Nenhum atestado enviado ainda</p>
+    </div>
+  } @else {
+    <div class="hrmc-grid">
+      @for (cert of certificates(); track cert.id) {
+        <div class="hrmc-card">
+          <span class="hrmc-card__icon">
+            <i class="pi" [ngClass]="cert.submissionType === 'PHOTO' ? 'pi-camera' : 'pi-file'"></i>
+          </span>
+          <div class="hrmc-card__info">
+            <span class="hrmc-card__title">{{ formatDate(cert.startDate) }} — {{ formatDate(cert.endDate) }}</span>
+            <span class="hrmc-card__meta">{{ cert.daysCount }} dia(s) · enviado em {{ formatDate(cert.submittedAt) }}</span>
+          </div>
+          <button class="hrmc-card__btn" (click)="baixar(cert)" [disabled]="baixandoId() === cert.id" aria-label="Baixar atestado">
+            <i class="pi" [ngClass]="baixandoId() === cert.id ? 'pi-spin pi-spinner' : 'pi-download'"></i>
+          </button>
+        </div>
+      }
+    </div>
+  }
+</section>

--- a/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.scss
+++ b/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.scss
@@ -1,0 +1,220 @@
+@use 'variables' as v;
+
+.hrmc-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.hrmc-header {
+  margin-bottom: 28px;
+
+  h1 {
+    font-family: v.$font-heading;
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: v.$primary;
+    margin: 0 0 6px;
+  }
+
+  p {
+    color: #6b7492;
+    font-size: 0.98rem;
+    margin: 0;
+  }
+}
+
+.hrmc-form-card {
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 18px;
+  padding: 24px;
+  margin-bottom: 40px;
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: v.$primary;
+    margin: 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.hrmc-upload {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+
+  &__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 12px;
+    border: 1px dashed rgba(35, 46, 97, 0.35);
+    color: v.$primary;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+
+    &:hover {
+      border-color: v.$secondary;
+      background: rgba(87, 193, 171, 0.08);
+    }
+  }
+
+  input[type='file'] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    overflow: hidden;
+  }
+
+  &__filename {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: #6b7492;
+  }
+}
+
+.hrmc-legibility {
+  margin-top: 16px;
+  padding: 14px 16px;
+  background: rgba(246, 173, 85, 0.10);
+  border: 1px solid rgba(246, 173, 85, 0.35);
+  border-radius: 12px;
+}
+
+.hrmc-form-actions {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hrmc-history-title {
+  font-family: v.$font-heading;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: v.$primary;
+  margin: 0 0 16px;
+}
+
+.hrmc-state {
+  padding: 40px 0;
+  color: #6b7492;
+  text-align: center;
+}
+
+.hrmc-empty {
+  text-align: center;
+  color: #9aa6bd;
+  padding: 56px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  .hrmc-empty-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    i { font-size: 2.2rem; }
+  }
+
+  p { margin: 0; font-weight: 700; color: #6b7492; }
+}
+
+.hrmc-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hrmc-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 18px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: rgba(87, 193, 171, 0.5);
+    box-shadow: 0 8px 24px rgba(35, 46, 97, 0.07);
+  }
+
+  &__icon {
+    flex-shrink: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 13px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(35, 46, 97, 0.08);
+    color: v.$primary;
+    i { font-size: 1.4rem; }
+  }
+
+  &__info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.0rem;
+    font-weight: 700;
+    color: v.$primary;
+  }
+
+  &__meta {
+    font-size: 0.82rem;
+    color: #8a93a8;
+  }
+
+  &__btn {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 12px;
+    cursor: pointer;
+    background: linear-gradient(135deg, v.$primary, v.$secondary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    box-shadow: 0 6px 16px rgba(35, 46, 97, 0.22);
+
+    i { font-size: 1.05rem; }
+
+    &:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 10px 22px rgba(35, 46, 97, 0.30); }
+    &:disabled { opacity: 0.6; cursor: default; }
+  }
+}
+
+@media (max-width: 600px) {
+  .hrmc-page { padding: 24px 16px 40px; }
+  .hrmc-header h1 { font-size: 1.6rem; }
+}

--- a/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.ts
+++ b/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.ts
@@ -1,0 +1,148 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { SelectModule } from 'primeng/select';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkCheckboxComponent } from '../../theme/ProautoKimium/pk-checkbox/pk-checkbox.component';
+import { MedicalCertificateService } from '../../../infrastructure/services/hr/medical-certificate.service';
+import { MedicalCertificate, SubmissionType } from '../../../domain/models/hr/medical-certificate.model';
+
+@Component({
+  selector: 'app-hr-medical-certificates',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    FormsModule,
+    SelectModule,
+    DatePickerModule,
+    PkButtonComponent,
+    PkCheckboxComponent,
+  ],
+  templateUrl: './hr-medical-certificates.component.html',
+  styleUrl: './hr-medical-certificates.component.scss',
+})
+export class HrMedicalCertificatesComponent implements OnInit {
+  certificates = signal<MedicalCertificate[]>([]);
+  loading = signal(true);
+  erro = signal(false);
+  enviando = signal(false);
+  baixandoId = signal<string | null>(null);
+
+  selectedFile: File | null = null;
+  legibilityConfirmed = false;
+
+  form: FormGroup;
+
+  submissionTypes = [
+    { label: 'Arquivo', value: 'FILE' },
+    { label: 'Foto', value: 'PHOTO' },
+  ];
+
+  constructor(private service: MedicalCertificateService, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      startDate: [null, Validators.required],
+      endDate: [null, Validators.required],
+      submissionType: ['FILE', Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading.set(true);
+    this.service.getMine().subscribe({
+      next: (data) => {
+        this.certificates.set(data ?? []);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.erro.set(true);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  get isPhoto(): boolean {
+    return this.form.get('submissionType')?.value === 'PHOTO';
+  }
+
+  // Toda vez que troca o tipo ou o arquivo, a confirmação de legibilidade precisa
+  // ser refeita — não faz sentido carregar a confirmação de uma foto anterior.
+  onSubmissionTypeChange(): void {
+    this.selectedFile = null;
+    this.legibilityConfirmed = false;
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedFile = input.files?.[0] ?? null;
+    this.legibilityConfirmed = false;
+  }
+
+  get podeEnviar(): boolean {
+    if (this.form.invalid || !this.selectedFile) return false;
+    if (this.isPhoto && !this.legibilityConfirmed) return false;
+    return true;
+  }
+
+  enviar(): void {
+    if (!this.podeEnviar || !this.selectedFile) return;
+
+    this.enviando.set(true);
+    const { startDate, endDate, submissionType } = this.form.value as {
+      startDate: Date;
+      endDate: Date;
+      submissionType: SubmissionType;
+    };
+
+    this.service
+      .submit({
+        startDate: this.toIsoDate(startDate),
+        endDate: this.toIsoDate(endDate),
+        submissionType,
+        confirmedLegible: submissionType === 'PHOTO' ? true : null,
+        file: this.selectedFile,
+      })
+      .subscribe({
+        next: () => {
+          this.enviando.set(false);
+          this.selectedFile = null;
+          this.legibilityConfirmed = false;
+          this.form.reset({ submissionType: 'FILE' });
+          this.carregar();
+        },
+        error: () => this.enviando.set(false),
+      });
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  baixar(cert: MedicalCertificate): void {
+    this.baixandoId.set(cert.id);
+    this.service.download(cert.id).subscribe({
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = cert.originalFilename;
+        a.click();
+        URL.revokeObjectURL(url);
+        this.baixandoId.set(null);
+      },
+      error: () => this.baixandoId.set(null),
+    });
+  }
+}

--- a/src/app/domain/models/hr/medical-certificate.model.ts
+++ b/src/app/domain/models/hr/medical-certificate.model.ts
@@ -1,0 +1,13 @@
+export type SubmissionType = 'PHOTO' | 'FILE';
+
+export interface MedicalCertificate {
+  id: string;
+  employeeId: string;
+  startDate: string;
+  endDate: string;
+  daysCount: number;
+  submissionType: SubmissionType;
+  confirmedLegible: boolean | null;
+  originalFilename: string;
+  submittedAt: string;
+}

--- a/src/app/infrastructure/services/hr/medical-certificate.service.ts
+++ b/src/app/infrastructure/services/hr/medical-certificate.service.ts
@@ -1,0 +1,44 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { MedicalCertificate, SubmissionType } from '../../../domain/models/hr/medical-certificate.model';
+
+export interface SubmitMedicalCertificatePayload {
+  startDate: string;
+  endDate: string;
+  submissionType: SubmissionType;
+  confirmedLegible: boolean | null;
+  file: File;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MedicalCertificateService {
+
+  constructor(private http: HttpClient) {}
+
+  getMine(): Observable<MedicalCertificate[]> {
+    return this.http.get<MedicalCertificate[]>(`${environment.apiUrl}/hr/medical-certificates/me`);
+  }
+
+  submit(payload: SubmitMedicalCertificatePayload): Observable<MedicalCertificate> {
+    const formData = new FormData();
+    formData.append('startDate', payload.startDate);
+    formData.append('endDate', payload.endDate);
+    formData.append('submissionType', payload.submissionType);
+    if (payload.confirmedLegible !== null) {
+      formData.append('confirmedLegible', String(payload.confirmedLegible));
+    }
+    formData.append('file', payload.file);
+
+    return this.http.post<MedicalCertificate>(`${environment.apiUrl}/hr/medical-certificates`, formData);
+  }
+
+  download(id: string): Observable<Blob> {
+    return this.http.get(`${environment.apiUrl}/hr/medical-certificates/${id}/file`, {
+      responseType: 'blob'
+    });
+  }
+}


### PR DESCRIPTION
  Formulário com período, tipo de envio (arquivo ou foto) e upload —
  no modo foto, o botão de enviar só libera depois de marcar a
  confirmação de legibilidade (mesma regra que o back-end já valida
  no MedicalCertificate.submit()). Histórico abaixo do formulário,
  mesmo padrão visual de card usado em Meus Documentos. Liga o card
  Atestados no hub.
