### PR TITLE
fix: adiciona campos obrigatórios de vínculo organizacional e cargo inicial ao cadastro de funcionário

### DIFF
--- a/src/app/components/auth/partners/employes/employes.component.html
+++ b/src/app/components/auth/partners/employes/employes.component.html
@@ -274,6 +274,105 @@
         </div>
       </div>
 
+      <!-- Vínculo organizacional -->
+      <div class="pk-form-section">
+        <h3 class="pk-form-section__title">
+          <i class="pi pi-building"></i> Vínculo Organizacional
+        </h3>
+        <div class="form-grid">
+          <div class="form-field">
+            <label for="companyId">Empresa <span class="required">*</span></label>
+            <p-select
+              id="companyId"
+              [options]="companyOptions"
+              formControlName="companyId"
+              optionLabel="label"
+              optionValue="value"
+              appendTo="body"
+              [filter]="true"
+              placeholder="Selecione…"
+              styleClass="select-field">
+            </p-select>
+          </div>
+          <div class="form-field">
+            <label for="teamId">Setor <span class="required">*</span></label>
+            <p-select
+              id="teamId"
+              [options]="teamOptions"
+              formControlName="teamId"
+              optionLabel="label"
+              optionValue="value"
+              appendTo="body"
+              [filter]="true"
+              placeholder="Selecione…"
+              styleClass="select-field">
+            </p-select>
+          </div>
+        </div>
+      </div>
+
+      <!-- Cargo inicial — só na criação, vira o primeiro CareerHistory (HIRING) -->
+      <div class="pk-form-section" *ngIf="!employeToEdit">
+        <h3 class="pk-form-section__title">
+          <i class="pi pi-briefcase"></i> Cargo Inicial
+        </h3>
+        <p class="pk-form-section__hint">
+          Define o primeiro registro de carreira do funcionário. Depois de criado, mudanças de cargo/salário são feitas em Cargos & Níveis.
+        </p>
+        <div class="form-grid">
+          <div class="form-field">
+            <label for="positionId">Cargo <span class="required">*</span></label>
+            <p-select
+              id="positionId"
+              [options]="positionOptions"
+              formControlName="positionId"
+              optionLabel="label"
+              optionValue="value"
+              appendTo="body"
+              [filter]="true"
+              placeholder="Selecione…"
+              styleClass="select-field">
+            </p-select>
+          </div>
+          <div class="form-field">
+            <label for="positionLevelId">Nível <span class="required">*</span></label>
+            <p-select
+              id="positionLevelId"
+              [options]="positionLevelOptions"
+              formControlName="positionLevelId"
+              optionLabel="label"
+              optionValue="value"
+              appendTo="body"
+              placeholder="Selecione um cargo primeiro…"
+              styleClass="select-field">
+            </p-select>
+          </div>
+          <div class="form-field">
+            <label for="contractType">Tipo de contrato <span class="required">*</span></label>
+            <p-select
+              id="contractType"
+              [options]="contractTypeOptions"
+              formControlName="contractType"
+              optionLabel="label"
+              optionValue="value"
+              appendTo="body"
+              styleClass="select-field">
+            </p-select>
+          </div>
+          <div class="form-field">
+            <label for="hiringDate">Data de admissão <span class="required">*</span></label>
+            <p-datepicker
+              id="hiringDate"
+              formControlName="hiringDate"
+              [showButtonBar]="true"
+              dateFormat="dd/mm/yy"
+              styleClass="datepicker-field"
+              placeholder="dd/mm/aaaa">
+            </p-datepicker>
+          </div>
+        </div>
+      </div>
+
       <!-- Configurações -->
       <div class="pk-form-section">
         <h3 class="pk-form-section__title">

--- a/src/app/components/auth/partners/employes/employes.component.scss
+++ b/src/app/components/auth/partners/employes/employes.component.scss
@@ -2,6 +2,13 @@
 
 
 
