### PR TITLE
feat: adiciona tela de solicitação de reembolso com comprovante

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,6 +52,7 @@ import { HoleritesComponent } from './components/auth/holerites/holerites.compon
 import { HrHubComponent } from './components/auth/hr-hub/hr-hub.component';
 import { HrDocumentsComponent } from './components/auth/hr-documents/hr-documents.component';
 import { HrMedicalCertificatesComponent } from './components/auth/hr-medical-certificates/hr-medical-certificates.component';
+import { HrReimbursementsComponent } from './components/auth/hr-reimbursements/hr-reimbursements.component';
 import {FirstAccessComponent} from "./components/public/first-access/first-access.component";
 
 
@@ -112,6 +113,7 @@ export const routes: Routes = [
       { path: 'documentos/rh', component: HrHubComponent },
       { path: 'documentos/rh/documents', component: HrDocumentsComponent },
       { path: 'documentos/rh/medical-certificates', component: HrMedicalCertificatesComponent },
+      { path: 'documentos/rh/reimbursements', component: HrReimbursementsComponent },
       { path: 'notificacoes', component: NotificacoesComponent },
       { path: 'perfil', component: PerfilComponent },
     ]

--- a/src/app/components/auth/hr-hub/hr-hub.component.ts
+++ b/src/app/components/auth/hr-hub/hr-hub.component.ts
@@ -20,7 +20,7 @@ export class HrHubComponent {
   categorias: HrCategoria[] = [
     { titulo: 'Meus Documentos', descricao: 'Documentos vinculados pelo RH ao seu cadastro',       icon: 'pi pi-id-card', rota: '/documentos/rh/documents' },
     { titulo: 'Atestados',       descricao: 'Envie atestados e acompanhe seu histórico',            icon: 'pi pi-heart', rota: '/documentos/rh/medical-certificates' },
-    { titulo: 'Reembolsos',      descricao: 'Solicite reembolsos e acompanhe o status',              icon: 'pi pi-wallet' },
+    { titulo: 'Reembolsos',      descricao: 'Solicite reembolsos e acompanhe o status',              icon: 'pi pi-wallet', rota: '/documentos/rh/reimbursements' },
     { titulo: 'Férias',          descricao: 'Solicite férias e acompanhe seu saldo',                 icon: 'pi pi-sun' },
   ];
 

--- a/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.html
+++ b/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.html
@@ -1,0 +1,119 @@
+<section class="hrr-page">
+  <header class="hrr-header">
+    <h1>Reembolsos</h1>
+    <p>Solicite reembolsos e acompanhe o status.</p>
+  </header>
+
+  <div class="hrr-form-card">
+    <h2 class="hrr-form-card__title"><i class="pi pi-plus-circle"></i> Novo reembolso</h2>
+
+    <form [formGroup]="form">
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="expenseDate">Data do gasto <span class="required">*</span></label>
+          <p-datepicker
+            id="expenseDate"
+            formControlName="expenseDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+        <div class="form-field">
+          <pk-input
+            label="Valor (R$)"
+            placeholder="0,00"
+            [pkRequired]="true"
+            type="number"
+            formControlName="amount"
+          />
+        </div>
+        <div class="form-field">
+          <pk-input
+            label="Categoria"
+            placeholder="Ex: Restaurante, Gasolina, Hotel"
+            [pkRequired]="true"
+            [pkMaxLength]="100"
+            type="text"
+            formControlName="category"
+          />
+        </div>
+      </div>
+
+      <div class="form-field hrr-reason">
+        <label for="reason">Motivo <span class="required">*</span></label>
+        <textarea
+          id="reason"
+          formControlName="reason"
+          rows="3"
+          maxlength="500"
+          placeholder="Explique o motivo do gasto">
+        </textarea>
+      </div>
+
+      <div class="hrr-upload">
+        <label class="hrr-upload__label" for="receiptInput">
+          <i class="pi pi-camera"></i> Enviar comprovante (foto ou arquivo)
+        </label>
+        <input id="receiptInput" type="file" accept="image/*,.pdf" (change)="onReceiptSelected($event)" />
+
+        @if (selectedReceipt) {
+          <span class="hrr-upload__filename"><i class="pi pi-file"></i> {{ selectedReceipt.name }}</span>
+        }
+      </div>
+
+      <div class="hrr-form-actions">
+        <pk-button
+          pkType="save"
+          pkLabel="Solicitar reembolso"
+          pkSize="sm"
+          [pkDisabled]="!podeEnviar || enviando()"
+          (clicked)="enviar()">
+        </pk-button>
+      </div>
+    </form>
+  </div>
+
+  <h2 class="hrr-history-title">Meus reembolsos</h2>
+
+  @if (loading()) {
+    <div class="hrr-state"><i class="pi pi-spin pi-spinner"></i> Carregando...</div>
+  } @else if (erro()) {
+    <div class="hrr-state">Não foi possível carregar seus reembolsos. Tente novamente mais tarde.</div>
+  } @else if (reimbursements().length === 0) {
+    <div class="hrr-empty">
+      <span class="hrr-empty-icon"><i class="pi pi-wallet"></i></span>
+      <p>Nenhum reembolso solicitado ainda</p>
+    </div>
+  } @else {
+    <div class="hrr-grid">
+      @for (r of reimbursements(); track r.id) {
+        <div class="hrr-card">
+          <div class="hrr-card__top">
+            <div class="hrr-card__main">
+              <span class="hrr-card__category">{{ r.category }}</span>
+              <span class="hrr-card__amount">{{ r.amount | currency:'BRL' }}</span>
+            </div>
+            <span class="hrr-badge" [ngClass]="'hrr-badge--' + r.status.toLowerCase()">{{ statusLabel(r.status) }}</span>
+          </div>
+
+          <p class="hrr-card__reason">{{ r.reason }}</p>
+          <span class="hrr-card__date">{{ formatDate(r.expenseDate) }}</span>
+
+          @if (r.status === 'REJECTED' && r.reviewNotes) {
+            <p class="hrr-card__notes hrr-card__notes--rejected"><i class="pi pi-info-circle"></i> {{ r.reviewNotes }}</p>
+          }
+          @if (r.status === 'PAID' && r.paymentDate) {
+            <p class="hrr-card__notes hrr-card__notes--paid"><i class="pi pi-check-circle"></i> Pago em {{ formatDate(r.paymentDate) }}</p>
+          }
+
+          <button class="hrr-card__btn" (click)="baixarComprovante(r)" [disabled]="baixandoId() === r.id">
+            <i class="pi" [ngClass]="baixandoId() === r.id ? 'pi-spin pi-spinner' : 'pi-download'"></i>
+            Ver comprovante
+          </button>
+        </div>
+      }
+    </div>
+  }
+</section>

--- a/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.scss
+++ b/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.scss
@@ -1,0 +1,272 @@
+@use 'variables' as v;
+
+.hrr-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.hrr-header {
+  margin-bottom: 28px;
+
+  h1 {
+    font-family: v.$font-heading;
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: v.$primary;
+    margin: 0 0 6px;
+  }
+
+  p {
+    color: #6b7492;
+    font-size: 0.98rem;
+    margin: 0;
+  }
+}
+
+.hrr-form-card {
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 18px;
+  padding: 24px;
+  margin-bottom: 40px;
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: v.$primary;
+    margin: 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.hrr-reason {
+  margin-top: 4px;
+
+  textarea {
+    resize: vertical;
+    border: 1px solid #d7dceb;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-family: inherit;
+  }
+}
+
+.hrr-upload {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+
+  &__label {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 12px;
+    border: 1px dashed rgba(35, 46, 97, 0.35);
+    color: v.$primary;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+
+    &:hover {
+      border-color: v.$secondary;
+      background: rgba(87, 193, 171, 0.08);
+    }
+  }
+
+  input[type='file'] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    overflow: hidden;
+  }
+
+  &__filename {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: #6b7492;
+  }
+}
+
+.hrr-form-actions {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hrr-history-title {
+  font-family: v.$font-heading;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: v.$primary;
+  margin: 0 0 16px;
+}
+
+.hrr-state {
+  padding: 40px 0;
+  color: #6b7492;
+  text-align: center;
+}
+
+.hrr-empty {
+  text-align: center;
+  color: #9aa6bd;
+  padding: 56px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  .hrr-empty-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    i { font-size: 2.2rem; }
+  }
+
+  p { margin: 0; font-weight: 700; color: #6b7492; }
+}
+
+.hrr-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.hrr-card {
+  padding: 18px 20px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: rgba(87, 193, 171, 0.5);
+    box-shadow: 0 8px 24px rgba(35, 46, 97, 0.07);
+  }
+
+  &__top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__category {
+    font-family: v.$font-heading;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: v.$primary;
+  }
+
+  &__amount {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: v.$secondary-dark;
+  }
+
+  &__reason {
+    margin: 10px 0 4px;
+    font-size: 0.88rem;
+    color: #5a6273;
+    line-height: 1.5;
+  }
+
+  &__date {
+    font-size: 0.8rem;
+    color: #9aa6bd;
+  }
+
+  &__notes {
+    margin: 10px 0 0;
+    font-size: 0.85rem;
+    padding: 8px 12px;
+    border-radius: 10px;
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+
+    &--rejected {
+      background: rgba(217, 45, 32, 0.08);
+      color: #b3261e;
+    }
+
+    &--paid {
+      background: rgba(87, 193, 171, 0.12);
+      color: v.$secondary-dark;
+    }
+  }
+
+  &__btn {
+    margin-top: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    border: none;
+    background: transparent;
+    color: v.$primary;
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    padding: 0;
+
+    &:hover:not(:disabled) { color: v.$secondary-dark; }
+    &:disabled { opacity: 0.6; cursor: default; }
+  }
+}
+
+.hrr-badge {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--pending {
+    background: rgba(107, 116, 146, 0.14);
+    color: #6b7492;
+  }
+
+  &--approved {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--rejected {
+    background: rgba(217, 45, 32, 0.10);
+    color: #d92d20;
+  }
+
+  &--paid {
+    background: rgba(35, 46, 97, 0.10);
+    color: v.$primary;
+  }
+}
+
+@media (max-width: 600px) {
+  .hrr-page { padding: 24px 16px 40px; }
+  .hrr-header h1 { font-size: 1.6rem; }
+}

--- a/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.ts
+++ b/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.ts
@@ -1,0 +1,131 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkInputComponent } from '../../theme/ProautoKimium/pk-input/pk-input.component';
+import { ReimbursementService } from '../../../infrastructure/services/hr/reimbursement.service';
+import { Reimbursement, ReimbursementStatus } from '../../../domain/models/hr/reimbursement.model';
+
+@Component({
+  selector: 'app-hr-reimbursements',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, DatePickerModule, PkButtonComponent, PkInputComponent],
+  templateUrl: './hr-reimbursements.component.html',
+  styleUrl: './hr-reimbursements.component.scss',
+})
+export class HrReimbursementsComponent implements OnInit {
+  reimbursements = signal<Reimbursement[]>([]);
+  loading = signal(true);
+  erro = signal(false);
+  enviando = signal(false);
+  baixandoId = signal<string | null>(null);
+
+  selectedReceipt: File | null = null;
+
+  form: FormGroup;
+
+  private readonly statusLabels: Record<ReimbursementStatus, string> = {
+    PENDING: 'Em análise',
+    APPROVED: 'Aprovado',
+    REJECTED: 'Recusado',
+    PAID: 'Pago',
+  };
+
+  constructor(private service: ReimbursementService, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      expenseDate: [null, Validators.required],
+      amount: [null, [Validators.required, Validators.min(0.01)]],
+      category: ['', Validators.required],
+      reason: ['', Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading.set(true);
+    this.service.getMine().subscribe({
+      next: (data) => {
+        this.reimbursements.set(data ?? []);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.erro.set(true);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  onReceiptSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.selectedReceipt = input.files?.[0] ?? null;
+  }
+
+  get podeEnviar(): boolean {
+    return this.form.valid && !!this.selectedReceipt;
+  }
+
+  enviar(): void {
+    if (!this.podeEnviar || !this.selectedReceipt) return;
+
+    this.enviando.set(true);
+    const { expenseDate, amount, category, reason } = this.form.value as {
+      expenseDate: Date;
+      amount: number;
+      category: string;
+      reason: string;
+    };
+
+    this.service
+      .request({
+        expenseDate: this.toIsoDate(expenseDate),
+        amount,
+        category,
+        reason,
+        receipt: this.selectedReceipt,
+      })
+      .subscribe({
+        next: () => {
+          this.enviando.set(false);
+          this.selectedReceipt = null;
+          this.form.reset();
+          this.carregar();
+        },
+        error: () => this.enviando.set(false),
+      });
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  statusLabel(status: ReimbursementStatus): string {
+    return this.statusLabels[status];
+  }
+
+  baixarComprovante(reimbursement: Reimbursement): void {
+    this.baixandoId.set(reimbursement.id);
+    this.service.downloadReceipt(reimbursement.id).subscribe({
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = reimbursement.receiptOriginalFilename;
+        a.click();
+        URL.revokeObjectURL(url);
+        this.baixandoId.set(null);
+      },
+      error: () => this.baixandoId.set(null),
+    });
+  }
+}

--- a/src/app/domain/models/hr/reimbursement.model.ts
+++ b/src/app/domain/models/hr/reimbursement.model.ts
@@ -1,0 +1,18 @@
+export type ReimbursementStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'PAID';
+
+export interface Reimbursement {
+  id: string;
+  employeeId: string;
+  expenseDate: string;
+  amount: number;
+  category: string;
+  reason: string;
+  receiptOriginalFilename: string;
+  status: ReimbursementStatus;
+  requestedAt: string;
+  reviewedById: string | null;
+  reviewedAt: string | null;
+  reviewNotes: string | null;
+  paymentDate: string | null;
+  paidAt: string | null;
+}

--- a/src/app/infrastructure/services/hr/reimbursement.service.ts
+++ b/src/app/infrastructure/services/hr/reimbursement.service.ts
@@ -1,0 +1,42 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { Reimbursement } from '../../../domain/models/hr/reimbursement.model';
+
+export interface RequestReimbursementPayload {
+  expenseDate: string;
+  amount: number;
+  category: string;
+  reason: string;
+  receipt: File;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ReimbursementService {
+
+  constructor(private http: HttpClient) {}
+
+  getMine(): Observable<Reimbursement[]> {
+    return this.http.get<Reimbursement[]>(`${environment.apiUrl}/hr/reimbursements/me`);
+  }
+
+  request(payload: RequestReimbursementPayload): Observable<Reimbursement> {
+    const formData = new FormData();
+    formData.append('expenseDate', payload.expenseDate);
+    formData.append('amount', String(payload.amount));
+    formData.append('category', payload.category);
+    formData.append('reason', payload.reason);
+    formData.append('receipt', payload.receipt);
+
+    return this.http.post<Reimbursement>(`${environment.apiUrl}/hr/reimbursements`, formData);
+  }
+
+  downloadReceipt(id: string): Observable<Blob> {
+    return this.http.get(`${environment.apiUrl}/hr/reimbursements/${id}/receipt`, {
+      responseType: 'blob'
+    });
+  }
+}


### PR DESCRIPTION
  Formulário com data do gasto, valor, categoria (texto livre), motivo
  e comprovante (input de arquivo sem forçar câmera, deixa o navegador
  oferecer câmera/galeria/arquivo). Histórico com badge de status
  (em análise/aprovado/recusado/pago) — mostra o motivo da recusa ou a
  data de pagamento quando aplicável. Liga o card Reembolsos no hub.
