### PR TITLE
feat: adiciona telas de aprovação de Férias e gerenciador de Reembolsos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -34,6 +34,8 @@ import { PainelDeVagasComponent } from './components/auth/rh/painel-de-vagas/pai
 import { CandidaturasComponent } from './components/auth/rh/candidaturas/candidaturas.component'; // 👈 novo
 import { OrgStructureComponent } from './components/auth/rh/org-structure/org-structure.component';
 import { CareerStructureComponent } from './components/auth/rh/career-structure/career-structure.component';
+import { VacationRequestsManagerComponent } from './components/auth/rh/vacation-requests-manager/vacation-requests-manager.component';
+import { ReimbursementsManagerComponent } from './components/auth/rh/reimbursements-manager/reimbursements-manager.component';
 import { TrabalheConoscoComponent } from './components/public/trabalhe-conosco/trabalhe-conosco.component';
 import {SecretsComponent} from "./components/auth/communication/secrets/secrets.component";
 import {ViewSecretsComponent} from "./components/public/view-secrets/view-secrets.component";
@@ -92,6 +94,8 @@ export const routes: Routes = [
       { path: 'rh/employees', component: EmployesComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/organizational-structure', component: OrgStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/career-structure', component: CareerStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/vacation-requests', component: VacationRequestsManagerComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/reimbursements', component: ReimbursementsManagerComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/painel-de-vagas', component: PainelDeVagasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/candidaturas', component: CandidaturasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'company/nfe-collector', component: NfeDataCollectorComponent, data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },

--- a/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.html
+++ b/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.html
@@ -1,0 +1,149 @@
+<p-toast position="top-right"></p-toast>
+
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-wallet"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Gerenciador de Reembolsos</h1>
+      <p class="page-subtitle">Analise, aprove e registre o pagamento dos reembolsos</p>
+    </div>
+  </div>
+  <div class="header-actions">
+    <div class="filter-field">
+      <p-select
+        [options]="statusOptions"
+        [(ngModel)]="statusFilter"
+        (onChange)="load()"
+        optionLabel="label"
+        optionValue="value"
+        appendTo="body"
+        styleClass="select-field">
+      </p-select>
+    </div>
+    <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  </div>
+</div>
+
+<div class="table-card">
+  <pk-table
+    [data]="reimbursements"
+    [loading]="loading"
+    totalLabel="reembolsos encontrados"
+    searchPlaceholder="Buscar…"
+    emptyIcon="pi pi-wallet"
+    emptyTitle="Nenhum reembolso encontrado"
+    emptySubtitle="Troque o filtro de status pra ver outros reembolsos."
+    pageReportTitle="Reembolsos">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th>Funcionário</th>
+        <th>Categoria</th>
+        <th>Valor</th>
+        <th>Data do gasto</th>
+        <th>Status</th>
+        <th class="col-center">Ações</th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-r>
+      <tr class="table-row">
+        <td>{{ employeeName(r.employeeId) }}</td>
+        <td>{{ r.category }}</td>
+        <td>{{ r.amount | currency:'BRL' }}</td>
+        <td>{{ formatDate(r.expenseDate) }}</td>
+        <td>
+          <span class="rm-badge" [ngClass]="'rm-badge--' + r.status.toLowerCase()">{{ statusLabel(r.status) }}</span>
+          @if (r.status === 'REJECTED' && r.reviewNotes) {
+            <div class="rm-notes">{{ r.reviewNotes }}</div>
+          }
+          @if (r.status === 'PAID' && r.paymentDate) {
+            <div class="rm-notes rm-notes--paid">Pago em {{ formatDate(r.paymentDate) }}</div>
+          }
+        </td>
+        <td class="col-center">
+          @if (r.status === 'PENDING') {
+            <button pButton type="button" icon="pi pi-check" class="action-btn action-btn--approve" pTooltip="Aprovar" tooltipPosition="left" (click)="openReview(r, 'approve')"></button>
+            <button pButton type="button" icon="pi pi-times" class="action-btn action-btn--reject" pTooltip="Recusar" tooltipPosition="left" (click)="openReview(r, 'reject')"></button>
+          } @else if (r.status === 'APPROVED') {
+            <button pButton type="button" icon="pi pi-money-bill" label="Pagar" class="action-btn action-btn--pay" (click)="openPay(r)"></button>
+          }
+          <button pButton type="button" icon="pi" [ngClass]="baixandoId === r.id ? 'pi-spin pi-spinner' : 'pi-download'"
+                  class="action-btn" pTooltip="Ver comprovante" tooltipPosition="left"
+                  [disabled]="baixandoId === r.id" (click)="baixarComprovante(r)"></button>
+        </td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<!-- Dialog: Aprovar/Recusar -->
+<pk-dialog
+  [header]="reviewAction === 'approve' ? 'Aprovar reembolso' : 'Recusar reembolso'"
+  [visible]="reviewDialogVisible"
+  (visibleChange)="reviewDialogVisible = $event">
+
+  <div pkDialogContent>
+    @if (reviewTarget) {
+      <p class="review-target">
+        <i class="pi pi-user"></i>
+        <strong>{{ employeeName(reviewTarget.employeeId) }}</strong>
+        — {{ reviewTarget.category }} · {{ reviewTarget.amount | currency:'BRL' }}
+      </p>
+    }
+
+    <div class="form-field form-field--full">
+      <label for="reviewNotes">
+        Observação
+        @if (reviewAction === 'reject') { <span class="required">*</span> }
+      </label>
+      <textarea id="reviewNotes" [(ngModel)]="reviewNotes" rows="3" maxlength="500"
+                placeholder="{{ reviewAction === 'reject' ? 'Explique o motivo da recusa' : 'Opcional' }}"></textarea>
+    </div>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="reviewDialogVisible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button
+      [pkType]="reviewAction === 'approve' ? 'save' : 'cancel'"
+      (clicked)="confirmReview()"
+      [pkLabel]="reviewAction === 'approve' ? 'Aprovar' : 'Recusar'"
+      pkSize="sm"
+      [pkDisabled]="!canConfirmReview"
+      [pkLoading]="reviewSaving">
+    </pk-button>
+  </div>
+</pk-dialog>
+
+<!-- Dialog: Pagar -->
+<pk-dialog header="Registrar pagamento" [visible]="payDialogVisible" (visibleChange)="payDialogVisible = $event">
+  <div pkDialogContent>
+    @if (payTarget) {
+      <p class="review-target">
+        <i class="pi pi-user"></i>
+        <strong>{{ employeeName(payTarget.employeeId) }}</strong>
+        — {{ payTarget.category }} · {{ payTarget.amount | currency:'BRL' }}
+      </p>
+    }
+
+    <div class="form-field form-field--full">
+      <label for="payDate">Data do pagamento <span class="required">*</span></label>
+      <p-datepicker
+        id="payDate"
+        [(ngModel)]="payDate"
+        [showButtonBar]="true"
+        dateFormat="dd/mm/yy"
+        styleClass="datepicker-field"
+        placeholder="dd/mm/aaaa">
+      </p-datepicker>
+    </div>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="payDialogVisible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button pkType="save" (clicked)="confirmPay()" pkLabel="Confirmar pagamento" pkSize="sm" [pkDisabled]="!payDate" [pkLoading]="paySaving"/>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.scss
+++ b/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.scss
@@ -1,0 +1,111 @@
+@use 'variables' as v;
+
+.col-center { text-align: center !important; }
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.filter-field {
+  min-width: 160px;
+}
+
+.action-btn.p-button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin-left: 6px;
+  border-radius: v.$radius-sm;
+  background: transparent;
+  border: 1px solid v.$border;
+  color: v.$text-muted;
+  transition: all .15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &--approve:hover {
+    background: v.$secondary;
+    border-color: v.$secondary;
+    color: #fff;
+  }
+
+  &--reject:hover {
+    background: #d92d20;
+    border-color: #d92d20;
+    color: #fff;
+  }
+
+  &--pay {
+    width: auto;
+    padding: 0 .7rem;
+    gap: .35rem;
+    font-size: .78rem;
+    font-weight: 600;
+
+    &:hover {
+      background: v.$primary;
+      border-color: v.$primary;
+      color: #fff;
+    }
+  }
+
+  &:disabled { opacity: 0.6; cursor: default; }
+}
+
+.rm-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--pending {
+    background: rgba(107, 116, 146, 0.14);
+    color: #6b7492;
+  }
+
+  &--approved {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--rejected {
+    background: rgba(217, 45, 32, 0.10);
+    color: #d92d20;
+  }
+
+  &--paid {
+    background: rgba(35, 46, 97, 0.10);
+    color: v.$primary;
+  }
+}
+
+.rm-notes {
+  margin-top: 4px;
+  font-size: 0.78rem;
+  color: #b3261e;
+  max-width: 220px;
+
+  &--paid {
+    color: v.$secondary-dark;
+  }
+}
+
+.review-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(35, 46, 97, 0.05);
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 0.88rem;
+  color: v.$text-muted;
+
+  i { color: v.$primary; }
+}

