### PR TITLE
chore: fixa header no topo, corrige touch targets e refina bottom nav mobile

### DIFF
--- a/src/app/components/auth/shared/top-menu/top-menu.component.html
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.html
@@ -255,11 +255,6 @@
      BOTTOM NAV (mobile) — navegação estilo app
 ═══════════════════════════════════════════════════════════ -->
 <nav class="mobile-bottom-nav" aria-label="Navegação principal">
-  <button type="button" class="mbn-item" [class.is-active]="drawerVisible" (click)="drawerVisible = true">
-    <i class="pi pi-bars"></i>
-    <span>Menu</span>
-  </button>
-
   <a class="mbn-item" routerLink="documentos" routerLinkActive="is-active">
     <i class="pi pi-folder"></i>
     <span>Documentos</span>
@@ -267,17 +262,12 @@
 
   <a class="mbn-item" routerLink="home" routerLinkActive="is-active">
     <i class="pi pi-home"></i>
-    <span>Home</span>
+    <span>Início</span>
   </a>
 
-  <a class="mbn-item" routerLink="notificacoes" routerLinkActive="is-active">
-    <span class="mbn-icon-wrap">
-      <i class="pi pi-bell"></i>
-      @if (notifications.unreadCount() > 0) {
-        <span class="mbn-badge">{{ notifications.unreadCount() > 9 ? '9+' : notifications.unreadCount() }}</span>
-      }
-    </span>
-    <span>Notificações</span>
+  <a class="mbn-item" routerLink="documentos/rh/announcements" routerLinkActive="is-active">
+    <i class="pi pi-megaphone"></i>
+    <span>Avisos</span>
   </a>
 
   <a class="mbn-item" routerLink="perfil" routerLinkActive="is-active">

--- a/src/app/components/auth/shared/top-menu/top-menu.component.scss
+++ b/src/app/components/auth/shared/top-menu/top-menu.component.scss
@@ -9,17 +9,19 @@ $text-muted: #888888;
 // ═══════════════════════════════════════════════════════════════
 
 .topbar {
-  position: relative;
+  position: fixed;
   top: 0; left: 0; right: 0;
   z-index: 1000;
-  height: 52px;
+  height: calc(52px + env(safe-area-inset-top));
+  padding-top: env(safe-area-inset-top);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 1.25rem;
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
   background: v.$primary;
-  border-bottom: 2px solid v.$primary-dark;
-  box-shadow: 0 2px 8px rgba(v.$neutral-900, 0.2);
+  border-bottom: 1px solid v.$primary-dark;
+  box-shadow: 0 2px 12px rgba(v.$neutral-900, 0.25);
 
   &-left {
     display: flex;
@@ -82,8 +84,9 @@ $text-muted: #888888;
 
   // ── Botões de ação (sino, sair) ────────────────────────────
   &-icon-btn {
-    width: 34px !important;
-    height: 34px !important;
+    width: 44px !important;
+    height: 44px !important;
+    min-width: 44px !important;
     color: rgba(255, 255, 255, 0.75) !important;
 
     &:hover {
@@ -91,7 +94,9 @@ $text-muted: #888888;
       color: #fff !important;
     }
 
-    .p-button-icon { font-size: 0.9rem !important; }
+    .p-button-icon { font-size: 1rem !important; }
+
+    &:active { transform: scale(0.95); }
   }
 }
 
@@ -99,19 +104,20 @@ $text-muted: #888888;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
   border: none;
   background: transparent;
-  border-radius: 8px;
+  border-radius: 10px;
   cursor: pointer;
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.1rem;
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
 
   &:hover { background: v.$primary-light; color: #ffffff; }
-  &:active { transform: scale(0.93); }
+  &:active { transform: scale(0.95); }
 }
 
 
@@ -298,18 +304,20 @@ $text-muted: #888888;
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 30px;
-    height: 30px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
     border: none;
     background: transparent;
-    border-radius: 7px;
+    border-radius: 10px;
     cursor: pointer;
-    color: rgba(255, 255, 255, 0.7);
-    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.85rem;
     transition: background 0.15s, color 0.15s;
     margin-left: auto;
 
     &:hover { background: v.$primary-light; color: #ffffff; }
+    &:active { transform: scale(0.95); }
   }
 
   // ── Corpo (scroll) ─────────────────────────────────────────
@@ -618,9 +626,6 @@ $text-muted: #888888;
   &--deep { margin-left: 1rem; }
 }
 
