### PR TITLE
Devolve a rolagem as telas comuns da area de trabalho

### DIFF
--- a/src/app/layouts/auth-layout/auth-layout.component.scss
+++ b/src/app/layouts/auth-layout/auth-layout.component.scss
@@ -30,13 +30,10 @@
   display: none;
 }
 
-// Por padrão a tela rola por inteiro. Telas de grade desligam isso via o mixin
-// `grid-screen` e deixam a rolagem para a própria tabela.
-.app-content > *:not(router-outlet) {
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-}
+// Por padrão a tela rola por inteiro; telas de grade desligam isso via o mixin
+// `grid-screen`. A regra NÃO pode morar aqui: a tela vem do `router-outlet` e
+// não carrega o `_ngcontent` deste componente, então o seletor encapsulado
+// nunca casaria com ela. Está em `styles/_shell.scss`.
 
 // No desktop entra a barra de abas entre a topbar e o conteúdo.
 @media (min-width: v.$bp-md) {

--- a/src/styles/_shell.scss
+++ b/src/styles/_shell.scss
@@ -1,0 +1,21 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// Comportamento padrão da tela dentro da área de trabalho
+//
+// Por que isto mora aqui e não no SCSS do auth-layout: a tela é criada pelo
+// `router-outlet`, fora do template do layout, então não recebe o atributo
+// `_ngcontent` dele. Escrita lá dentro, a regra compilava para
+// `.app-content[_ngcontent-x] > *[_ngcontent-x]` e não casava com tela nenhuma
+// — o resultado era tela comum sem altura definida, cortada pelo
+// `overflow: hidden` do `.app-content`, sem como rolar até o fim do conteúdo.
+//
+// Por que `:where()`: zera a especificidade (0,0,0). Isto é um padrão, não uma
+// imposição — qualquer tela que declare o próprio `:host` (as de grade, via o
+// mixin `grid-screen`, que trocam a rolagem da página pela rolagem da tabela)
+// vence sem precisar de `!important` nem depender da ordem de carga do CSS.
+// ═══════════════════════════════════════════════════════════════════════════
+
+:where(.app-content) > :where(:not(router-outlet)) {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -10,6 +10,7 @@
 @use 'tabs';
 @use 'dialogs';
 @use 'auth-form';
+@use 'shell';
 @use 'dark-compat';
 
 // @import "/node_modules/bootstrap/dist/css/bootstrap.min.css" layer(bootstrap);


### PR DESCRIPTION
A regra que dava altura e rolagem a tela morava no SCSS do auth-layout e o
Angular encapsulou os dois lados do seletor: virava
`.app-content[_ngcontent-x] > *[_ngcontent-x]`. A tela vem do router-outlet,
fora do template do layout, e nunca recebe esse atributo -- a regra nunca
casou com nada. Passou despercebido porque as telas de grade e as de
formulario declaram o proprio :host; a home e as demais ficavam sem altura
definida e eram cortadas pelo overflow do .app-content.

Vai para o CSS global, fora da encapsulacao, com :where para especificidade
zero: e um padrao, nao uma imposicao. Sem isso o overflow-y: auto passaria a
sobrepor o overflow: hidden das telas de grade e quebraria o cabecalho fixo
e a paginacao sempre visivel.
