### PR TITLE
feat: adiciona tela de solicitação de férias com saldo disponível

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -53,6 +53,7 @@ import { HrHubComponent } from './components/auth/hr-hub/hr-hub.component';
 import { HrDocumentsComponent } from './components/auth/hr-documents/hr-documents.component';
 import { HrMedicalCertificatesComponent } from './components/auth/hr-medical-certificates/hr-medical-certificates.component';
 import { HrReimbursementsComponent } from './components/auth/hr-reimbursements/hr-reimbursements.component';
+import { HrVacationRequestsComponent } from './components/auth/hr-vacation-requests/hr-vacation-requests.component';
 import {FirstAccessComponent} from "./components/public/first-access/first-access.component";
 
 
@@ -114,6 +115,7 @@ export const routes: Routes = [
       { path: 'documentos/rh/documents', component: HrDocumentsComponent },
       { path: 'documentos/rh/medical-certificates', component: HrMedicalCertificatesComponent },
       { path: 'documentos/rh/reimbursements', component: HrReimbursementsComponent },
+      { path: 'documentos/rh/vacation-requests', component: HrVacationRequestsComponent },
       { path: 'notificacoes', component: NotificacoesComponent },
       { path: 'perfil', component: PerfilComponent },
     ]

--- a/src/app/components/auth/hr-hub/hr-hub.component.ts
+++ b/src/app/components/auth/hr-hub/hr-hub.component.ts
@@ -21,7 +21,7 @@ export class HrHubComponent {
     { titulo: 'Meus Documentos', descricao: 'Documentos vinculados pelo RH ao seu cadastro',       icon: 'pi pi-id-card', rota: '/documentos/rh/documents' },
     { titulo: 'Atestados',       descricao: 'Envie atestados e acompanhe seu histórico',            icon: 'pi pi-heart', rota: '/documentos/rh/medical-certificates' },
     { titulo: 'Reembolsos',      descricao: 'Solicite reembolsos e acompanhe o status',              icon: 'pi pi-wallet', rota: '/documentos/rh/reimbursements' },
-    { titulo: 'Férias',          descricao: 'Solicite férias e acompanhe seu saldo',                 icon: 'pi pi-sun' },
+    { titulo: 'Férias',          descricao: 'Solicite férias e acompanhe seu saldo',                 icon: 'pi pi-sun', rota: '/documentos/rh/vacation-requests' },
   ];
 
   constructor(private router: Router) {}

--- a/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.html
+++ b/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.html
@@ -1,0 +1,98 @@
+<section class="hrv-page">
+  <header class="hrv-header">
+    <h1>Férias</h1>
+    <p>Solicite férias e acompanhe seu saldo.</p>
+  </header>
+
+  @if (!loading() && !erro()) {
+    <div class="hrv-balance">
+      <span class="hrv-balance__icon"><i class="pi pi-sun"></i></span>
+      <div class="hrv-balance__info">
+        <span class="hrv-balance__label">Saldo disponível</span>
+        <span class="hrv-balance__value">
+          {{ balance() !== null ? balance() + ' dia(s)' : 'Não informado — fale com o RH' }}
+        </span>
+      </div>
+    </div>
+  }
+
+  <div class="hrv-form-card">
+    <h2 class="hrv-form-card__title"><i class="pi pi-plus-circle"></i> Nova solicitação</h2>
+
+    <form [formGroup]="form">
+      <div class="form-grid">
+        <div class="form-field">
+          <label for="startDate">Data inicial <span class="required">*</span></label>
+          <p-datepicker
+            id="startDate"
+            formControlName="startDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+        <div class="form-field">
+          <label for="endDate">Data final <span class="required">*</span></label>
+          <p-datepicker
+            id="endDate"
+            formControlName="endDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+      </div>
+
+      @if (daysRequested !== null) {
+        <p class="hrv-days-preview" [class.hrv-days-preview--over]="excedeSaldo">
+          <i class="pi" [ngClass]="excedeSaldo ? 'pi-exclamation-triangle' : 'pi-info-circle'"></i>
+          {{ daysRequested }} dia(s) solicitado(s)
+          @if (excedeSaldo) {
+            — maior que o seu saldo disponível
+          }
+        </p>
+      }
+
+      <div class="hrv-form-actions">
+        <pk-button
+          pkType="save"
+          pkLabel="Solicitar férias"
+          pkSize="sm"
+          [pkDisabled]="!podeEnviar || enviando()"
+          (clicked)="enviar()">
+        </pk-button>
+      </div>
+    </form>
+  </div>
+
+  <h2 class="hrv-history-title">Minhas solicitações</h2>
+
+  @if (loading()) {
+    <div class="hrv-state"><i class="pi pi-spin pi-spinner"></i> Carregando...</div>
+  } @else if (erro()) {
+    <div class="hrv-state">Não foi possível carregar suas férias. Tente novamente mais tarde.</div>
+  } @else if (requests().length === 0) {
+    <div class="hrv-empty">
+      <span class="hrv-empty-icon"><i class="pi pi-calendar"></i></span>
+      <p>Nenhuma solicitação de férias ainda</p>
+    </div>
+  } @else {
+    <div class="hrv-grid">
+      @for (r of requests(); track r.id) {
+        <div class="hrv-card">
+          <div class="hrv-card__top">
+            <span class="hrv-card__period">{{ formatDate(r.startDate) }} — {{ formatDate(r.endDate) }}</span>
+            <span class="hrv-badge" [ngClass]="'hrv-badge--' + r.status.toLowerCase()">{{ statusLabel(r.status) }}</span>
+          </div>
+          <span class="hrv-card__days">{{ r.daysRequested }} dia(s)</span>
+
+          @if (r.status === 'REJECTED' && r.reviewNotes) {
+            <p class="hrv-card__notes"><i class="pi pi-info-circle"></i> {{ r.reviewNotes }}</p>
+          }
+        </div>
+      }
+    </div>
+  }
+</section>

