### PR TITLE
feat: bloqueio de usuários, redefinição de senha e melhorias no admin-center

### DIFF
--- a/src/app/components/auth/admin-center/admin-center.component.html
+++ b/src/app/components/auth/admin-center/admin-center.component.html
@@ -35,12 +35,14 @@
         <th>Login</th>
         <th>Funcionário</th>
         <th>Permissões</th>
-        <th style="width: 84px; text-align: center">Ações</th>
+        <th style="width: 80px; text-align: center">Status</th>
+        <th style="width: 140px; text-align: center">Ações</th>
       </tr>
     </ng-template>
 
     <ng-template #bodyTpl let-user>
-      <tr [class.ac-row-active]="editingUser?.login === user.login">
+      <tr [class.ac-row-active]="editingUser?.login === user.login"
+          [class.ac-row-blocked]="!user.active">
         <td class="ac-login-cell">
           <i class="pi pi-user ac-login-icon"></i>
           {{ user.login }}
@@ -59,8 +61,22 @@
           </span>
         </td>
         <td style="text-align: center">
-          <pk-button pkType="edit" pkSize="sm" [pkIconOnly]="true"
-                     pkTooltip="Editar permissões" (clicked)="selectUserToEdit(user)"/>
+          <span class="ac-status" [class.ac-status-active]="user.active" [class.ac-status-blocked]="!user.active">
+            <i class="pi" [ngClass]="user.active ? 'pi-check-circle' : 'pi-ban'"></i>
+            {{ user.active ? 'Ativo' : 'Bloqueado' }}
+          </span>
+        </td>
+        <td style="text-align: center">
+          <div class="ac-actions">
+            <pk-button pkType="edit" pkSize="sm" [pkIconOnly]="true"
+                       pkTooltip="Editar permissões" (clicked)="selectUserToEdit(user)"/>
+            <pk-button [pkType]="user.active ? 'delete' : 'save'" pkSize="sm" [pkIconOnly]="true"
+                       [pkIcon]="user.active ? 'pi pi-lock' : 'pi pi-lock-open'"
+                       [pkTooltip]="user.active ? 'Bloquear acesso' : 'Liberar acesso'"
+                       (clicked)="toggleBlock(user)"/>
+            <pk-button pkType="token" pkSize="sm" [pkIconOnly]="true"
+                       pkTooltip="Redefinir senha" (clicked)="resetPassword(user)"/>
+          </div>
         </td>
       </tr>
     </ng-template>

--- a/src/app/components/auth/admin-center/admin-center.component.scss
+++ b/src/app/components/auth/admin-center/admin-center.component.scss
@@ -161,6 +161,40 @@
   &[data-role="ALMOXARIFADO"]    { background: #f1f5f9; color: #334155; }
 }
 
+// ─── Status ──────────────────────────────────────────────────────────────────
+.ac-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+
+  &.ac-status-active {
+    background: #d1fae5;
+    color: #065f46;
+  }
+
+  &.ac-status-blocked {
+    background: #fee2e2;
+    color: #991b1b;
+  }
+
+  i { font-size: 12px; }
+}
+
+// ─── Linha bloqueada ─────────────────────────────────────────────────────────
+.ac-row-blocked > td { opacity: 0.6; }
+
+// ─── Ações ───────────────────────────────────────────────────────────────────
+.ac-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
 // ─── Responsivo ───────────────────────────────────────────────────────────────
 @media (max-width: 640px) {
   .ac-topbar {

--- a/src/app/components/auth/admin-center/admin-center.component.ts
+++ b/src/app/components/auth/admin-center/admin-center.component.ts
@@ -197,6 +197,53 @@ export class AdminCenterComponent implements OnInit {
     });
   }
 
