### PR TITLE
Migra selos, chips, abas e cartoes para os tokens

### DIFF
--- a/src/app/components/auth/partners/customer/customer.component.scss
+++ b/src/app/components/auth/partners/customer/customer.component.scss
@@ -55,27 +55,7 @@ $text-light:        #94a3b8;
   i { color: v.$text-light; font-size: .8rem; }
 }
 
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: .3rem;
-  border-radius: 100px;
-  padding: .25rem .65rem;
-  font-size: .75rem;
-  font-weight: 600;
-
-  i { font-size: .7rem; }
-
-  &--active {
-    background: rgba(16,185,129,.1);
-    color: #059669;
-  }
-
-  &--inactive {
-    background: rgba(239,68,68,.08);
-    color: #dc2626;
-  }
-}
+// .status-chip agora e global (styles/chips.scss), sobre os tokens de status.
 
 .action-btn.p-button {
   width: 32px;

--- a/src/app/components/auth/partners/employes/employes.component.scss
+++ b/src/app/components/auth/partners/employes/employes.component.scss
@@ -120,27 +120,7 @@
   i { color: v.$text-light; font-size: .8rem; }
 }
 
-.status-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: .3rem;
-  border-radius: 100px;
-  padding: .25rem .65rem;
-  font-size: .75rem;
-  font-weight: 600;
-
-  i { font-size: .7rem; }
-
-  &--active {
-    background: rgba(16,185,129,.1);
-    color: #059669;
-  }
-
-  &--inactive {
-    background: rgba(239,68,68,.08);
-    color: #dc2626;
-  }
-}
+// .status-chip agora e global (styles/chips.scss), sobre os tokens de status.
 
 .hierarchy-badge {
   display: inline-flex;

--- a/src/styles/badges.scss
+++ b/src/styles/badges.scss
@@ -1,18 +1,34 @@
-@use 'variables' as v;
+// ═══════════════════════════════════════════════════════════════════════════
+// Selos de código
+//
+// Código de parceiro, código de sistema, ordem de nível: é DADO, não ação.
+// Antes vinham em navy preenchido, a mesma cor do botão primário — numa grade
+// cheia isso puxa o olho para o que não se clica e disputa com o botão de
+// verdade. Agora são neutros: superfície discreta e texto de conteúdo.
+// ═══════════════════════════════════════════════════════════════════════════
 
 .code-badge {
   display: inline-block;
-  background: v.$primary-lighter;
-  color: #fff;
-  font-size: .78rem;
-  font-weight: 700;
-  padding: .2rem .55rem;
-  border-radius: 6px;
+  background: var(--app-surface-3);
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+  font-size: var(--text-ui-sm);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  padding: 2px 8px;
+  border-radius: var(--radius-control);
 
+  // Segundo plano: código de gerente, matriz — referência a outro registro.
   &--secondary {
-    background: rgba(87,193,171,.1);
-    color: v.$secondary-dark;
+    background: transparent;
+    color: var(--app-text-muted);
   }
 
-  &.code-badge-hidden { background: #f1f5f9; color: v.$primary; }
+  // Produto fora do ar: o selo perde contraste junto com a linha.
+  &.code-badge-hidden {
+    background: transparent;
+    color: var(--app-text-subtle);
+    border-style: dashed;
+  }
 }

--- a/src/styles/chips.scss
+++ b/src/styles/chips.scss
@@ -1,46 +1,100 @@
-@use 'variables' as v;
+// ═══════════════════════════════════════════════════════════════════════════
+// Chips
+//
+// Duas famílias, e a diferença importa:
+//
+// `.status-chip` diz em que estado o registro está (ativo, pago, recusado) —
+// cor por PAPEL, do vocabulário de status. Estava duplicado no SCSS de
+// Clientes e de Funcionários, com verde e vermelho cravados em hex, o que
+// deixava o tema escuro sem ajuste.
+//
+// `.chip-*` é rótulo de conteúdo (cor de produto, telefone do perfil): neutro,
+// porque não é estado nem ação.
+// ═══════════════════════════════════════════════════════════════════════════
 
+// ─── Estado ────────────────────────────────────────────────────────────────
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-ui-sm);
+  font-weight: 600;
+  white-space: nowrap;
+
+  i { font-size: var(--text-micro); }
+
+  &--active,
+  &--success {
+    background: var(--app-success-soft);
+    color: var(--app-success);
+  }
+
+  &--warning,
+  &--pending {
+    background: var(--app-warning-soft);
+    color: var(--app-warning);
+  }
+
+  &--inactive,
+  &--danger {
+    background: var(--app-danger-soft);
+    color: var(--app-danger);
+  }
+
+  &--neutral {
+    background: var(--app-surface-3);
+    color: var(--app-text-muted);
+  }
+}
+
+// ─── Rótulo de conteúdo ────────────────────────────────────────────────────
 .chip-container {
   display: flex;
   flex-wrap: wrap;
-  gap: .3rem;
+  gap: 5px;
 }
 
 .chip-color {
   display: inline-block;
-  background: #f1f5f9;
-  color: v.$secondary;
-  font-size: .72rem;
+  background: var(--app-surface-3);
+  color: var(--app-text-muted);
+  border: 1px solid var(--app-border);
+  font-size: var(--text-micro);
   font-weight: 500;
-  padding: .15rem .5rem;
-  border-radius: 999px;
-  border: 1px solid v.$secondary;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
 
   &.chip-color-muted {
-    background: #f9fafb;
-    color: v.$primary;
+    background: transparent;
   }
 
   &.chip-color-more {
-    background: #e5e7eb;
-    color: v.$primary;
+    background: transparent;
+    color: var(--app-text-subtle);
     font-style: italic;
   }
-}
-
-::ng-deep .p-inputchips {
-  width: 100%;
-  .p-inputchips-multiple-container { width: 100%; min-height: 40px; font-size: .88rem; }
 }
 
 .chip-area {
   display: inline-flex;
   align-items: center;
-  padding: .2rem .65rem;
-  background: v.$secondary-lighter;
-  color: v.$primary;
-  border-radius: 99px;
-  font-size: .78rem;
+  padding: 2px 10px;
+  background: var(--app-surface-3);
+  color: var(--app-text-muted);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-ui-sm);
   font-weight: 500;
   white-space: nowrap;