--- a/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
+++ b/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
@@ -1,0 +1,206 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { SelectModule } from 'primeng/select';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { ReimbursementService } from '../../../../infrastructure/services/hr/reimbursement.service';
+import { EmployeeService } from '../../../../infrastructure/services/partners/employee/employee.service';
+import { Reimbursement, ReimbursementStatus } from '../../../../domain/models/hr/reimbursement.model';
+
+type ReviewAction = 'approve' | 'reject';
+
+@Component({
+  selector: 'app-reimbursements-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TableModule, SelectModule, DatePickerModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent],
+  templateUrl: './reimbursements-manager.component.html',
+  styleUrl: './reimbursements-manager.component.scss',
+  providers: [MessageService],
+})
+export class ReimbursementsManagerComponent implements OnInit {
+  reimbursements: Reimbursement[] = [];
+  loading = false;
+  baixandoId: string | null = null;
+  employeeNames = new Map<string, string>();
+
+  statusFilter: ReimbursementStatus | null = 'PENDING';
+  statusOptions: { label: string; value: ReimbursementStatus | null }[] = [
+    { label: 'Em análise', value: 'PENDING' },
+    { label: 'Aprovados', value: 'APPROVED' },
+    { label: 'Recusados', value: 'REJECTED' },
+    { label: 'Pagos', value: 'PAID' },
+    { label: 'Todos', value: null },
+  ];
+
+  reviewDialogVisible = false;
+  reviewAction: ReviewAction = 'approve';
+  reviewTarget: Reimbursement | null = null;
+  reviewNotes = '';
+  reviewSaving = false;
+
+  payDialogVisible = false;
+  payTarget: Reimbursement | null = null;
+  payDate: Date | null = null;
+  paySaving = false;
+
+  constructor(
+    private reimbursementService: ReimbursementService,
+    private employeeService: EmployeeService,
+    private msgService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadEmployeeNames();
+    this.load();
+  }
+
+  loadEmployeeNames(): void {
+    this.employeeService.getEmployes().subscribe({
+      next: (list) => {
+        this.employeeNames = new Map(list.filter((e) => e.id).map((e) => [e.id as string, e.name]));
+      },
+      error: () => (this.employeeNames = new Map()),
+    });
+  }
+
+  employeeName(employeeId: string): string {
+    return this.employeeNames.get(employeeId) ?? employeeId;
+  }
+
+  load(): void {
+    this.loading = true;
+    this.reimbursementService.getAll(this.statusFilter ?? undefined).subscribe({
+      next: (list) => {
+        this.reimbursements = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  statusLabel(status: ReimbursementStatus): string {
+    switch (status) {
+      case 'PENDING': return 'Em análise';
+      case 'APPROVED': return 'Aprovado';
+      case 'REJECTED': return 'Recusado';
+      case 'PAID': return 'Pago';
+    }
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  baixarComprovante(r: Reimbursement): void {
+    this.baixandoId = r.id;
+    this.reimbursementService.downloadReceipt(r.id).subscribe({
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = r.receiptOriginalFilename;
+        a.click();
+        URL.revokeObjectURL(url);
+        this.baixandoId = null;
+      },
+      error: () => (this.baixandoId = null),
+    });
+  }
+
+  // ---- Aprovar / Recusar ----
+
+  openReview(reimbursement: Reimbursement, action: ReviewAction): void {
+    this.reviewTarget = reimbursement;
+    this.reviewAction = action;
+    this.reviewNotes = '';
+    this.reviewDialogVisible = true;
+  }
+
+  get canConfirmReview(): boolean {
+    if (this.reviewAction === 'reject') return this.reviewNotes.trim().length > 0;
+    return true;
+  }
+
+  confirmReview(): void {
+    if (!this.reviewTarget || !this.canConfirmReview) return;
+
+    this.reviewSaving = true;
+    const payload = { notes: this.reviewNotes };
+    const call = this.reviewAction === 'approve'
+      ? this.reimbursementService.approve(this.reviewTarget.id, payload)
+      : this.reimbursementService.reject(this.reviewTarget.id, payload);
+
+    call.subscribe({
+      next: () => {
+        this.reviewSaving = false;
+        this.reviewDialogVisible = false;
+        this.load();
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: this.reviewAction === 'approve' ? 'Reembolso aprovado!' : 'Reembolso recusado!',
+        });
+      },
+      error: (err) => {
+        this.reviewSaving = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  // ---- Pagar ----
+
+  openPay(reimbursement: Reimbursement): void {
+    this.payTarget = reimbursement;
+    this.payDate = null;
+    this.payDialogVisible = true;
+  }
+
+  confirmPay(): void {
+    if (!this.payTarget || !this.payDate) return;
+
+    this.paySaving = true;
+    this.reimbursementService.pay(this.payTarget.id, { paymentDate: this.toIsoDate(this.payDate) }).subscribe({
+      next: () => {
+        this.paySaving = false;
+        this.payDialogVisible = false;
+        this.load();
+        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Pagamento registrado!' });
+      },
+      error: (err) => {
+        this.paySaving = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.html
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.html
@@ -1,0 +1,112 @@
+<p-toast position="top-right"></p-toast>
+
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-sun"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Aprovação de Férias</h1>
+      <p class="page-subtitle">Analise as solicitações de férias dos funcionários</p>
+    </div>
+  </div>
+  <div class="header-actions">
+    <div class="filter-field">
+      <p-select
+        [options]="statusOptions"
+        [(ngModel)]="statusFilter"
+        (onChange)="load()"
+        optionLabel="label"
+        optionValue="value"
+        appendTo="body"
+        styleClass="select-field">
+      </p-select>
+    </div>
+    <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+  </div>
+</div>
+
+<div class="table-card">
+  <pk-table
+    [data]="requests"
+    [loading]="loading"
+    totalLabel="solicitações encontradas"
+    searchPlaceholder="Buscar…"
+    emptyIcon="pi pi-sun"
+    emptyTitle="Nenhuma solicitação encontrada"
+    emptySubtitle="Troque o filtro de status pra ver outras solicitações."
+    pageReportTitle="Férias">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th>Funcionário</th>
+        <th>Período</th>
+        <th>Dias</th>
+        <th>Status</th>
+        <th>Solicitado em</th>
+        <th class="col-center">Ações</th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-r>
+      <tr class="table-row">
+        <td>{{ employeeName(r.employeeId) }}</td>
+        <td>{{ formatDate(r.startDate) }} — {{ formatDate(r.endDate) }}</td>
+        <td><span class="code-badge">{{ r.daysRequested }}</span></td>
+        <td>
+          <span class="vr-badge" [ngClass]="'vr-badge--' + r.status.toLowerCase()">{{ statusLabel(r.status) }}</span>
+          @if (r.status === 'REJECTED' && r.reviewNotes) {
+            <div class="vr-notes">{{ r.reviewNotes }}</div>
+          }
+        </td>
+        <td>{{ formatDate(r.requestedAt) }}</td>
+        <td class="col-center">
+          @if (r.status === 'PENDING') {
+            <button pButton type="button" icon="pi pi-check" class="action-btn action-btn--approve" pTooltip="Aprovar" tooltipPosition="left" (click)="openReview(r, 'approve')"></button>
+            <button pButton type="button" icon="pi pi-times" class="action-btn action-btn--reject" pTooltip="Recusar" tooltipPosition="left" (click)="openReview(r, 'reject')"></button>
+          } @else {
+            <span class="text-muted">—</span>
+          }
+        </td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>
+
+<pk-dialog
+  [header]="reviewAction === 'approve' ? 'Aprovar solicitação' : 'Recusar solicitação'"
+  [visible]="reviewDialogVisible"
+  (visibleChange)="reviewDialogVisible = $event">
+
+  <div pkDialogContent>
+    @if (reviewTarget) {
+      <p class="review-target">
+        <i class="pi pi-user"></i>
+        <strong>{{ employeeName(reviewTarget.employeeId) }}</strong>
+        — {{ formatDate(reviewTarget.startDate) }} a {{ formatDate(reviewTarget.endDate) }} ({{ reviewTarget.daysRequested }} dias)
+      </p>
+    }
+
+    <div class="form-field form-field--full">
+      <label for="reviewNotes">
+        Observação
+        @if (reviewAction === 'reject') { <span class="required">*</span> }
+      </label>
+      <textarea id="reviewNotes" [(ngModel)]="reviewNotes" rows="3" maxlength="500"
+                placeholder="{{ reviewAction === 'reject' ? 'Explique o motivo da recusa' : 'Opcional' }}"></textarea>
+    </div>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" (clicked)="reviewDialogVisible = false" pkLabel="Cancelar" pkSize="sm"/>
+    <pk-button
+      [pkType]="reviewAction === 'approve' ? 'save' : 'cancel'"
+      (clicked)="confirmReview()"
+      [pkLabel]="reviewAction === 'approve' ? 'Aprovar' : 'Recusar'"
+      pkSize="sm"
+      [pkDisabled]="!canConfirmReview"
+      [pkLoading]="reviewSaving">
+    </pk-button>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.scss
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.scss
@@ -1,0 +1,87 @@
+@use 'variables' as v;
+
+.col-center { text-align: center !important; }
+.text-muted { color: v.$text-light; font-size: .85rem; }
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.filter-field {
+  min-width: 160px;
+}
+
+.action-btn.p-button {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  margin-left: 6px;
+  border-radius: v.$radius-sm;
+  background: transparent;
+  border: 1px solid v.$border;
+  color: v.$text-muted;
+  transition: all .15s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &--approve:hover {
+    background: v.$secondary;
+    border-color: v.$secondary;
+    color: #fff;
+  }
+
+  &--reject:hover {
+    background: #d92d20;
+    border-color: #d92d20;
+    color: #fff;
+  }
+}
+
+.vr-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--pending {
+    background: rgba(107, 116, 146, 0.14);
+    color: #6b7492;
+  }
+
+  &--approved {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--rejected {
+    background: rgba(217, 45, 32, 0.10);
+    color: #d92d20;
+  }
+}
+
+.vr-notes {
+  margin-top: 4px;
+  font-size: 0.78rem;
+  color: #b3261e;
+  max-width: 220px;
+}
+
+.review-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(35, 46, 97, 0.05);
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 0.88rem;
+  color: v.$text-muted;
+
+  i { color: v.$primary; }
+}

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
@@ -1,0 +1,146 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { SelectModule } from 'primeng/select';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { VacationRequestService } from '../../../../infrastructure/services/hr/vacation-request.service';
+import { EmployeeService } from '../../../../infrastructure/services/partners/employee/employee.service';
+import { VacationRequest, VacationRequestStatus } from '../../../../domain/models/hr/vacation-request.model';
+
+type ReviewAction = 'approve' | 'reject';
+
+@Component({
+  selector: 'app-vacation-requests-manager',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TableModule, SelectModule, Toast, PkButtonComponent, PkDialogComponent, PkTableComponent],
+  templateUrl: './vacation-requests-manager.component.html',
+  styleUrl: './vacation-requests-manager.component.scss',
+  providers: [MessageService],
+})
+export class VacationRequestsManagerComponent implements OnInit {
+  requests: VacationRequest[] = [];
+  loading = false;
+  employeeNames = new Map<string, string>();
+
+  statusFilter: VacationRequestStatus | null = 'PENDING';
+  statusOptions: { label: string; value: VacationRequestStatus | null }[] = [
+    { label: 'Pendentes', value: 'PENDING' },
+    { label: 'Aprovadas', value: 'APPROVED' },
+    { label: 'Recusadas', value: 'REJECTED' },
+    { label: 'Todas', value: null },
+  ];
+
+  reviewDialogVisible = false;
+  reviewAction: ReviewAction = 'approve';
+  reviewTarget: VacationRequest | null = null;
+  reviewNotes = '';
+  reviewSaving = false;
+
+  constructor(
+    private vacationRequestService: VacationRequestService,
+    private employeeService: EmployeeService,
+    private msgService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadEmployeeNames();
+    this.load();
+  }
+
+  loadEmployeeNames(): void {
+    this.employeeService.getEmployes().subscribe({
+      next: (list) => {
+        this.employeeNames = new Map(list.filter((e) => e.id).map((e) => [e.id as string, e.name]));
+      },
+      error: () => (this.employeeNames = new Map()),
+    });
+  }
+
+  employeeName(employeeId: string): string {
+    return this.employeeNames.get(employeeId) ?? employeeId;
+  }
+
+  load(): void {
+    this.loading = true;
+    this.vacationRequestService.getAll(this.statusFilter ?? undefined).subscribe({
+      next: (list) => {
+        this.requests = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  statusLabel(status: VacationRequestStatus): string {
+    switch (status) {
+      case 'PENDING': return 'Em análise';
+      case 'APPROVED': return 'Aprovado';
+      case 'REJECTED': return 'Recusado';
+    }
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  openReview(request: VacationRequest, action: ReviewAction): void {
+    this.reviewTarget = request;
+    this.reviewAction = action;
+    this.reviewNotes = '';
+    this.reviewDialogVisible = true;
+  }
+
+  get canConfirmReview(): boolean {
+    if (this.reviewAction === 'reject') return this.reviewNotes.trim().length > 0;
+    return true;
+  }
+
+  confirmReview(): void {
+    if (!this.reviewTarget || !this.canConfirmReview) return;
+
+    this.reviewSaving = true;
+    const payload = { notes: this.reviewNotes };
+    const call = this.reviewAction === 'approve'
+      ? this.vacationRequestService.approve(this.reviewTarget.id, payload)
+      : this.vacationRequestService.reject(this.reviewTarget.id, payload);
+
+    call.subscribe({
+      next: () => {
+        this.reviewSaving = false;
+        this.reviewDialogVisible = false;
+        this.load();
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: this.reviewAction === 'approve' ? 'Solicitação aprovada!' : 'Solicitação recusada!',
+        });
+      },
+      error: (err) => {
+        this.reviewSaving = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 409: return 'Registro já existe';
+      case 422: return 'Dados inválidos';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/shared/top-menu/top-menu.component.ts
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.ts
@@ -93,7 +93,9 @@ export class TopMenuComponent implements OnInit, OnDestroy {
           { label: 'Coletar dados Holerite',  icon: 'pi pi-fw pi-file-arrow-up',      routerLink: ['rh/holerit/extractor'],roles: ['ADMIN', 'RH'] },
           { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], roles: ['ADMIN', 'RH'] },
           { label: 'Estrutura Organizacional', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] },
-          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], roles: ['ADMIN', 'RH'] }
+          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], roles: ['ADMIN', 'RH'] },
+          { label: 'Aprovar Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], roles: ['ADMIN', 'RH'] },
+          { label: 'Gerenciar Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], roles: ['ADMIN', 'RH'] }
         ],
       },
       {

--- a/src/app/domain/models/employee.model.ts
+++ b/src/app/domain/models/employee.model.ts
@@ -1,4 +1,5 @@
 export interface Employee{
+  id?: string, // presente na resposta da API; opcional pra não quebrar telas antigas que montam Employee só com os campos do form
   partnerCode: string,
   document: string,
   name: string,

--- a/src/app/domain/models/hr/reimbursement.model.ts
+++ b/src/app/domain/models/hr/reimbursement.model.ts
@@ -16,3 +16,11 @@ export interface Reimbursement {
   paymentDate: string | null;
   paidAt: string | null;
 }
+
+export interface ReviewReimbursementPayload {
+  notes: string;
+}
+
+export interface PayReimbursementPayload {
+  paymentDate: string;
+}

--- a/src/app/domain/models/hr/vacation-request.model.ts
+++ b/src/app/domain/models/hr/vacation-request.model.ts
@@ -18,3 +18,7 @@ export interface EmployeeVacationOverview {
   vacationBalanceDays: number | null;
   requests: VacationRequest[];
 }
+
+export interface ReviewVacationRequestPayload {
+  notes: string;
+}

--- a/src/app/infrastructure/services/hr/reimbursement.service.ts
+++ b/src/app/infrastructure/services/hr/reimbursement.service.ts
@@ -2,7 +2,12 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { Reimbursement } from '../../../domain/models/hr/reimbursement.model';
+import {
+  PayReimbursementPayload,
+  Reimbursement,
+  ReimbursementStatus,
+  ReviewReimbursementPayload
+} from '../../../domain/models/hr/reimbursement.model';
 
 export interface RequestReimbursementPayload {
   expenseDate: string;
@@ -38,5 +43,24 @@ export class ReimbursementService {
     return this.http.get(`${environment.apiUrl}/hr/reimbursements/${id}/receipt`, {
       responseType: 'blob'
     });
+  }
+
+  /** Gerenciador do RH — sem status, lista tudo. */
+  getAll(status?: ReimbursementStatus): Observable<Reimbursement[]> {
+    const params: Record<string, string> = {};
+    if (status) params['status'] = status;
+    return this.http.get<Reimbursement[]>(`${environment.apiUrl}/hr/reimbursements`, { params });
+  }
+
+  approve(id: string, payload: ReviewReimbursementPayload): Observable<Reimbursement> {
+    return this.http.post<Reimbursement>(`${environment.apiUrl}/hr/reimbursements/${id}/approve`, payload);
+  }
+
+  reject(id: string, payload: ReviewReimbursementPayload): Observable<Reimbursement> {
+    return this.http.post<Reimbursement>(`${environment.apiUrl}/hr/reimbursements/${id}/reject`, payload);
+  }
+
+  pay(id: string, payload: PayReimbursementPayload): Observable<Reimbursement> {
+    return this.http.post<Reimbursement>(`${environment.apiUrl}/hr/reimbursements/${id}/pay`, payload);
   }
 }

--- a/src/app/infrastructure/services/hr/vacation-request.service.ts
+++ b/src/app/infrastructure/services/hr/vacation-request.service.ts
@@ -2,7 +2,12 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { EmployeeVacationOverview, VacationRequest } from '../../../domain/models/hr/vacation-request.model';
+import {
+  EmployeeVacationOverview,
+  ReviewVacationRequestPayload,
+  VacationRequest,
+  VacationRequestStatus
+} from '../../../domain/models/hr/vacation-request.model';
 
 export interface CreateVacationRequestPayload {
   startDate: string;
@@ -23,5 +28,20 @@ export class VacationRequestService {
 
   request(payload: CreateVacationRequestPayload): Observable<VacationRequest> {
     return this.http.post<VacationRequest>(`${environment.apiUrl}/hr/vacation-requests`, payload);
+  }
+
+  /** Gerenciador do RH — sem status, lista tudo. */
+  getAll(status?: VacationRequestStatus): Observable<VacationRequest[]> {
+    const params: Record<string, string> = {};
+    if (status) params['status'] = status;
+    return this.http.get<VacationRequest[]>(`${environment.apiUrl}/hr/vacation-requests`, { params });
+  }
+
+  approve(id: string, payload: ReviewVacationRequestPayload): Observable<VacationRequest> {
+    return this.http.post<VacationRequest>(`${environment.apiUrl}/hr/vacation-requests/${id}/approve`, payload);
+  }
+
+  reject(id: string, payload: ReviewVacationRequestPayload): Observable<VacationRequest> {
+    return this.http.post<VacationRequest>(`${environment.apiUrl}/hr/vacation-requests/${id}/reject`, payload);
   }
 }


### PR DESCRIPTION
  Duas telas de RH com filtro de status, tabela e dialogs de
  aprovar/recusar (recusar exige observação). Reembolsos tem também o
  fluxo de pagamento (aprovado -> botão Pagar -> confirma data -> vira
  Pago) e download do comprovante. Employee ganha campo id (já vinha na
  API, só não estava tipado) pra resolver nome do funcionário nas
  tabelas via lookup local, evitando mostrar UUID cru pro RH.