+  // ── Bloqueio / desbloqueio ────────────────────────────────────────────────
+
+  toggleBlock(user: UserResponseDTO): void {
+    const action$ = user.active
+      ? this.authService.blockUser(user.login)
+      : this.authService.unblockUser(user.login);
+
+    action$.subscribe({
+      next: () => {
+        user.active = !user.active;
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: user.active
+            ? `Acesso de "${user.login}" foi liberado.`
+            : `Acesso de "${user.login}" foi bloqueado.`,
+        });
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Erro',
+          detail: 'Falha ao alterar o acesso do usuário.',
+        });
+      },
+    });
+  }
+
+  resetPassword(user: UserResponseDTO): void {
+    this.authService.resetPasswordByAdmin(user.login).subscribe({
+      next: () => {
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: `E-mail de redefinição enviado para "${user.login}".`,
+        });
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Erro',
+          detail: 'Falha ao enviar e-mail de redefinição.',
+        });
+      },
+    });
+  }
+
   // ── Outros ───────────────────────────────────────────────────────────────
 
   generateAccessTokens(): void {

--- a/src/app/components/public/login/login.component.ts
+++ b/src/app/components/public/login/login.component.ts
@@ -37,9 +37,11 @@ export class LoginComponent {
         this.loading = false;
         this.router.navigate(['/home'])
       },
-      error: () => {
+      error: (err) => {
         this.loading = false;
-        this.errorMessage = 'Usuário ou senha inválidos'
+        this.errorMessage = err.status === 403
+          ? (err.error?.message ?? 'Acesso bloqueado. Entre em contato com o RH.')
+          : 'Usuário ou senha inválidos';
       }
     });
   }

--- a/src/app/components/theme/ProautoKimium/pk-button/pk-button.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-button/pk-button.component.ts
@@ -63,6 +63,7 @@ export class PkButtonComponent {
   pkLoading  = input<boolean>(false);
   pkTooltip  = input<string>('');
   pkIconOnly = input<boolean>(false);
+  pkIcon     = input<string | null>(null);
 
   clicked = output<MouseEvent>();
 
@@ -74,7 +75,7 @@ export class PkButtonComponent {
   });
 
   resolvedIcon = computed(() =>
-    this.pkLoading() ? 'pi pi-spin pi-spinner' : this.config().icon
+    this.pkLoading() ? 'pi pi-spin pi-spinner' : (this.pkIcon() ?? this.config().icon)
   );
 
   hostClasses = computed(() => ({

--- a/src/app/domain/models/user.model.ts
+++ b/src/app/domain/models/user.model.ts
@@ -8,7 +8,8 @@ export interface RegisterDTO {
 export interface UserResponseDTO {
   login: string;
   roles: string[];
-  codParceiro?: string | null;   // funcionário vinculado, se houver
+  codParceiro?: string | null;
+  active: boolean;
 }
 
 export interface UserRole {

--- a/src/app/infrastructure/services/auth.service.ts
+++ b/src/app/infrastructure/services/auth.service.ts
@@ -137,6 +137,30 @@ export class AuthService {
     );
   }
 
+  blockUser(login: string): Observable<string> {
+    return this.http.put(
+      `${environment.apiUrl}/auth/users/${login}/block`,
+      null,
+      { responseType: 'text' }
+    );
+  }
+
+  unblockUser(login: string): Observable<string> {
+    return this.http.put(
+      `${environment.apiUrl}/auth/users/${login}/unblock`,
+      null,
+      { responseType: 'text' }
+    );
+  }
+
+  resetPasswordByAdmin(login: string): Observable<string> {
+    return this.http.post(
+      `${environment.apiUrl}/auth/users/${login}/reset-password`,
+      null,
+      { responseType: 'text' }
+    );
+  }
+
   /** Vincula um usuário a um funcionário (parceiro) pelo código do parceiro. */
   linkEmployee(login: string, codParceiro: string): Observable<string> {
     return this.http.put(


### PR DESCRIPTION
- Botões de bloquear/desbloquear com ícones de cadeado no admin-center
- Botão de redefinir senha pelo admin (envia email com deep link)
- Coluna de status ativo/bloqueado na tabela de usuários
- Login exibe mensagem do backend quando usuário bloqueado
- pk-button aceita pkIcon para sobrescrever ícone padrão
- UserResponseDTO inclui campo active
