### PR TITLE
feat: adicionar visualizador fullscreen de imagens na galeria

### DIFF
--- a/src/app/components/auth/gallery/gallery.component.html
+++ b/src/app/components/auth/gallery/gallery.component.html
@@ -61,7 +61,9 @@
       @for (doc of filtrados(); track doc.id) {
         <div class="gl-card">
           <!-- Preview -->
-          <div class="gl-card__preview">
+          <div class="gl-card__preview"
+               [class.gl-card__preview--clickable]="isImage(doc) && thumbnails()[doc.id]"
+               (click)="openViewer(doc)">
             @if (thumbnails()[doc.id]) {
               <img [src]="thumbnails()[doc.id]" [alt]="doc.title"/>
             } @else if (isImage(doc)) {
@@ -110,6 +112,31 @@
   }
 
 </section>
+
+<!-- Image Viewer -->
+@if (viewerDoc(); as doc) {
+  <div class="viewer-overlay" (click)="closeViewer()">
+    <button class="viewer-close" (click)="closeViewer()">
+      <i class="pi pi-times"></i>
+    </button>
+    <div class="viewer-info">
+      <span class="viewer-title">{{ doc.title }}</span>
+      <span class="viewer-category" [style.--accent]="getCategoryTab(doc.category).accent">
+        {{ getCategoryTab(doc.category).label }}
+      </span>
+    </div>
+    <img class="viewer-img" [src]="thumbnails()[doc.id]" [alt]="doc.title" (click)="$event.stopPropagation()"/>
+    <div class="viewer-actions" (click)="$event.stopPropagation()">
+      <button class="viewer-btn" (click)="download(doc)" [disabled]="downloadingId() === doc.id">
+        @if (downloadingId() === doc.id) {
+          <i class="pi pi-spin pi-spinner"></i> Baixando...
+        } @else {
+          <i class="pi pi-download"></i> Baixar
+        }
+      </button>
+    </div>
+  </div>
+}
 
 <!-- Upload Dialog -->
 <pk-dialog

--- a/src/app/components/auth/gallery/gallery.component.scss
+++ b/src/app/components/auth/gallery/gallery.component.scss
@@ -195,11 +195,20 @@
     justify-content: center;
     overflow: hidden;
 
+    &--clickable {
+      cursor: pointer;
+
+      &:hover img {
+        transform: scale(1.03);
+      }
+    }
+
     img {
       width: 100%;
       height: 100%;
       object-fit: contain;
       padding: 12px;
+      transition: transform v.$transition-base ease;
     }
   }
 
@@ -442,6 +451,122 @@
       background: color.adjust(v.$primary, $lightness: -5%);
       color: #fff;
     }
+  }
+}
+
+// ── Image Viewer ──
+.viewer-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.92);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  animation: viewer-fade-in 0.2s ease;
+}
+
+@keyframes viewer-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.viewer-close {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease;
+  z-index: 1;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.25);
+  }
+}
+
+.viewer-info {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  z-index: 1;
+}
+
+.viewer-title {
+  color: #fff;
+  font-family: v.$font-heading;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.viewer-category {
+  padding: 3px 10px;
+  border-radius: v.$radius-full;
+  font-size: 0.7rem;
+  font-weight: 600;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent);
+}
+
+.viewer-img {
+  max-width: calc(100% - 32px);
+  max-height: calc(100vh - 140px);
+  max-height: calc(100dvh - 140px);
+  object-fit: contain;
+  border-radius: v.$radius-md;
+  user-select: none;
+  -webkit-user-select: none;
+  background: #fff;
+  padding: 24px;
+  box-shadow: 0 4px 40px rgba(0, 0, 0, 0.4);
+}
+
+.viewer-actions {
+  position: absolute;
+  bottom: 24px;
+  display: flex;
+  gap: 10px;
+
+  @media (max-width: v.$bp-sm) {
+    bottom: 32px;
+  }
+}
+
+.viewer-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 24px;
+  border-radius: v.$radius-full;
+  border: none;
+  background: #fff;
+  color: v.$primary;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: #f0f0f0;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 }
 

--- a/src/app/components/auth/gallery/gallery.component.ts
+++ b/src/app/components/auth/gallery/gallery.component.ts
@@ -32,6 +32,7 @@ export class GalleryComponent implements OnInit {
   uploadDialogVisible = signal(false);
   uploading = signal(false);
   thumbnails = signal<Record<string, string>>({});
+  viewerDoc = signal<GalleryDocument | null>(null);
 
   uploadTitle = '';
   uploadDescription = '';
@@ -101,6 +102,16 @@ export class GalleryComponent implements OnInit {
 
   isImage(doc: GalleryDocument): boolean {
     return doc.contentType?.startsWith('image/') ?? false;
+  }
+
+  openViewer(doc: GalleryDocument): void {
+    if (this.isImage(doc) && this.thumbnails()[doc.id]) {
+      this.viewerDoc.set(doc);
+    }
+  }
+
+  closeViewer(): void {
+    this.viewerDoc.set(null);
   }
 
   download(doc: GalleryDocument): void {


### PR DESCRIPTION
Ao clicar na imagem do card, abre overlay com a imagem em tela cheia,
botão de download e informações do documento. Fundo branco atrás da
imagem para PNGs com transparência. Otimizado para mobile.