+.pk-form-section__hint {
+  margin: -0.5rem 0 1rem;
+  font-size: 0.78rem;
+  color: v.$text-muted;
+  line-height: 1.4;
+}
+
 // ─── Table Card ───────────────────────────────────────────────────────────────
 .table-card {
   background: v.$bg-panel;

--- a/src/app/components/auth/partners/employes/employes.component.ts
+++ b/src/app/components/auth/partners/employes/employes.component.ts
@@ -1,9 +1,13 @@
 import {Component, CUSTOM_ELEMENTS_SCHEMA, OnInit} from '@angular/core';
 import { FormGroup, FormBuilder, Validators, ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { Department, Employee, Hierarchy } from '../../../../domain/models/employee.model';
+import { ContractType, Department, Employee, Hierarchy } from '../../../../domain/models/employee.model';
 import { EmployeeService } from '../../../../infrastructure/services/partners/employee/employee.service';
 import { AuthService } from '../../../../infrastructure/services/auth.service';
 import { UserResponseDTO } from '../../../../domain/models/user.model';
+import { CompanyService } from '../../../../infrastructure/services/hr/company.service';
+import { TeamService } from '../../../../infrastructure/services/hr/team.service';
+import { PositionService } from '../../../../infrastructure/services/hr/position.service';
+import { PositionLevelService } from '../../../../infrastructure/services/hr/position-level.service';
 import { MessageService } from 'primeng/api';
 import { CommonModule } from '@angular/common';
 import { ButtonModule } from 'primeng/button';
@@ -44,6 +48,16 @@ export class EmployesComponent{
   hierarchyList: {label: string, value: Hierarchy} [] = []
   departmentList: {label: string, value: Department} [] = []
 
+  // Vínculo organizacional / cargo inicial (Estrutura Organizacional + Cargos & Níveis)
+  companyOptions: {label: string, value: string}[] = [];
+  teamOptions: {label: string, value: string}[] = [];
+  positionOptions: {label: string, value: string}[] = [];
+  positionLevelOptions: {label: string, value: string}[] = [];
+  contractTypeOptions: {label: string, value: ContractType}[] = [
+    { label: 'CLT', value: ContractType.CLT },
+    { label: 'PJ', value: ContractType.PJ },
+  ];
+
   // Vínculo usuário <-> funcionário
   users: UserResponseDTO[] = [];
   linkVisible = false;
@@ -54,6 +68,10 @@ export class EmployesComponent{
   constructor(
     private employeService: EmployeeService,
     private authService: AuthService,
+    private companyService: CompanyService,
+    private teamService: TeamService,
+    private positionService: PositionService,
+    private positionLevelService: PositionLevelService,
     private fb: FormBuilder,
     private msgService: MessageService
   ){
@@ -66,14 +84,63 @@ export class EmployesComponent{
       managerCode: [''],
       hierarchy: [Hierarchy.ASSISTENTE, Validators.required],
       birthday: [null],
-      department: [Department.ALIMENTOS, Validators.required]
+      department: [Department.ALIMENTOS, Validators.required],
+      companyId: [null, Validators.required],
+      teamId: [null, Validators.required],
+      positionId: [null, Validators.required],
+      positionLevelId: [{ value: null, disabled: true }, Validators.required],
+      contractType: [ContractType.CLT, Validators.required],
+      hiringDate: [null, Validators.required],
     });
+
+    this.form.get('positionId')?.valueChanges.subscribe((positionId) => this.onPositionChange(positionId));
   }
 
   ngOnInit(){
     this.loadHierarchyList();
     this.loadDepartmentList();
     this.loadUsers();
+    this.loadOrgOptions();
+  }
+
+  loadOrgOptions(): void {
+    this.companyService.getAll().subscribe({
+      next: (list) => (this.companyOptions = list.map((c) => ({ label: c.name, value: c.id }))),
+      error: () => (this.companyOptions = []),
+    });
+    this.teamService.getAll().subscribe({
+      next: (list) => (this.teamOptions = list.map((t) => ({ label: t.name, value: t.id }))),
+      error: () => (this.teamOptions = []),
+    });
+    this.positionService.getAll().subscribe({
+      next: (list) => (this.positionOptions = list.map((p) => ({ label: p.name, value: p.id }))),
+      error: () => (this.positionOptions = []),
+    });
+  }
+
+  onPositionChange(positionId: string | null): void {
+    const levelControl = this.form.get('positionLevelId');
+    levelControl?.reset(null);
+    this.positionLevelOptions = [];
+
+    if (!positionId) {
+      levelControl?.disable();
+      return;
+    }
+
+    this.positionLevelService.getByPosition(positionId).subscribe({
+      next: (levels) => {
+        this.positionLevelOptions = levels.map((l) => ({
+          label: `${l.name} — ${l.resolvedSalary.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}`,
+          value: l.id,
+        }));
+        levelControl?.enable();
+      },
+      error: () => {
+        this.positionLevelOptions = [];
+        levelControl?.disable();
+      },
+    });
   }
 
   loadUsers(){
@@ -180,6 +247,12 @@ export class EmployesComponent{
     this.dialogTitle = 'Editar funcionário';
     this.employeToEdit = employee;
 
+    // Cargo/nível/contrato/admissão só existem na criação (viram o primeiro CareerHistory) — não editáveis por aqui.
+    this.form.get('positionId')?.disable();
+    this.form.get('positionLevelId')?.disable();
+    this.form.get('contractType')?.disable();
+    this.form.get('hiringDate')?.disable();
+
     this.form.patchValue({
       partnerCode: employee.partnerCode,
       document: employee.document,
@@ -190,6 +263,12 @@ export class EmployesComponent{
       hierarchy: employee.hierarchy,
       birthday: employee.birthday,
       department: employee.department,
+      companyId: employee.companyId ?? null,
+      teamId: employee.teamId ?? null,
+      positionId: null,
+      positionLevelId: null,
+      contractType: null,
+      hiringDate: null,
     });
 
     this.visible = true;
@@ -198,8 +277,14 @@ export class EmployesComponent{
   showDialog() {
     this.dialogTitle = 'Adicionar Funcionário';
     this.employeToEdit = null;
+
+    this.form.get('positionId')?.enable();
+    this.form.get('contractType')?.enable();
+    this.form.get('hiringDate')?.enable();
+
     this.form.reset({
-      ativo: true
+      ativo: true,
+      contractType: ContractType.CLT,
     });
     this.visible = true;
   }
@@ -210,6 +295,9 @@ export class EmployesComponent{
 
       if(employee.birthday instanceof Date){
         employee.birthday = employee.birthday.toISOString().split('T')[0];
+      }
+      if(employee.hiringDate instanceof Date){
+        employee.hiringDate = employee.hiringDate.toISOString().split('T')[0];
       }
 
       if(this.employeToEdit){

--- a/src/app/domain/models/employee.model.ts
+++ b/src/app/domain/models/employee.model.ts
@@ -8,7 +8,19 @@ export interface Employee{
   managerCode: string,
   hierarchy: Hierarchy,
   birthday: Date,
-  department: Department
+  department: Department,
+  companyId?: string | null,
+  teamId?: string | null,
+  // Só usados na criação — cargo/nível/contrato geram o primeiro CareerHistory (HIRING) e não são editáveis por aqui depois
+  positionId?: string | null,
+  positionLevelId?: string | null,
+  contractType?: ContractType | null,
+  hiringDate?: Date | string | null
+}
+
+export enum ContractType {
+  CLT = 'CLT',
+  PJ = 'PJ'
 }
 
 export enum Hierarchy {


### PR DESCRIPTION
O formulário de Funcionários nunca foi atualizado depois que o
  backend passou a exigir empresa/setor/cargo/nível/contrato/admissão na criação (para gerar o primeiro CareerHistory) — cadastro estava quebrado. Adiciona Empresa/Setor (sempre editáveis) e
  Cargo/Nível em cascata + Tipo de contrato + Data de admissão (só na criação; edição não mexe em cargo/salário, isso é fluxo de Cargos & Níveis).