--- a/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.scss
+++ b/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.scss
@@ -1,0 +1,224 @@
+@use 'variables' as v;
+
+.hrv-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
+}
+
+.hrv-header {
+  margin-bottom: 24px;
+
+  h1 {
+    font-family: v.$font-heading;
+    font-size: 1.9rem;
+    font-weight: 800;
+    color: v.$primary;
+    margin: 0 0 6px;
+  }
+
+  p {
+    color: #6b7492;
+    font-size: 0.98rem;
+    margin: 0;
+  }
+}
+
+.hrv-balance {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 22px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, v.$primary, v.$secondary);
+  color: #fff;
+  margin-bottom: 24px;
+  box-shadow: 0 12px 30px rgba(35, 46, 97, 0.20);
+
+  &__icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.18);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    i { font-size: 1.6rem; }
+  }
+
+  &__info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__label {
+    font-size: 0.8rem;
+    opacity: 0.85;
+  }
+
+  &__value {
+    font-family: v.$font-heading;
+    font-size: 1.3rem;
+    font-weight: 800;
+  }
+}
+
+.hrv-form-card {
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 18px;
+  padding: 24px;
+  margin-bottom: 40px;
+
+  &__title {
+    font-family: v.$font-heading;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: v.$primary;
+    margin: 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+.hrv-days-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 14px 0 0;
+  font-size: 0.88rem;
+  color: v.$secondary-dark;
+
+  &--over {
+    color: #d92d20;
+  }
+}
+
+.hrv-form-actions {
+  margin-top: 22px;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.hrv-history-title {
+  font-family: v.$font-heading;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: v.$primary;
+  margin: 0 0 16px;
+}
+
+.hrv-state {
+  padding: 40px 0;
+  color: #6b7492;
+  text-align: center;
+}
+
+.hrv-empty {
+  text-align: center;
+  color: #9aa6bd;
+  padding: 56px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  .hrv-empty-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    i { font-size: 2.2rem; }
+  }
+
+  p { margin: 0; font-weight: 700; color: #6b7492; }
+}
+
+.hrv-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.hrv-card {
+  padding: 16px 18px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-radius: 16px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: rgba(87, 193, 171, 0.5);
+    box-shadow: 0 8px 24px rgba(35, 46, 97, 0.07);
+  }
+
+  &__top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  &__period {
+    font-family: v.$font-heading;
+    font-size: 1.0rem;
+    font-weight: 700;
+    color: v.$primary;
+  }
+
+  &__days {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.82rem;
+    color: #8a93a8;
+  }
+
+  &__notes {
+    margin: 10px 0 0;
+    font-size: 0.85rem;
+    padding: 8px 12px;
+    border-radius: 10px;
+    background: rgba(217, 45, 32, 0.08);
+    color: #b3261e;
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+.hrv-badge {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--pending {
+    background: rgba(107, 116, 146, 0.14);
+    color: #6b7492;
+  }
+
+  &--approved {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--rejected {
+    background: rgba(217, 45, 32, 0.10);
+    color: #d92d20;
+  }
+}
+
+@media (max-width: 600px) {
+  .hrv-page { padding: 24px 16px 40px; }
+  .hrv-header h1 { font-size: 1.6rem; }
+}

--- a/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.ts
+++ b/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.ts
@@ -1,0 +1,110 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../theme/ProautoKimium/pk-button/pk-button.component';
+import { VacationRequestService } from '../../../infrastructure/services/hr/vacation-request.service';
+import { VacationRequest, VacationRequestStatus } from '../../../domain/models/hr/vacation-request.model';
+
+@Component({
+  selector: 'app-hr-vacation-requests',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, DatePickerModule, PkButtonComponent],
+  templateUrl: './hr-vacation-requests.component.html',
+  styleUrl: './hr-vacation-requests.component.scss',
+})
+export class HrVacationRequestsComponent implements OnInit {
+  balance = signal<number | null>(null);
+  requests = signal<VacationRequest[]>([]);
+  loading = signal(true);
+  erro = signal(false);
+  enviando = signal(false);
+
+  form: FormGroup;
+
+  private readonly statusLabels: Record<VacationRequestStatus, string> = {
+    PENDING: 'Em análise',
+    APPROVED: 'Aprovado',
+    REJECTED: 'Recusado',
+  };
+
+  constructor(private service: VacationRequestService, private fb: FormBuilder) {
+    this.form = this.fb.group({
+      startDate: [null, Validators.required],
+      endDate: [null, Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading.set(true);
+    this.service.getMyOverview().subscribe({
+      next: (data) => {
+        this.balance.set(data.vacationBalanceDays);
+        this.requests.set(data.requests ?? []);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.erro.set(true);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  get daysRequested(): number | null {
+    const { startDate, endDate } = this.form.value as { startDate: Date | null; endDate: Date | null };
+    if (!startDate || !endDate) return null;
+    const diff = Math.round((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+    return diff >= 0 ? diff + 1 : null;
+  }
+
+  get excedeSaldo(): boolean {
+    const dias = this.daysRequested;
+    const saldo = this.balance();
+    return dias !== null && saldo !== null && dias > saldo;
+  }
+
+  get podeEnviar(): boolean {
+    return this.form.valid && this.daysRequested !== null && !this.excedeSaldo;
+  }
+
+  enviar(): void {
+    if (!this.podeEnviar) return;
+
+    this.enviando.set(true);
+    const { startDate, endDate } = this.form.value as { startDate: Date; endDate: Date };
+
+    this.service
+      .request({
+        startDate: this.toIsoDate(startDate),
+        endDate: this.toIsoDate(endDate),
+        replacementEmployeeId: null,
+      })
+      .subscribe({
+        next: () => {
+          this.enviando.set(false);
+          this.form.reset();
+          this.carregar();
+        },
+        error: () => this.enviando.set(false),
+      });
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  statusLabel(status: VacationRequestStatus): string {
+    return this.statusLabels[status];
+  }
+}

--- a/src/app/domain/models/hr/vacation-request.model.ts
+++ b/src/app/domain/models/hr/vacation-request.model.ts
@@ -1,0 +1,20 @@
+export type VacationRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface VacationRequest {
+  id: string;
+  employeeId: string;
+  startDate: string;
+  endDate: string;
+  daysRequested: number;
+  replacementEmployeeId: string | null;
+  status: VacationRequestStatus;
+  requestedAt: string;
+  reviewedById: string | null;
+  reviewedAt: string | null;
+  reviewNotes: string | null;
+}
+
+export interface EmployeeVacationOverview {
+  vacationBalanceDays: number | null;
+  requests: VacationRequest[];
+}

--- a/src/app/infrastructure/services/hr/vacation-request.service.ts
+++ b/src/app/infrastructure/services/hr/vacation-request.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { EmployeeVacationOverview, VacationRequest } from '../../../domain/models/hr/vacation-request.model';
+
+export interface CreateVacationRequestPayload {
+  startDate: string;
+  endDate: string;
+  replacementEmployeeId: string | null;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class VacationRequestService {
+
+  constructor(private http: HttpClient) {}
+
+  getMyOverview(): Observable<EmployeeVacationOverview> {
+    return this.http.get<EmployeeVacationOverview>(`${environment.apiUrl}/hr/vacation-requests/me`);
+  }
+
+  request(payload: CreateVacationRequestPayload): Observable<VacationRequest> {
+    return this.http.post<VacationRequest>(`${environment.apiUrl}/hr/vacation-requests`, payload);
+  }
+}


### PR DESCRIPTION
  Mostra o saldo em destaque no topo (vem do GET /me que agora traz
  vacationBalanceDays + histórico). Calcula os dias solicitados no
  front conforme o período escolhido e bloqueia o envio se passar do
  saldo, antes mesmo de chamar a API. Campo de substituto deixado de
  fora por ora (ver nota de escopo). Liga o card Férias no hub —
  fecha as 4 telas de auto-atendimento.
