### PR TITLE
feat: adiciona tela de Cargos & Níveis com aplicação de dissídio

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -33,6 +33,7 @@ import { ExcelCredentialsComponent } from './components/auth/documents/excel-cre
 import { PainelDeVagasComponent } from './components/auth/rh/painel-de-vagas/painel-de-vagas.component';
 import { CandidaturasComponent } from './components/auth/rh/candidaturas/candidaturas.component'; // 👈 novo
 import { OrgStructureComponent } from './components/auth/rh/org-structure/org-structure.component';
+import { CareerStructureComponent } from './components/auth/rh/career-structure/career-structure.component';
 import { TrabalheConoscoComponent } from './components/public/trabalhe-conosco/trabalhe-conosco.component';
 import {SecretsComponent} from "./components/auth/communication/secrets/secrets.component";
 import {ViewSecretsComponent} from "./components/public/view-secrets/view-secrets.component";
@@ -90,6 +91,7 @@ export const routes: Routes = [
       { path: 'rh/holerit/extractor', component: HoleritExtractorComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/employees', component: EmployesComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/organizational-structure', component: OrgStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/career-structure', component: CareerStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/painel-de-vagas', component: PainelDeVagasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/candidaturas', component: CandidaturasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'company/nfe-collector', component: NfeDataCollectorComponent, data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },

--- a/src/app/components/auth/rh/career-structure/career-structure.component.html
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.html
@@ -1,0 +1,228 @@
+<p-toast position="top-right"></p-toast>
+
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-briefcase"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Cargos & Níveis</h1>
+      <p class="page-subtitle">Estrutura de cargos, níveis salariais e dissídio</p>
+    </div>
+  </div>
+  <div class="header-actions">
+    <pk-button pkType="refresh" (clicked)="loadPositions()" pkLabel="Atualizar" pkSize="sm"/>
+    <pk-button pkType="new" (clicked)="showAdjustmentDialog()" pkLabel="Aplicar Dissídio" pkSize="sm"/>
+    <pk-button pkType="new" (clicked)="showPositionDialog()" pkLabel="Novo Cargo" pkSize="sm"/>
+  </div>
+</div>
+
+<div class="table-card">
+  <pk-table
+    [data]="positions"
+    [loading]="loadingPositions"
+    totalLabel="cargos encontrados"
+    searchPlaceholder="Buscar por nome…"
+    [filterFields]="['name']"
+    emptyIcon="pi pi-briefcase"
+    emptyTitle="Nenhum cargo cadastrado"
+    emptySubtitle="Adicione um novo cargo para começar."
+    pageReportTitle="Cargos">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+        <th class="col-center">Ações</th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-p>
+      <tr class="table-row" [class.table-row--selected]="selectedPosition?.id === p.id">
+        <td>{{ p.name }}</td>
+        <td class="col-center">
+          <button pButton type="button" icon="pi pi-list" label="Ver Níveis" class="action-btn" (click)="selectPosition(p)"></button>
+        </td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+@if (selectedPosition) {
+  <div class="levels-section">
+    <div class="page-header page-header--sub">
+      <div class="header-left">
+        <div>
+          <h2 class="page-title page-title--sm">Níveis — {{ selectedPosition.name }}</h2>
+          <p class="page-subtitle">Cada nível é fixo ou percentual sobre o nível imediatamente anterior</p>
+        </div>
+      </div>
+      <div class="header-actions">
+        <pk-button pkType="new" (clicked)="showLevelDialog()" pkLabel="Novo Nível" pkSize="sm"/>
+      </div>
+    </div>
+
+    <div class="table-card">
+      <pk-table
+        [data]="levels"
+        [loading]="loadingLevels"
+        totalLabel="níveis encontrados"
+        searchPlaceholder="Buscar por nome…"
+        [filterFields]="['name']"
+        emptyIcon="pi pi-sort-amount-down"
+        emptyTitle="Nenhum nível cadastrado"
+        emptySubtitle="Adicione o primeiro nível deste cargo — o nível 1 precisa ser fixo."
+        pageReportTitle="Níveis">
+
+        <ng-template #headerTpl>
+          <tr>
+            <th>Ordem</th>
+            <th>Nome</th>
+            <th>Tipo</th>
+            <th>Valor</th>
+            <th>Salário calculado</th>
+          </tr>
+        </ng-template>
+
+        <ng-template #bodyTpl let-l>
+          <tr class="table-row">
+            <td><span class="code-badge">{{ l.levelOrder }}</span></td>
+            <td>{{ l.name }}</td>
+            <td>{{ l.adjustmentType === 'FIXED' ? 'Fixo' : 'Percentual' }}</td>
+            <td>
+              @if (l.adjustmentType === 'FIXED') {
+                {{ l.fixedAmount | currency:'BRL' }}
+              } @else {
+                +{{ l.percentageIncrease }}%
+              }
+            </td>
+            <td><strong>{{ l.resolvedSalary | currency:'BRL' }}</strong></td>
+          </tr>
+        </ng-template>
+
+      </pk-table>
+    </div>
+  </div>
+}
+
+<!-- Dialog: Novo Cargo -->
+<pk-dialog header="Novo Cargo" [visible]="positionDialogVisible" (visibleChange)="positionDialogVisible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="positionForm" (ngSubmit)="savePosition()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field form-field--full">
+          <pk-input label="Nome" placeholder="Ex: Desenvolvedor Java" [pkRequired]="true" [pkMaxLength]="100" type="text" formControlName="name"/>
+        </div>
+      </div>
+    </form>
+  </div>
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="positionDialogVisible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="savePosition()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="positionForm.invalid"/>
+  </div>
+</pk-dialog>
+
+<!-- Dialog: Novo Nível -->
+<pk-dialog header="Novo Nível" [visible]="levelDialogVisible" (visibleChange)="levelDialogVisible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="levelForm" (ngSubmit)="saveLevel()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field">
+          <pk-input label="Nome" placeholder="Ex: Júnior" [pkRequired]="true" [pkMaxLength]="50" type="text" formControlName="name"/>
+        </div>
+        <div class="form-field">
+          <pk-input label="Ordem" placeholder="1, 2, 3…" [pkRequired]="true" type="number" formControlName="levelOrder"/>
+        </div>
+        <div class="form-field form-field--full">
+          <label for="adjustmentType">Tipo de reajuste <span class="required">*</span></label>
+          <p-select
+            id="adjustmentType"
+            [options]="adjustmentTypeOptions"
+            formControlName="adjustmentType"
+            optionLabel="label"
+            optionValue="value"
+            appendTo="body"
+            styleClass="select-field">
+          </p-select>
+        </div>
+
+        @if (isFixedLevel) {
+          <div class="form-field form-field--full">
+            <pk-input label="Valor fixo (R$)" placeholder="0,00" [pkRequired]="true" type="number" formControlName="fixedAmount"/>
+          </div>
+        } @else {
+          <div class="form-field form-field--full">
+            <pk-input label="Percentual sobre o nível anterior (%)" placeholder="Ex: 5" [pkRequired]="true" type="number" formControlName="percentageIncrease"/>
+          </div>
+        }
+      </div>
+    </form>
+  </div>
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="levelDialogVisible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="saveLevel()" pkLabel="Salvar" pkSize="sm" [pkDisabled]="levelForm.invalid"/>
+  </div>
+</pk-dialog>
+
+<!-- Dialog: Aplicar Dissídio -->
+<pk-dialog header="Aplicar Dissídio" [visible]="adjustmentDialogVisible" (visibleChange)="adjustmentDialogVisible = $event">
+  <div pkDialogContent>
+    <form [formGroup]="adjustmentForm" (ngSubmit)="applyAdjustment()" class="dialog-form">
+      <div class="form-grid">
+        <div class="form-field">
+          <pk-input label="Percentual (%)" placeholder="Ex: 5" [pkRequired]="true" type="number" formControlName="percentage"/>
+        </div>
+        <div class="form-field">
+          <label for="effectiveDate">Data efetiva <span class="required">*</span></label>
+          <p-datepicker
+            id="effectiveDate"
+            formControlName="effectiveDate"
+            [showButtonBar]="true"
+            dateFormat="dd/mm/yy"
+            styleClass="datepicker-field"
+            placeholder="dd/mm/aaaa">
+          </p-datepicker>
+        </div>
+        <div class="form-field form-field--full">
+          <label for="scope">Escopo <span class="required">*</span></label>
+          <p-select
+            id="scope"
+            [options]="scopeOptions"
+            formControlName="scope"
+            optionLabel="label"
+            optionValue="value"
+            appendTo="body"
+            styleClass="select-field">
+          </p-select>
+        </div>
+
+        @if (isSpecificPositionScope) {
+          <div class="form-field form-field--full">
+            <label for="positionId">Cargo <span class="required">*</span></label>
+            <p-select
+              id="positionId"
+              [options]="positions"
+              formControlName="positionId"
+              optionLabel="name"
+              optionValue="id"
+              appendTo="body"
+              placeholder="Selecione…"
+              styleClass="select-field">
+            </p-select>
+          </div>
+        }
+      </div>
+    </form>
+
+    @if (adjustmentResult) {
+      <div class="adjustment-result">
+        <i class="pi pi-check-circle"></i>
+        {{ adjustmentResult.positionLevelsUpdated }} nível(is) atualizado(s), {{ adjustmentResult.employeesAffected }} funcionário(s) afetado(s).
+      </div>
+    }
+  </div>
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="adjustmentDialogVisible = false" pkLabel="Fechar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="applyAdjustment()" pkLabel="Aplicar" pkSize="sm" [pkDisabled]="adjustmentForm.invalid" [pkLoading]="applyingAdjustment"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/career-structure/career-structure.component.scss
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.scss
@@ -1,0 +1,56 @@
+@use 'variables' as v;
+
+.col-center { text-align: center !important; }
+
+.action-btn.p-button {
+  width: auto;
+  padding: 0 .7rem;
+  height: 32px;
+  gap: .35rem;
+  font-size: .78rem;
+  font-weight: 600;
+  border-radius: v.$radius-sm;
+  background: transparent;
+  border: 1px solid v.$border;
+  color: v.$text-muted;
+  transition: all .15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: v.$primary;
+    border-color: v.$primary;
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(35, 46, 97, .25);
+  }
+}
+
+.table-row--selected {
+  background: rgba(87, 193, 171, 0.08);
+}
+
+.levels-section {
+  margin-top: 32px;
+}
+
+.page-header--sub {
+  margin-bottom: 16px;
+}
+
+.page-title--sm {
+  font-size: 1.25rem !important;
+}
+
+.adjustment-result {
+  margin-top: 18px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background: rgba(87, 193, 171, 0.12);
+  color: v.$secondary-dark;
+  font-size: 0.9rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/app/components/auth/rh/career-structure/career-structure.component.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.ts
@@ -1,0 +1,252 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { SelectModule } from 'primeng/select';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
+import { PositionService } from '../../../../infrastructure/services/hr/position.service';
+import { PositionLevelService } from '../../../../infrastructure/services/hr/position-level.service';
+import { CollectiveBargainingAdjustmentService } from '../../../../infrastructure/services/hr/collective-bargaining-adjustment.service';
+import {
+  AdjustmentScope,
+  CollectiveBargainingAdjustmentResult,
+  Position,
+  PositionLevel,
+  SalaryAdjustmentType
+} from '../../../../domain/models/hr/career.model';
+
+@Component({
+  selector: 'app-career-structure',
+  standalone: true,
+  imports: [
+    CommonModule, ReactiveFormsModule, TableModule, SelectModule, DatePickerModule, Toast,
+    PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent,
+  ],
+  templateUrl: './career-structure.component.html',
+  styleUrl: './career-structure.component.scss',
+  providers: [MessageService],
+})
+export class CareerStructureComponent implements OnInit {
+  // Posições
+  positions: Position[] = [];
+  loadingPositions = false;
+  positionDialogVisible = false;
+  positionForm: FormGroup;
+
+  // Níveis da posição selecionada
+  selectedPosition: Position | null = null;
+  levels: PositionLevel[] = [];
+  loadingLevels = false;
+  levelDialogVisible = false;
+  levelForm: FormGroup;
+
+  // Dissídio
+  adjustmentDialogVisible = false;
+  adjustmentForm: FormGroup;
+  adjustmentResult: CollectiveBargainingAdjustmentResult | null = null;
+  applyingAdjustment = false;
+
+  adjustmentTypeOptions: { label: string; value: SalaryAdjustmentType }[] = [
+    { label: 'Valor fixo', value: 'FIXED' },
+    { label: 'Percentual sobre o nível anterior', value: 'PERCENTAGE' },
+  ];
+
+  scopeOptions: { label: string; value: AdjustmentScope }[] = [
+    { label: 'Todas as posições', value: 'ALL_POSITIONS' },
+    { label: 'Uma posição específica', value: 'SPECIFIC_POSITION' },
+  ];
+
+  constructor(
+    private positionService: PositionService,
+    private positionLevelService: PositionLevelService,
+    private adjustmentService: CollectiveBargainingAdjustmentService,
+    private fb: FormBuilder,
+    private msgService: MessageService
+  ) {
+    this.positionForm = this.fb.group({
+      name: ['', Validators.required],
+    });
+
+    this.levelForm = this.fb.group({
+      name: ['', Validators.required],
+      levelOrder: [null, [Validators.required, Validators.min(1)]],
+      adjustmentType: ['FIXED', Validators.required],
+      fixedAmount: [null],
+      percentageIncrease: [null],
+    });
+
+    this.adjustmentForm = this.fb.group({
+      percentage: [null, [Validators.required, Validators.min(0.01)]],
+      effectiveDate: [null, Validators.required],
+      scope: ['ALL_POSITIONS', Validators.required],
+      positionId: [null],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadPositions();
+  }
+
+  // ---- Posições ----
+
+  loadPositions(): void {
+    this.loadingPositions = true;
+    this.positionService.getAll().subscribe({
+      next: (list) => {
+        this.positions = list;
+        this.loadingPositions = false;
+      },
+      error: (err) => {
+        this.loadingPositions = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  showPositionDialog(): void {
+    this.positionForm.reset();
+    this.positionDialogVisible = true;
+  }
+
+  savePosition(): void {
+    if (!this.positionForm.valid) return;
+
+    this.positionService.create(this.positionForm.value).subscribe({
+      next: () => {
+        this.positionDialogVisible = false;
+        this.loadPositions();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Cargo cadastrado com sucesso!' });
+      },
+      error: (err) => {
+        this.positionDialogVisible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  // ---- Níveis ----
+
+  selectPosition(position: Position): void {
+    this.selectedPosition = position;
+    this.loadLevels();
+  }
+
+  loadLevels(): void {
+    if (!this.selectedPosition) return;
+
+    this.loadingLevels = true;
+    this.positionLevelService.getByPosition(this.selectedPosition.id).subscribe({
+      next: (list) => {
+        this.levels = list;
+        this.loadingLevels = false;
+      },
+      error: (err) => {
+        this.loadingLevels = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  get isFixedLevel(): boolean {
+    return this.levelForm.get('adjustmentType')?.value === 'FIXED';
+  }
+
+  showLevelDialog(): void {
+    this.levelForm.reset({ adjustmentType: 'FIXED' });
+    this.levelDialogVisible = true;
+  }
+
+  saveLevel(): void {
+    if (!this.levelForm.valid || !this.selectedPosition) return;
+
+    const { name, levelOrder, adjustmentType, fixedAmount, percentageIncrease } = this.levelForm.value;
+
+    this.positionLevelService.create({
+      name,
+      levelOrder,
+      positionId: this.selectedPosition.id,
+      adjustmentType,
+      fixedAmount: adjustmentType === 'FIXED' ? fixedAmount : null,
+      percentageIncrease: adjustmentType === 'PERCENTAGE' ? percentageIncrease : null,
+    }).subscribe({
+      next: () => {
+        this.levelDialogVisible = false;
+        this.loadLevels();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Nível cadastrado com sucesso!' });
+      },
+      error: (err) => {
+        this.levelDialogVisible = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  // ---- Dissídio ----
+
+  get isSpecificPositionScope(): boolean {
+    return this.adjustmentForm.get('scope')?.value === 'SPECIFIC_POSITION';
+  }
+
+  showAdjustmentDialog(): void {
+    this.adjustmentForm.reset({ scope: 'ALL_POSITIONS' });
+    this.adjustmentResult = null;
+    this.adjustmentDialogVisible = true;
+  }
+
+  applyAdjustment(): void {
+    if (!this.adjustmentForm.valid) return;
+
+    const { percentage, effectiveDate, scope, positionId } = this.adjustmentForm.value as {
+      percentage: number;
+      effectiveDate: Date;
+      scope: AdjustmentScope;
+      positionId: string | null;
+    };
+
+    this.applyingAdjustment = true;
+    this.adjustmentService.apply({
+      percentage,
+      effectiveDate: this.toIsoDate(effectiveDate),
+      scope,
+      positionId: scope === 'SPECIFIC_POSITION' ? positionId : null,
+    }).subscribe({
+      next: (result) => {
+        this.applyingAdjustment = false;
+        this.adjustmentResult = result;
+        this.msgService.add({ severity: 'success', summary: 'Dissídio aplicado', detail: `${result.positionLevelsUpdated} nível(is) atualizado(s), ${result.employeesAffected} funcionário(s) afetado(s).` });
+        if (this.selectedPosition) this.loadLevels();
+      },
+      error: (err) => {
+        this.applyingAdjustment = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/shared/top-menu/top-menu.component.ts
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.ts
@@ -92,7 +92,8 @@ export class TopMenuComponent implements OnInit, OnDestroy {
           { label: 'Holerit',                icon: 'pi pi-fw pi-file',      routerLink: ['rh/holerit'],          roles: ['ADMIN', 'RH'] },
           { label: 'Coletar dados Holerite',  icon: 'pi pi-fw pi-file-arrow-up',      routerLink: ['rh/holerit/extractor'],roles: ['ADMIN', 'RH'] },
           { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], roles: ['ADMIN', 'RH'] },
-          { label: 'Estrutura Organizacional', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] }
+          { label: 'Estrutura Organizacional', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] },
+          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], roles: ['ADMIN', 'RH'] }
         ],
       },
       {

--- a/src/app/domain/models/hr/career.model.ts
+++ b/src/app/domain/models/hr/career.model.ts
@@ -1,0 +1,49 @@
+export interface Position {
+  id: string;
+  name: string;
+}
+
+export interface CreatePositionRequest {
+  name: string;
+}
+
+export type SalaryAdjustmentType = 'FIXED' | 'PERCENTAGE';
+
+export interface PositionLevel {
+  id: string;
+  name: string;
+  levelOrder: number;
+  positionId: string;
+  adjustmentType: SalaryAdjustmentType;
+  fixedAmount: number | null;
+  percentageIncrease: number | null;
+  resolvedSalary: number;
+}
+
+export interface CreatePositionLevelRequest {
+  name: string;
+  levelOrder: number;
+  positionId: string;
+  adjustmentType: SalaryAdjustmentType;
+  fixedAmount: number | null;
+  percentageIncrease: number | null;
+}
+
+export type AdjustmentScope = 'ALL_POSITIONS' | 'SPECIFIC_POSITION';
+
+export interface ApplyCollectiveBargainingAdjustmentRequest {
+  percentage: number;
+  effectiveDate: string;
+  scope: AdjustmentScope;
+  positionId: string | null;
+}
+
+export interface CollectiveBargainingAdjustmentResult {
+  id: string;
+  percentage: number;
+  effectiveDate: string;
+  scope: AdjustmentScope;
+  positionId: string | null;
+  positionLevelsUpdated: number;
+  employeesAffected: number;
+}

--- a/src/app/infrastructure/services/hr/collective-bargaining-adjustment.service.ts
+++ b/src/app/infrastructure/services/hr/collective-bargaining-adjustment.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import {
+  ApplyCollectiveBargainingAdjustmentRequest,
+  CollectiveBargainingAdjustmentResult
+} from '../../../domain/models/hr/career.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CollectiveBargainingAdjustmentService {
+
+  constructor(private http: HttpClient) {}
+
+  apply(request: ApplyCollectiveBargainingAdjustmentRequest): Observable<CollectiveBargainingAdjustmentResult> {
+    return this.http.post<CollectiveBargainingAdjustmentResult>(
+      `${environment.apiUrl}/hr/collective-bargaining-adjustments`,
+      request
+    );
+  }
+}

--- a/src/app/infrastructure/services/hr/position-level.service.ts
+++ b/src/app/infrastructure/services/hr/position-level.service.ts
@@ -1,0 +1,23 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CreatePositionLevelRequest, PositionLevel } from '../../../domain/models/hr/career.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PositionLevelService {
+
+  constructor(private http: HttpClient) {}
+
+  getByPosition(positionId: string): Observable<PositionLevel[]> {
+    return this.http.get<PositionLevel[]>(`${environment.apiUrl}/hr/position-levels`, {
+      params: { positionId }
+    });
+  }
+
+  create(request: CreatePositionLevelRequest): Observable<PositionLevel> {
+    return this.http.post<PositionLevel>(`${environment.apiUrl}/hr/position-levels`, request);
+  }
+}

--- a/src/app/infrastructure/services/hr/position.service.ts
+++ b/src/app/infrastructure/services/hr/position.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CreatePositionRequest, Position } from '../../../domain/models/hr/career.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PositionService {
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<Position[]> {
+    return this.http.get<Position[]>(`${environment.apiUrl}/hr/positions`);
+  }
+
+  create(request: CreatePositionRequest): Observable<Position> {
+    return this.http.post<Position>(`${environment.apiUrl}/hr/positions`, request);
+  }
+}


### PR DESCRIPTION
  Layout mestre-detalhe: tabela de cargos, ao selecionar mostra os
  níveis dele com o salário calculado pelo back-end (resolvedSalary).
  Formulário de nível alterna valor fixo/percentual conforme o tipo
  escolhido. Dialog de dissídio separado (todas as posições ou uma
  específica), mostra quantos níveis e funcionários foram afetados
  depois de aplicar. Nova entrada no menu RH: Cargos & Níveis.
