### PR TITLE
feat: adiciona telas de Calendário RH e Visão de Equipe

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -36,6 +36,8 @@ import { OrgStructureComponent } from './components/auth/rh/org-structure/org-st
 import { CareerStructureComponent } from './components/auth/rh/career-structure/career-structure.component';
 import { VacationRequestsManagerComponent } from './components/auth/rh/vacation-requests-manager/vacation-requests-manager.component';
 import { ReimbursementsManagerComponent } from './components/auth/rh/reimbursements-manager/reimbursements-manager.component';
+import { HrCalendarComponent } from './components/auth/rh/hr-calendar/hr-calendar.component';
+import { TeamOverviewComponent } from './components/auth/rh/team-overview/team-overview.component';
 import { TrabalheConoscoComponent } from './components/public/trabalhe-conosco/trabalhe-conosco.component';
 import {SecretsComponent} from "./components/auth/communication/secrets/secrets.component";
 import {ViewSecretsComponent} from "./components/public/view-secrets/view-secrets.component";
@@ -96,6 +98,8 @@ export const routes: Routes = [
       { path: 'rh/career-structure', component: CareerStructureComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/vacation-requests', component: VacationRequestsManagerComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/reimbursements', component: ReimbursementsManagerComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/calendar', component: HrCalendarComponent, data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/team-overview', component: TeamOverviewComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/painel-de-vagas', component: PainelDeVagasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'rh/candidaturas', component: CandidaturasComponent, data: { roles: ['ADMIN', 'RH'] } },
       { path: 'company/nfe-collector', component: NfeDataCollectorComponent, data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },

--- a/src/app/components/auth/rh/hr-calendar/hr-calendar.component.html
+++ b/src/app/components/auth/rh/hr-calendar/hr-calendar.component.html
@@ -1,0 +1,75 @@
+<p-toast position="top-right"></p-toast>
+
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-calendar"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Calendário RH</h1>
+      <p class="page-subtitle">Tudo que está agendado no período, com filtros</p>
+    </div>
+  </div>
+</div>
+
+<div class="filters-bar">
+  <div class="form-field">
+    <label for="startDate">De</label>
+    <p-datepicker id="startDate" [(ngModel)]="startDate" dateFormat="dd/mm/yy" styleClass="datepicker-field" (onSelect)="load()"></p-datepicker>
+  </div>
+  <div class="form-field">
+    <label for="endDate">Até</label>
+    <p-datepicker id="endDate" [(ngModel)]="endDate" dateFormat="dd/mm/yy" styleClass="datepicker-field" (onSelect)="load()"></p-datepicker>
+  </div>
+  <div class="form-field">
+    <label for="teamFilter">Setor</label>
+    <p-select id="teamFilter" [options]="teamOptions" [(ngModel)]="teamFilter" (onChange)="load()"
+              optionLabel="label" optionValue="value" appendTo="body" placeholder="Todos" [showClear]="true" styleClass="select-field"></p-select>
+  </div>
+  <div class="form-field">
+    <label for="companyFilter">Empresa</label>
+    <p-select id="companyFilter" [options]="companyOptions" [(ngModel)]="companyFilter" (onChange)="load()"
+              optionLabel="label" optionValue="value" appendTo="body" placeholder="Todas" [showClear]="true" styleClass="select-field"></p-select>
+  </div>
+  <div class="form-field">
+    <label for="statusFilter">Status</label>
+    <p-select id="statusFilter" [options]="statusOptions" [(ngModel)]="statusFilter" (onChange)="load()"
+              optionLabel="label" optionValue="value" appendTo="body" styleClass="select-field"></p-select>
+  </div>
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Buscar" pkSize="sm"/>
+</div>
+
+<div class="table-card">
+  <pk-table
+    [data]="events"
+    [loading]="loading"
+    totalLabel="eventos encontrados"
+    searchPlaceholder="Buscar por funcionário…"
+    [filterFields]="['employeeName']"
+    emptyIcon="pi pi-calendar"
+    emptyTitle="Nenhum evento no período"
+    emptySubtitle="Ajuste o período ou os filtros pra ver outros eventos."
+    pageReportTitle="Eventos">
+
+    <ng-template #headerTpl>
+      <tr>
+        <th>Tipo</th>
+        <th>Funcionário</th>
+        <th>Setor</th>
+        <th>Período</th>
+        <th>Status</th>
+      </tr>
+    </ng-template>
+
+    <ng-template #bodyTpl let-e>
+      <tr class="table-row">
+        <td><span class="event-type-badge"><i class="pi pi-sun"></i> {{ eventTypeLabel(e.eventType) }}</span></td>
+        <td>{{ e.employeeName }}</td>
+        <td>{{ e.teamName ?? '—' }}</td>
+        <td>{{ formatDate(e.startDate) }} — {{ formatDate(e.endDate) }}</td>
+        <td><span class="hc-badge" [ngClass]="'hc-badge--' + e.status.toLowerCase()">{{ statusLabel(e.status) }}</span></td>
+      </tr>
+    </ng-template>
+
+  </pk-table>
+</div>

--- a/src/app/components/auth/rh/hr-calendar/hr-calendar.component.scss
+++ b/src/app/components/auth/rh/hr-calendar/hr-calendar.component.scss
@@ -1,0 +1,52 @@
+@use 'variables' as v;
+
+.filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 14px;
+  margin: 20px 0 24px;
+
+  .form-field {
+    min-width: 150px;
+  }
+}
+
+.event-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: v.$primary;
+  font-size: 0.85rem;
+}
+
+.hc-badge {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--pending {
+    background: rgba(107, 116, 146, 0.14);
+    color: #6b7492;
+  }
+
+  &--approved {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--rejected {
+    background: rgba(217, 45, 32, 0.10);
+    color: #d92d20;
+  }
+}
+
+@media (max-width: 700px) {
+  .filters-bar { gap: 10px; }
+  .filters-bar .form-field { min-width: 130px; }
+}

--- a/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
+++ b/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
@@ -1,0 +1,125 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TableModule } from 'primeng/table';
+import { SelectModule } from 'primeng/select';
+import { DatePickerModule } from 'primeng/datepicker';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { CalendarService } from '../../../../infrastructure/services/hr/calendar.service';
+import { TeamService } from '../../../../infrastructure/services/hr/team.service';
+import { CompanyService } from '../../../../infrastructure/services/hr/company.service';
+import { CalendarEvent, CalendarEventStatus } from '../../../../domain/models/hr/calendar.model';
+
+@Component({
+  selector: 'app-hr-calendar',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TableModule, SelectModule, DatePickerModule, Toast, PkButtonComponent, PkTableComponent],
+  templateUrl: './hr-calendar.component.html',
+  styleUrl: './hr-calendar.component.scss',
+  providers: [MessageService],
+})
+export class HrCalendarComponent implements OnInit {
+  events: CalendarEvent[] = [];
+  loading = false;
+
+  startDate: Date;
+  endDate: Date;
+  teamFilter: string | null = null;
+  companyFilter: string | null = null;
+  statusFilter: CalendarEventStatus | null = 'APPROVED';
+
+  teamOptions: { label: string; value: string }[] = [];
+  companyOptions: { label: string; value: string }[] = [];
+  statusOptions: { label: string; value: CalendarEventStatus | null }[] = [
+    { label: 'Aprovados', value: 'APPROVED' },
+    { label: 'Pendentes', value: 'PENDING' },
+    { label: 'Recusados', value: 'REJECTED' },
+  ];
+
+  constructor(
+    private calendarService: CalendarService,
+    private teamService: TeamService,
+    private companyService: CompanyService,
+    private msgService: MessageService
+  ) {
+    const now = new Date();
+    this.startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    this.endDate = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+  }
+
+  ngOnInit(): void {
+    this.loadFilters();
+    this.load();
+  }
+
+  loadFilters(): void {
+    this.teamService.getAll().subscribe({
+      next: (list) => (this.teamOptions = list.map((t) => ({ label: t.name, value: t.id }))),
+      error: () => (this.teamOptions = []),
+    });
+    this.companyService.getAll().subscribe({
+      next: (list) => (this.companyOptions = list.map((c) => ({ label: c.name, value: c.id }))),
+      error: () => (this.companyOptions = []),
+    });
+  }
+
+  load(): void {
+    if (!this.startDate || !this.endDate) return;
+
+    this.loading = true;
+    this.calendarService.getEvents({
+      start: this.toIsoDate(this.startDate),
+      end: this.toIsoDate(this.endDate),
+      teamId: this.teamFilter ?? undefined,
+      companyId: this.companyFilter ?? undefined,
+      status: this.statusFilter ?? undefined,
+    }).subscribe({
+      next: (list) => {
+        this.events = [...list].sort((a, b) => a.startDate.localeCompare(b.startDate));
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  eventTypeLabel(type: string): string {
+    return type === 'VACATION' ? 'Férias' : type;
+  }
+
+  statusLabel(status: CalendarEventStatus): string {
+    switch (status) {
+      case 'PENDING': return 'Pendente';
+      case 'APPROVED': return 'Aprovado';
+      case 'REJECTED': return 'Recusado';
+    }
+  }
+
+  formatDate(iso: string): string {
+    return new Date(iso).toLocaleDateString('pt-BR');
+  }
+
+  private toIsoDate(date: Date): string {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 404: return 'Recurso não encontrado';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/rh/team-overview/team-overview.component.html
+++ b/src/app/components/auth/rh/team-overview/team-overview.component.html
@@ -1,0 +1,66 @@
+<p-toast position="top-right"></p-toast>
+
+<div class="page-header">
+  <div class="header-left">
+    <div class="header-icon">
+      <i class="pi pi-users"></i>
+    </div>
+    <div>
+      <h1 class="page-title">Visão de Equipe</h1>
+      <p class="page-subtitle">Quem está disponível, de férias ou com férias agendadas</p>
+    </div>
+  </div>
+</div>
+
+<div class="filters-bar">
+  <div class="form-field">
+    <label for="teamFilter">Setor</label>
+    <p-select id="teamFilter" [options]="teamOptions" [(ngModel)]="teamFilter" (onChange)="load()"
+              optionLabel="label" optionValue="value" appendTo="body" placeholder="Todos" [showClear]="true" styleClass="select-field"></p-select>
+  </div>
+  <div class="form-field">
+    <label for="companyFilter">Empresa</label>
+    <p-select id="companyFilter" [options]="companyOptions" [(ngModel)]="companyFilter" (onChange)="load()"
+              optionLabel="label" optionValue="value" appendTo="body" placeholder="Todas" [showClear]="true" styleClass="select-field"></p-select>
+  </div>
+  <pk-button pkType="refresh" (clicked)="load()" pkLabel="Atualizar" pkSize="sm"/>
+</div>
+
+<div class="summary-row">
+  <div class="summary-chip summary-chip--available">
+    <i class="pi pi-check-circle"></i> {{ availableCount }} disponíveis
+  </div>
+  <div class="summary-chip summary-chip--vacation">
+    <i class="pi pi-sun"></i> {{ onVacationCount }} de férias
+  </div>
+  <div class="summary-chip summary-chip--scheduled">
+    <i class="pi pi-calendar"></i> {{ scheduledCount }} com férias agendadas
+  </div>
+</div>
+
+@if (loading) {
+  <div class="to-state"><i class="pi pi-spin pi-spinner"></i> Carregando...</div>
+} @else if (entries.length === 0) {
+  <div class="to-empty">
+    <span class="to-empty-icon"><i class="pi pi-users"></i></span>
+    <p>Nenhum funcionário encontrado</p>
+  </div>
+} @else {
+  <div class="team-grid">
+    @for (e of entries; track e.employeeId) {
+      <div class="team-card" [ngClass]="'team-card--' + e.availabilityStatus.toLowerCase()">
+        <div class="team-card__avatar">{{ initials(e.name) }}</div>
+        <div class="team-card__info">
+          <span class="team-card__name">{{ e.name }}</span>
+          <span class="team-card__meta">{{ e.teamName ?? 'Sem setor' }} @if (e.companyName) { · {{ e.companyName }} }</span>
+        </div>
+        <div class="team-card__badges">
+          <span class="to-badge" [ngClass]="'to-badge--' + e.availabilityStatus.toLowerCase()">{{ statusLabel(e.availabilityStatus) }}</span>
+          @if (e.contractType) {
+            <span class="to-badge to-badge--contract">{{ e.contractType }}</span>
+          }
+        </div>
+      </div>
+    }
+  </div>
+}

--- a/src/app/components/auth/rh/team-overview/team-overview.component.scss
+++ b/src/app/components/auth/rh/team-overview/team-overview.component.scss
@@ -1,0 +1,172 @@
+@use 'variables' as v;
+
+.filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 14px;
+  margin: 20px 0 20px;
+
+  .form-field {
+    min-width: 180px;
+  }
+}
+
+.summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+
+  &--available {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--vacation {
+    background: rgba(246, 173, 85, 0.18);
+    color: #b06d12;
+  }
+
+  &--scheduled {
+    background: rgba(35, 46, 97, 0.10);
+    color: v.$primary;
+  }
+}
+
+.to-state {
+  padding: 40px 0;
+  color: #6b7492;
+  text-align: center;
+}
+
+.to-empty {
+  text-align: center;
+  color: #9aa6bd;
+  padding: 56px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  .to-empty-icon {
+    width: 80px;
+    height: 80px;
+    border-radius: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, rgba(35, 46, 97, 0.08), rgba(87, 193, 171, 0.16));
+    color: v.$primary;
+    i { font-size: 2.2rem; }
+  }
+
+  p { margin: 0; font-weight: 700; color: #6b7492; }
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.team-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 18px;
+  background: #ffffff;
+  border: 1px solid #e6e9f0;
+  border-left: 4px solid #cbd3e1;
+  border-radius: 14px;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 8px 24px rgba(35, 46, 97, 0.08);
+  }
+
+  &--available { border-left-color: v.$secondary; }
+  &--on_vacation { border-left-color: #f6ad55; }
+  &--vacation_scheduled { border-left-color: v.$primary; }
+
+  &__avatar {
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, v.$primary, v.$secondary);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 1.1rem;
+  }
+
+  &__info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__name {
+    font-family: v.$font-heading;
+    font-weight: 700;
+    color: v.$primary;
+    font-size: 0.95rem;
+  }
+
+  &__meta {
+    font-size: 0.78rem;
+    color: #8a93a8;
+  }
+
+  &__badges {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 4px;
+  }
+}
+
+.to-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+
+  &--available {
+    background: rgba(87, 193, 171, 0.16);
+    color: v.$secondary-dark;
+  }
+
+  &--on_vacation {
+    background: rgba(246, 173, 85, 0.18);
+    color: #b06d12;
+  }
+
+  &--vacation_scheduled {
+    background: rgba(35, 46, 97, 0.10);
+    color: v.$primary;
+  }
+
+  &--contract {
+    background: #f1f3f8;
+    color: #6b7492;
+  }
+}

--- a/src/app/components/auth/rh/team-overview/team-overview.component.ts
+++ b/src/app/components/auth/rh/team-overview/team-overview.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { SelectModule } from 'primeng/select';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { TeamOverviewService } from '../../../../infrastructure/services/hr/team-overview.service';
+import { TeamService } from '../../../../infrastructure/services/hr/team.service';
+import { CompanyService } from '../../../../infrastructure/services/hr/company.service';
+import { AvailabilityStatus, TeamOverviewEntry } from '../../../../domain/models/hr/team-overview.model';
+
+@Component({
+  selector: 'app-team-overview',
+  standalone: true,
+  imports: [CommonModule, FormsModule, SelectModule, Toast, PkButtonComponent],
+  templateUrl: './team-overview.component.html',
+  styleUrl: './team-overview.component.scss',
+  providers: [MessageService],
+})
+export class TeamOverviewComponent implements OnInit {
+  entries: TeamOverviewEntry[] = [];
+  loading = false;
+
+  teamFilter: string | null = null;
+  companyFilter: string | null = null;
+
+  teamOptions: { label: string; value: string }[] = [];
+  companyOptions: { label: string; value: string }[] = [];
+
+  constructor(
+    private teamOverviewService: TeamOverviewService,
+    private teamService: TeamService,
+    private companyService: CompanyService,
+    private msgService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadFilters();
+    this.load();
+  }
+
+  loadFilters(): void {
+    this.teamService.getAll().subscribe({
+      next: (list) => (this.teamOptions = list.map((t) => ({ label: t.name, value: t.id }))),
+      error: () => (this.teamOptions = []),
+    });
+    this.companyService.getAll().subscribe({
+      next: (list) => (this.companyOptions = list.map((c) => ({ label: c.name, value: c.id }))),
+      error: () => (this.companyOptions = []),
+    });
+  }
+
+  load(): void {
+    this.loading = true;
+    this.teamOverviewService.getOverview(this.teamFilter ?? undefined, this.companyFilter ?? undefined).subscribe({
+      next: (list) => {
+        this.entries = list;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });
+      },
+    });
+  }
+
+  get availableCount(): number {
+    return this.entries.filter((e) => e.availabilityStatus === 'AVAILABLE').length;
+  }
+
+  get onVacationCount(): number {
+    return this.entries.filter((e) => e.availabilityStatus === 'ON_VACATION').length;
+  }
+
+  get scheduledCount(): number {
+    return this.entries.filter((e) => e.availabilityStatus === 'VACATION_SCHEDULED').length;
+  }
+
+  statusLabel(status: AvailabilityStatus): string {
+    switch (status) {
+      case 'AVAILABLE': return 'Disponível';
+      case 'ON_VACATION': return 'Em férias';
+      case 'VACATION_SCHEDULED': return 'Férias agendadas';
+    }
+  }
+
+  initials(name: string): string {
+    return name?.charAt(0)?.toUpperCase() ?? '?';
+  }
+
+  private getErrorMessage(err: any): string {
+    switch (err.status) {
+      case 400: return 'Requisição inválida';
+      case 401: return 'Não autorizado. Faça login novamente';
+      case 403: return 'Você não tem permissão para esta ação';
+      case 500: return 'Erro interno do servidor';
+      case 0:   return 'Sem conexão com o servidor';
+      default:  return `Erro inesperado (${err.status})`;
+    }
+  }
+}

--- a/src/app/components/auth/shared/top-menu/top-menu.component.ts
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.ts
@@ -95,7 +95,9 @@ export class TopMenuComponent implements OnInit, OnDestroy {
           { label: 'Estrutura Organizacional', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] },
           { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], roles: ['ADMIN', 'RH'] },
           { label: 'Aprovar Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], roles: ['ADMIN', 'RH'] },
-          { label: 'Gerenciar Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], roles: ['ADMIN', 'RH'] }
+          { label: 'Gerenciar Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], roles: ['ADMIN', 'RH'] },
+          { label: 'Calendário RH', icon: 'pi pi-fw pi-calendar', routerLink: ['rh/calendar'], roles: ['ADMIN', 'RH'] },
+          { label: 'Visão de Equipe', icon: 'pi pi-fw pi-users', routerLink: ['rh/team-overview'], roles: ['ADMIN', 'RH'] }
         ],
       },
       {

--- a/src/app/domain/models/hr/calendar.model.ts
+++ b/src/app/domain/models/hr/calendar.model.ts
@@ -1,0 +1,14 @@
+export type CalendarEventType = 'VACATION';
+export type CalendarEventStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
+
+export interface CalendarEvent {
+  id: string;
+  eventType: CalendarEventType;
+  employeeId: string;
+  employeeName: string;
+  teamId: string | null;
+  teamName: string | null;
+  startDate: string;
+  endDate: string;
+  status: CalendarEventStatus;
+}

--- a/src/app/domain/models/hr/team-overview.model.ts
+++ b/src/app/domain/models/hr/team-overview.model.ts
@@ -1,0 +1,13 @@
+export type ContractType = 'CLT' | 'PJ';
+export type AvailabilityStatus = 'AVAILABLE' | 'ON_VACATION' | 'VACATION_SCHEDULED';
+
+export interface TeamOverviewEntry {
+  employeeId: string;
+  name: string;
+  teamId: string | null;
+  teamName: string | null;
+  companyId: string | null;
+  companyName: string | null;
+  contractType: ContractType | null;
+  availabilityStatus: AvailabilityStatus;
+}

--- a/src/app/infrastructure/services/hr/calendar.service.ts
+++ b/src/app/infrastructure/services/hr/calendar.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { CalendarEvent, CalendarEventStatus } from '../../../domain/models/hr/calendar.model';
+
+export interface CalendarQuery {
+  start: string;
+  end: string;
+  teamId?: string;
+  companyId?: string;
+  status?: CalendarEventStatus;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CalendarService {
+
+  constructor(private http: HttpClient) {}
+
+  getEvents(query: CalendarQuery): Observable<CalendarEvent[]> {
+    const params: Record<string, string> = { start: query.start, end: query.end };
+    if (query.teamId) params['teamId'] = query.teamId;
+    if (query.companyId) params['companyId'] = query.companyId;
+    if (query.status) params['status'] = query.status;
+
+    return this.http.get<CalendarEvent[]>(`${environment.apiUrl}/hr/calendar`, { params });
+  }
+}

--- a/src/app/infrastructure/services/hr/team-overview.service.ts
+++ b/src/app/infrastructure/services/hr/team-overview.service.ts
@@ -1,0 +1,21 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { TeamOverviewEntry } from '../../../domain/models/hr/team-overview.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TeamOverviewService {
+
+  constructor(private http: HttpClient) {}
+
+  getOverview(teamId?: string, companyId?: string): Observable<TeamOverviewEntry[]> {
+    const params: Record<string, string> = {};
+    if (teamId) params['teamId'] = teamId;
+    if (companyId) params['companyId'] = companyId;
+
+    return this.http.get<TeamOverviewEntry[]>(`${environment.apiUrl}/hr/team-overview`, { params });
+  }
+}


### PR DESCRIPTION
  Calendário: lista de eventos agrupável por período (default mês
  atual), filtros de setor/empresa/status — sem grid de mês, decisão
  de escopo pra não depender de um componente de calendário visual que
  o projeto não tem. Visão de Equipe: grid de cards por funcionário
  com borda colorida por disponibilidade e badge CLT/PJ, mais um
  resumo com contagem por status. Os dois endpoints já devolvem nome
  de funcionário/setor prontos, sem precisar de lookup.