+}
+
+::ng-deep .p-inputchips {
+  width: 100%;
+
+  .p-inputchips-multiple-container {
+    width: 100%;
+    min-height: var(--field-h);
+    font-size: var(--text-ui);
+  }
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -42,18 +42,20 @@
   overflow: visible;
 }
 
+// Elevação por borda e superfície: a sombra é fio de cabelo e o hover escurece
+// o traço em vez de levantar o cartão do plano.
 @mixin card-base {
-  background: v.$bg-panel;
-  border: 1px solid v.$border;
-  border-radius: v.$radius-md;
-  box-shadow: v.$shadow-sm;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  box-shadow: var(--app-shadow-sm);
   display: flex;
   align-items: center;
   gap: v.$space-4;
   transition: v.$transition-base;
 
   &:hover {
-    box-shadow: v.$shadow-md;
+    border-color: var(--app-border-strong);
   }
 }
 
@@ -67,7 +69,7 @@
   justify-content: $justify-content;
 }
 
-@mixin card-icon($width, $height, $bg: v.$bg-hover, $color: v.$primary) {
+@mixin card-icon($width, $height, $bg: var(--app-surface-2), $color: var(--app-action)) {
   width: $width;
   height: $height;
   border-radius: v.$radius-full;

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -1,9 +1,14 @@
-@use 'variables' as v;
+// ═══════════════════════════════════════════════════════════════════════════
+// Abas internas de tela (Calculadoras, Produtos do site)
+//
+// Não confundir com a barra de abas do shell: aqui é navegação dentro de uma
+// tela só. Item ativo em navy está certo — navegação é ação.
+// ═══════════════════════════════════════════════════════════════════════════
 
 .tabs-nav {
   display: flex;
-  gap: .5rem;
-  border-bottom: 2px solid v.$border;
+  gap: 2px;
+  border-bottom: 1px solid var(--app-border);
   padding-bottom: 0;
   flex-wrap: wrap;
 }
@@ -11,40 +16,58 @@
 .tab-btn {
   display: flex;
   align-items: center;
-  gap: .45rem;
-  padding: .6rem 1.1rem;
+  gap: 6px;
+  height: var(--btn-h-md);
+  padding: 0 14px;
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
-  border-radius: v.$radius-sm v.$radius-sm 0 0;
-  font-size: .88rem;
+  margin-bottom: -1px;
+  border-radius: var(--radius-control) var(--radius-control) 0 0;
+  font-size: var(--text-ui);
   font-weight: 500;
-  color: v.$neutral-400;
+  color: var(--app-text-muted);
   cursor: pointer;
-  transition: color .18s, border-color .18s, background .18s;
+  transition: color .15s, border-color .15s, background .15s;
 
-  i { font-size: .85rem; }
+  i { font-size: var(--text-ui-sm); }
 
   &:hover {
-    color: v.$primary;
-    background: v.$neutral-100;
+    color: var(--app-action);
+    background: var(--app-surface-2);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--app-action);
+    outline-offset: -2px;
   }
 
   &--active {
-    color: v.$primary;
-    border-bottom-color: v.$primary;
+    color: var(--app-action);
+    border-bottom-color: var(--app-action);
     font-weight: 700;
   }
 
+  // Contagem ao lado do rótulo: número é dado, não ação — fica neutro, e só
+  // acompanha a cor quando a aba está ativa.
   .tab-badge {
-    background: v.$primary;
-    color: #fff;
-    font-size: .7rem;
+    background: var(--app-surface-3);
+    color: var(--app-text-muted);
+    font-size: var(--text-micro);
     font-weight: 700;
-    border-radius: 99px;
-    padding: .1rem .45rem;
-    min-width: 1.4rem;
+    font-variant-numeric: tabular-nums;
+    border-radius: var(--radius-pill);
+    padding: 1px 7px;
+    min-width: 20px;
     text-align: center;
   }
+
+  &--active .tab-badge {
+    background: var(--app-action-soft);
+    color: var(--app-action);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-btn { transition: none; }
 }


### PR DESCRIPTION
Eram os ultimos estilos globais em variaveis SCSS, que compilam para valor
fixo e por isso nao respondiam ao tema escuro.

Duas correcoes de papel de cor no caminho: o selo de codigo vinha em navy
preenchido, a mesma cor do botao primario, disputando o olho numa grade
cheia com o que realmente se clica -- agora e neutro. E o .status-chip
estava duplicado, identico, no SCSS de Clientes e de Funcionarios, com
verde e vermelho em hex; virou global sobre os tokens de status.

O card-base tambem parou de crescer a sombra no hover: elevacao e borda e
superficie, sombra e fio de cabelo.