-// ── Utilitário de espaçamento do conteúdo principal ───────────
-.page-content { padding-top: 52px; }
-
 // ═══════════════════════════════════════════════════════════════
 // TOPBAR — responsivo (mobile): evita a busca sobrepor o sino
 // ═══════════════════════════════════════════════════════════════
@@ -710,12 +715,13 @@ $text-muted: #888888;
 
   .mbn-item {
     flex: 1 1 0;
-    min-width: 0;
+    min-width: 44px;
+    min-height: 44px;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 3px;
+    gap: 4px;
     padding: 6px 2px;
     background: none;
     border: none;
@@ -723,7 +729,7 @@ $text-muted: #888888;
     color: v.$neutral-500;
     text-decoration: none;
     font-family: v.$font-body;
-    font-size: 0.6rem;
+    font-size: 0.65rem;
     font-weight: 600;
     line-height: 1;
     letter-spacing: -0.1px;
@@ -731,7 +737,7 @@ $text-muted: #888888;
     -webkit-tap-highlight-color: transparent;
 
     i {
-      font-size: 1.3rem;
+      font-size: 1.4rem;
       line-height: 1;
       transition: transform 0.25s ease;
     }
@@ -743,8 +749,7 @@ $text-muted: #888888;
       white-space: nowrap;
     }
 
-    &:hover { color: v.$primary; }
-    &:active i { transform: scale(0.88); }
+    &:active i { transform: scale(0.95); }
 
     &.is-active {
       color: v.$primary;
@@ -783,21 +788,23 @@ $text-muted: #888888;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 38px;
-  height: 38px;
-  border-radius: 50%;
-  color: v.$neutral-500;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  border-radius: 10px;
+  color: rgba(255, 255, 255, 0.75);
   text-decoration: none;
   transition: background 0.15s ease, color 0.15s ease;
 
   i { font-size: 1.15rem; }
 
-  &:hover { background: rgba(v.$primary, 0.08); color: v.$primary; }
+  &:hover { background: v.$primary-light; color: #ffffff; }
+  &:active { transform: scale(0.95); }
 
   .topbar-bell-badge {
     position: absolute;
-    top: 2px;
-    right: 0;
+    top: 4px;
+    right: 2px;
     min-width: 16px;
     height: 16px;
     padding: 0 4px;
@@ -808,6 +815,6 @@ $text-muted: #888888;
     font-weight: 700;
     line-height: 16px;
     text-align: center;
-    box-shadow: 0 0 0 2px #fff;
+    box-shadow: 0 0 0 2px v.$primary;
   }
 }

--- a/src/app/layouts/auth-layout/auth-layout.component.scss
+++ b/src/app/layouts/auth-layout/auth-layout.component.scss
@@ -1,3 +1,8 @@
+// Compensa o header fixo (52px + safe-area-inset-top do notch) pra o conteúdo não ficar atrás.
+.content {
+  padding-top: calc(52px + env(safe-area-inset-top));
+}
+
 // Respiro para o conteúdo não ficar atrás do bottom nav no mobile.
 @media (max-width: 768px) {
   .content {


### PR DESCRIPTION
Header agora é position:fixed com safe-area-inset-top pro notch. Touch targets de 44px
  em todos os botões (hamburger, sino, logout, drawer close, bottom nav). Cor do sino corrigida no fundo navy. Bottom nav simplificado: remove botão Menu (acessível pelo hamburger do
  header), troca Notificações por atalho de Avisos, renomeia Home para Início.
