### PR TITLE
feat: adiciona telas de gestão da Estrutura Organizacional pro RH

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -32,6 +32,7 @@ import { FuelSupplyComponent } from './components/auth/company/vehicle/fuel-supp
 import { ExcelCredentialsComponent } from './components/auth/documents/excel-credentials/excel-credentials.component';
 import { PainelDeVagasComponent } from './components/auth/rh/painel-de-vagas/painel-de-vagas.component';
 import { CandidaturasComponent } from './components/auth/rh/candidaturas/candidaturas.component'; // 👈 novo
+import { OrgStructureComponent } from './components/auth/rh/org-structure/org-structure.component';
 import { TrabalheConoscoComponent } from './components/public/trabalhe-conosco/trabalhe-conosco.component';
 import {SecretsComponent} from "./components/auth/communication/secrets/secrets.component";
 import {ViewSecretsComponent} from "./components/public/view-secrets/view-secrets.component";
@@ -88,6 +89,7 @@ export const routes: Routes = [
       { path: 'rh/holerit', component: HoleritSpliterComponent },
       { path: 'rh/holerit/extractor', component: HoleritExtractorComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/employees', component: EmployesComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/organizational-structure', component: OrgStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/painel-de-vagas', component: PainelDeVagasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/candidaturas', component: CandidaturasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'company/nfe-collector', component: NfeDataCollectorComponent, data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },

--- a/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.html
+++ b/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.html
@@ -1,0 +1,60 @@
+<div class="section-actions">
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  <pk-button pkType="new" (clicked)="showDialog()" pkLabel="Nova Empresa" pkSize="sm"/>
+</div>
+
+<div class="table-card">
+  <p-toast position="top-right"></p-toast>
+
+  <pk-table
+    [data]="companies"
+    [loading]="loading"
+    totalLabel="empresas encontradas"
+    searchPlaceholder="Buscar por nome, CNPJ…"
+    [filterFields]="['name', 'legalName', 'cnpj']"
+    emptyIcon="pi pi-building"
+    emptyTitle="Nenhuma empresa cadastrada"
+    emptySubtitle="Adicione uma nova empresa para começar."
+    pageReportTitle="Empresas">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+        <th pSortableColumn="legalName">Razão Social <p-sortIcon field="legalName"></p-sortIcon></th>
+        <th pSortableColumn="cnpj">CNPJ <p-sortIcon field="cnpj"></p-sortIcon></th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-c>
+      <tr class="table-row">
+        <td>{{ c.name }}</td>
+        <td>{{ c.legalName }}</td>
+        <td>{{ c.cnpj }}</td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<pk-dialog header="Nova Empresa" [visible]="visible" (visibleChange)="visible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="form" (ngSubmit)="save()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field form-field--full">
+          <pk-input label="Nome" placeholder="Ex: Proauto Kimium" [pkRequired]="true" [pkMaxLength]="100" type="text" formControlName="name"/>
+        </div>
+        <div class="form-field form-field--full">
+          <pk-input label="Razão Social" placeholder="Razão social completa" [pkRequired]="true" [pkMaxLength]="150" type="text" formControlName="legalName"/>
+        </div>
+        <div class="form-field form-field--full">
+          <pk-input label="CNPJ" placeholder="00.000.000/0000-00" [pkRequired]="true" [pkMaxLength]="18" type="text" formControlName="cnpj"/>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="visible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="save()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="form.invalid"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.scss
+++ b/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.scss
@@ -1,0 +1,6 @@
+.section-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 16px;
+}

--- a/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.ts
+++ b/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.ts
@@ -1,0 +1,92 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
+import { CompanyService } from '../../../../infrastructure/services/hr/company.service';
+import { Company } from '../../../../domain/models/hr/org-structure.model';
+
+@Component({
+  selector: 'app-org-structure-companies',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent],
+  templateUrl: './org-structure-companies.component.html',
+  styleUrl: './org-structure-companies.component.scss',
+  providers: [MessageService],
+})
+export class OrgStructureCompaniesComponent implements OnInit {
+  companies: Company[] = [];
+  loading = false;
+  visible = false;
+  form: FormGroup;
+
+  constructor(
+    private companyService: CompanyService,
+    private fb: FormBuilder,
+    private msgService: MessageService
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      legalName: ['', Validators.required],
+      cnpj: ['', Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.companyService.getAll().subscribe({
+      next: (list) => {
+        this.companies = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  showDialog(): void {
+    this.form.reset();
+    this.visible = true;
+  }
+
+  save(): void {
+    if (!this.form.valid) return;
+
+    this.companyService.create(this.form.value).subscribe({
+      next: () => {
+        this.visible = false;
+        this.load();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Empresa cadastrada com sucesso!' });
+      },
+      error: (err) => {
+        this.visible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.html
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.html
@@ -1,0 +1,50 @@
+<div class="section-actions">
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  <pk-button pkType="new" (clicked)="showDialog()" pkLabel="Novo Departamento" pkSize="sm"/>
+</div>
+
+<div class="table-card">
+  <p-toast position="top-right"></p-toast>
+
+  <pk-table
+    [data]="departments"
+    [loading]="loading"
+    totalLabel="departamentos encontrados"
+    searchPlaceholder="Buscar por nome…"
+    [filterFields]="['name']"
+    emptyIcon="pi pi-sitemap"
+    emptyTitle="Nenhum departamento cadastrado"
+    emptySubtitle="Adicione um novo departamento para começar."
+    pageReportTitle="Departamentos">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-d>
+      <tr class="table-row">
+        <td>{{ d.name }}</td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<pk-dialog header="Novo Departamento" [visible]="visible" (visibleChange)="visible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="form" (ngSubmit)="save()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field form-field--full">
+          <pk-input label="Nome" placeholder="Ex: Administrativo" [pkRequired]="true" [pkMaxLength]="100" type="text" formControlName="name"/>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="visible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="save()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="form.invalid"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.scss
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.scss
@@ -1,0 +1,6 @@
+.section-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 16px;
+}

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
@@ -1,0 +1,90 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
+import { DepartmentService } from '../../../../infrastructure/services/hr/department.service';
+import { Department } from '../../../../domain/models/hr/org-structure.model';
+
+@Component({
+  selector: 'app-org-structure-departments',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent],
+  templateUrl: './org-structure-departments.component.html',
+  styleUrl: './org-structure-departments.component.scss',
+  providers: [MessageService],
+})
+export class OrgStructureDepartmentsComponent implements OnInit {
+  departments: Department[] = [];
+  loading = false;
+  visible = false;
+  form: FormGroup;
+
+  constructor(
+    private departmentService: DepartmentService,
+    private fb: FormBuilder,
+    private msgService: MessageService
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.departmentService.getAll().subscribe({
+      next: (list) => {
+        this.departments = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  showDialog(): void {
+    this.form.reset();
+    this.visible = true;
+  }
+
+  save(): void {
+    if (!this.form.valid) return;
+
+    this.departmentService.create(this.form.value).subscribe({
+      next: () => {
+        this.visible = false;
+        this.load();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Departamento cadastrado com sucesso!' });
+      },
+      error: (err) => {
+        this.visible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.html
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.html
@@ -1,0 +1,55 @@
+<div class="section-actions">
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  <pk-button pkType="new" (clicked)="showDialog()" pkLabel="Nova Hierarquia" pkSize="sm"/>
+</div>
+
+<div class="table-card">
+  <p-toast position="top-right"></p-toast>
+
+  <pk-table
+    [data]="hierarchies"
+    [loading]="loading"
+    totalLabel="hierarquias encontradas"
+    searchPlaceholder="Buscar por nome…"
+    [filterFields]="['name']"
+    emptyIcon="pi pi-sort-amount-down"
+    emptyTitle="Nenhuma hierarquia cadastrada"
+    emptySubtitle="Adicione uma nova hierarquia para começar."
+    pageReportTitle="Hierarquias">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th>Nível</th>
+        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-h>
+      <tr class="table-row">
+        <td><span class="code-badge">{{ h.levelOrder }}</span></td>
+        <td>{{ h.name }}</td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<pk-dialog header="Nova Hierarquia" [visible]="visible" (visibleChange)="visible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="form" (ngSubmit)="save()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field form-field--full">
+          <pk-input label="Nome" placeholder="Ex: Coordenador" [pkRequired]="true" [pkMaxLength]="50" type="text" formControlName="name"/>
+        </div>
+        <div class="form-field form-field--full">
+          <pk-input label="Nível" placeholder="Ex: 5 (quanto menor, mais alto na hierarquia)" [pkRequired]="true" type="number" formControlName="levelOrder"/>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="visible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="save()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="form.invalid"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.scss
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.scss
@@ -1,0 +1,6 @@
+.section-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 16px;
+}

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
@@ -1,0 +1,92 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
+import { HierarchyService } from '../../../../infrastructure/services/hr/hierarchy.service';
+import { Hierarchy } from '../../../../domain/models/hr/org-structure.model';
+
+@Component({
+  selector: 'app-org-structure-hierarchies',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent],
+  templateUrl: './org-structure-hierarchies.component.html',
+  styleUrl: './org-structure-hierarchies.component.scss',
+  providers: [MessageService],
+})
+export class OrgStructureHierarchiesComponent implements OnInit {
+  hierarchies: Hierarchy[] = [];
+  loading = false;
+  visible = false;
+  form: FormGroup;
+
+  constructor(
+    private hierarchyService: HierarchyService,
+    private fb: FormBuilder,
+    private msgService: MessageService
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      levelOrder: [null, [Validators.required, Validators.min(1)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  // Ordenada por nível — é o que dá sentido visual pra hierarquia (quem manda em quem).
+  load(): void {
+    this.loading = true;
+    this.hierarchyService.getAll().subscribe({
+      next: (list) => {
+        this.hierarchies = [...list].sort((a, b) => a.levelOrder - b.levelOrder);
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  showDialog(): void {
+    this.form.reset();
+    this.visible = true;
+  }
+
+  save(): void {
+    if (!this.form.valid) return;
+
+    this.hierarchyService.create(this.form.value).subscribe({
+      next: () => {
+        this.visible = false;
+        this.load();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Hierarquia cadastrada com sucesso!' });
+      },
+      error: (err) => {
+        this.visible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.html
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.html
@@ -1,0 +1,68 @@
+<div class="section-actions">
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  <pk-button pkType="new" (clicked)="showDialog()" pkLabel="Novo Setor" pkSize="sm"/>
+</div>
+
+<div class="table-card">
+  <p-toast position="top-right"></p-toast>
+
+  <pk-table
+    [data]="teams"
+    [loading]="loading"
+    totalLabel="setores encontrados"
+    searchPlaceholder="Buscar por nome…"
+    [filterFields]="['name']"
+    emptyIcon="pi pi-users"
+    emptyTitle="Nenhum setor cadastrado"
+    emptySubtitle="Adicione um novo setor para começar."
+    pageReportTitle="Setores">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+        <th>Departamento</th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-t>
+      <tr class="table-row">
+        <td>{{ t.name }}</td>
+        <td>{{ t.department?.name }}</td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<pk-dialog header="Novo Setor" [visible]="visible" (visibleChange)="visible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="form" (ngSubmit)="save()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field form-field--full">
+          <pk-input label="Nome" placeholder="Ex: Compras" [pkRequired]="true" [pkMaxLength]="100" type="text" formControlName="name"/>
+        </div>
+        <div class="form-field form-field--full">
+          <label for="departmentId">Departamento <span class="required">*</span></label>
+          <p-select
+            id="departmentId"
+            [options]="departmentOptions"
+            formControlName="departmentId"
+            optionLabel="label"
+            optionValue="value"
+            appendTo="body"
+            placeholder="Selecione…"
+            styleClass="select-field">
+          </p-select>
+          <small class="field-error" *ngIf="form.get('departmentId')?.invalid && form.get('departmentId')?.touched">
+            Campo obrigatório
+          </small>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="visible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="save()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="form.invalid"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.scss
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.scss
@@ -1,0 +1,6 @@
+.section-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-bottom: 16px;
+}

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
@@ -1,0 +1,105 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { SelectModule } from 'primeng/select';
+import { TableModule } from 'primeng/table';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
+import { TeamService } from '../../../../infrastructure/services/hr/team.service';
+import { DepartmentService } from '../../../../infrastructure/services/hr/department.service';
+import { Department, Team } from '../../../../domain/models/hr/org-structure.model';
+
+@Component({
+  selector: 'app-org-structure-teams',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, SelectModule, TableModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent],
+  templateUrl: './org-structure-teams.component.html',
+  styleUrl: './org-structure-teams.component.scss',
+  providers: [MessageService],
+})
+export class OrgStructureTeamsComponent implements OnInit {
+  teams: Team[] = [];
+  departmentOptions: { label: string; value: string }[] = [];
+  loading = false;
+  visible = false;
+  form: FormGroup;
+
+  constructor(
+    private teamService: TeamService,
+    private departmentService: DepartmentService,
+    private fb: FormBuilder,
+    private msgService: MessageService
+  ) {
+    this.form = this.fb.group({
+      name: ['', Validators.required],
+      departmentId: [null, Validators.required],
+    });
+  }
+
+  ngOnInit(): void {
+    this.load();
+    this.loadDepartmentOptions();
+  }
+
+  load(): void {
+    this.loading = true;
+    this.teamService.getAll().subscribe({
+      next: (list) => {
+        this.teams = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  loadDepartmentOptions(): void {
+    this.departmentService.getAll().subscribe({
+      next: (list: Department[]) => {
+        this.departmentOptions = list.map((d) => ({ label: d.name, value: d.id }));
+      },
+      error: () => (this.departmentOptions = []),
+    });
+  }
+
+  showDialog(): void {
+    this.form.reset();
+    this.visible = true;
+  }
+
+  save(): void {
+    if (!this.form.valid) return;
+
+    this.teamService.create(this.form.value).subscribe({
+      next: () => {
+        this.visible = false;
+        this.load();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Setor cadastrado com sucesso!' });
+      },
+      error: (err) => {
+        this.visible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/org-structure/org-structure.component.html
+++ b/src/app/components/auth/rh/org-structure/org-structure.component.html
@@ -1,0 +1,39 @@
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-sitemap"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Estrutura Organizacional</h1>
+      <p class="page-subtitle">Empresas, departamentos, setores e hierarquias</p>
+    </div>
+  </div>
+</div>
+
+<div class="org-switcher">
+  @for (section of sections; track section.key) {
+    <button
+      type="button"
+      class="org-switcher__item"
+      [class.org-switcher__item--active]="activeSection() === section.key"
+      (click)="select(section.key)">
+      <i [class]="section.icon"></i>
+      {{ section.label }}
+    </button>
+  }
+</div>
+
+@switch (activeSection()) {
+  @case ('companies') {
+    <app-org-structure-companies />
+  }
+  @case ('departments') {
+    <app-org-structure-departments />
+  }
+  @case ('teams') {
+    <app-org-structure-teams />
+  }
+  @case ('hierarchies') {
+    <app-org-structure-hierarchies />
+  }
+}

--- a/src/app/components/auth/rh/org-structure/org-structure.component.scss
+++ b/src/app/components/auth/rh/org-structure/org-structure.component.scss
@@ -1,0 +1,44 @@
+@use 'variables' as v;
+
+.org-switcher {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 20px 0 24px;
+
+  &__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 18px;
+    border-radius: 12px;
+    border: 1px solid #e6e9f0;
+    background: #ffffff;
+    color: #6b7492;
+    font-weight: 600;
+    font-size: 0.88rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    i { font-size: 0.95rem; }
+
+    &:hover {
+      border-color: rgba(87, 193, 171, 0.5);
+      color: v.$primary;
+    }
+
+    &--active {
+      background: linear-gradient(135deg, v.$primary, v.$secondary);
+      border-color: transparent;
+      color: #ffffff;
+      box-shadow: 0 8px 20px rgba(35, 46, 97, 0.20);
+
+      &:hover { color: #ffffff; }
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .org-switcher { gap: 6px; }
+  .org-switcher__item { padding: 8px 14px; font-size: 0.82rem; }
+}

--- a/src/app/components/auth/rh/org-structure/org-structure.component.ts
+++ b/src/app/components/auth/rh/org-structure/org-structure.component.ts
@@ -1,0 +1,36 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OrgStructureCompaniesComponent } from '../org-structure-companies/org-structure-companies.component';
+import { OrgStructureDepartmentsComponent } from '../org-structure-departments/org-structure-departments.component';
+import { OrgStructureTeamsComponent } from '../org-structure-teams/org-structure-teams.component';
+import { OrgStructureHierarchiesComponent } from '../org-structure-hierarchies/org-structure-hierarchies.component';
+
+type OrgStructureSection = 'companies' | 'departments' | 'teams' | 'hierarchies';
+
+@Component({
+  selector: 'app-org-structure',
+  standalone: true,
+  imports: [
+    CommonModule,
+    OrgStructureCompaniesComponent,
+    OrgStructureDepartmentsComponent,
+    OrgStructureTeamsComponent,
+    OrgStructureHierarchiesComponent,
+  ],
+  templateUrl: './org-structure.component.html',
+  styleUrl: './org-structure.component.scss',
+})
+export class OrgStructureComponent {
+  activeSection = signal<OrgStructureSection>('companies');
+
+  sections: { key: OrgStructureSection; label: string; icon: string }[] = [
+    { key: 'companies', label: 'Empresas', icon: 'pi pi-building' },
+    { key: 'departments', label: 'Departamentos', icon: 'pi pi-sitemap' },
+    { key: 'teams', label: 'Setores', icon: 'pi pi-users' },
+    { key: 'hierarchies', label: 'Hierarquias', icon: 'pi pi-sort-amount-down' },
+  ];
+
+  select(section: OrgStructureSection): void {
+    this.activeSection.set(section);
+  }
+}

--- a/src/app/components/auth/shared/top-menu/top-menu.component.ts
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.ts
@@ -91,7 +91,8 @@ export class TopMenuComponent implements OnInit, OnDestroy {
           { label: 'Portal de Vagas', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/painel-de-vagas'], roles: ['ADMIN', 'RH'] },
           { label: 'Holerit',                icon: 'pi pi-fw pi-file',      routerLink: ['rh/holerit'],          roles: ['ADMIN', 'RH'] },
           { label: 'Coletar dados Holerite',  icon: 'pi pi-fw pi-file-arrow-up',      routerLink: ['rh/holerit/extractor'],roles: ['ADMIN', 'RH'] },
-          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], roles: ['ADMIN', 'RH'] }
+          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], roles: ['ADMIN', 'RH'] },
+          { label: 'Estrutura Organizacional', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] }
         ],
       },
       {

--- a/src/app/domain/models/hr/org-structure.model.ts
+++ b/src/app/domain/models/hr/org-structure.model.ts
@@ -1,0 +1,43 @@
+export interface Company {
+  id: string;
+  name: string;
+  legalName: string;
+  cnpj: string;
+}
+
+export interface CreateCompanyRequest {
+  name: string;
+  legalName: string;
+  cnpj: string;
+}
+
+export interface Department {
+  id: string;
+  name: string;
+}
+
+export interface CreateDepartmentRequest {
+  name: string;
+}
+
+export interface Team {
+  id: string;
+  name: string;
+  department: Department;
+}
+
+export interface CreateTeamRequest {
+  name: string;
+  departmentId: string;
+}
+
+export interface Hierarchy {
+  id: string;
+  name: string;
+  levelOrder: number;
+}
+
+export interface CreateHierarchyRequest {
+  name: string;
+  levelOrder: number;
+}

--- a/src/app/infrastructure/services/hr/company.service.ts
+++ b/src/app/infrastructure/services/hr/company.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { Company, CreateCompanyRequest } from '../../../domain/models/hr/org-structure.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CompanyService {
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Company[]> {
+    return this.http.get<Company[]>(`${environment.apiUrl}/hr/companies`);
+  }
+
+  create(request: CreateCompanyRequest): Observable<Company> {
+    return this.http.post<Company>(`${environment.apiUrl}/hr/companies`, request);
+  }
+}

--- a/src/app/infrastructure/services/hr/department.service.ts
+++ b/src/app/infrastructure/services/hr/department.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CreateDepartmentRequest, Department } from '../../../domain/models/hr/org-structure.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DepartmentService {
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Department[]> {
+    return this.http.get<Department[]>(`${environment.apiUrl}/hr/departments`);
+  }
+
+  create(request: CreateDepartmentRequest): Observable<Department> {
+    return this.http.post<Department>(`${environment.apiUrl}/hr/departments`, request);
+  }
+}

--- a/src/app/infrastructure/services/hr/hierarchy.service.ts
+++ b/src/app/infrastructure/services/hr/hierarchy.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CreateHierarchyRequest, Hierarchy } from '../../../domain/models/hr/org-structure.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class HierarchyService {
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Hierarchy[]> {
+    return this.http.get<Hierarchy[]>(`${environment.apiUrl}/hr/hierarchies`);
+  }
+
+  create(request: CreateHierarchyRequest): Observable<Hierarchy> {
+    return this.http.post<Hierarchy>(`${environment.apiUrl}/hr/hierarchies`, request);
+  }
+}

--- a/src/app/infrastructure/services/hr/team.service.ts
+++ b/src/app/infrastructure/services/hr/team.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CreateTeamRequest, Team } from '../../../domain/models/hr/org-structure.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TeamService {
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Team[]> {
+    return this.http.get<Team[]>(`${environment.apiUrl}/hr/teams`);
+  }
+
+  create(request: CreateTeamRequest): Observable<Team> {
+    return this.http.post<Team>(`${environment.apiUrl}/hr/teams`, request);
+  }
+}


### PR DESCRIPTION
  Empresas, Departamentos, Setores e Hierarquias — 4 seções dentro de
  um hub com seletor simples (sem lib de abas nova). Cada seção segue
  o padrão já usado em Funcionários (pk-table + pk-dialog + Toast),
  sem edição/exclusão porque o back-end só tem criar e listar. Setor
  depende da lista de Departamento pra popular o select. Nova entrada
  no menu RH: Estrutura Organizacional.
