### PR TITLE
Corrige data exibida um dia antes nas telas de RH

### DIFF
--- a/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.ts
+++ b/src/app/components/auth/hr-medical-certificates/hr-medical-certificates.component.ts
@@ -8,6 +8,7 @@ import { PkCheckboxComponent } from '../../theme/ProautoKimium/pk-checkbox/pk-ch
 import { MedicalCertificateService } from '../../../infrastructure/services/hr/medical-certificate.service';
 import { MedicalCertificate, SubmissionType } from '../../../domain/models/hr/medical-certificate.model';
 import { PageHeaderComponent } from '../shared/page-header/page-header.component';
+import { formatDateBr } from '../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-hr-medical-certificates',
@@ -129,7 +130,7 @@ export class HrMedicalCertificatesComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   baixar(cert: MedicalCertificate): void {

--- a/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.ts
+++ b/src/app/components/auth/hr-reimbursements/hr-reimbursements.component.ts
@@ -7,6 +7,7 @@ import { PkInputComponent } from '../../theme/ProautoKimium/pk-input/pk-input.co
 import { ReimbursementService } from '../../../infrastructure/services/hr/reimbursement.service';
 import { Reimbursement, ReimbursementStatus } from '../../../domain/models/hr/reimbursement.model';
 import { PageHeaderComponent } from '../shared/page-header/page-header.component';
+import { formatDateBr } from '../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-hr-reimbursements',
@@ -107,7 +108,7 @@ export class HrReimbursementsComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   statusLabel(status: ReimbursementStatus): string {

--- a/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.ts
+++ b/src/app/components/auth/hr-vacation-requests/hr-vacation-requests.component.ts
@@ -9,6 +9,7 @@ import { VacationRequestService } from '../../../infrastructure/services/hr/vaca
 import { VacationRequest, VacationRequestStatus } from '../../../domain/models/hr/vacation-request.model';
 import { countBusinessDays, getHolidaysInRange, HolidayInfo } from '../../../domain/utils/brazilian-business-days';
 import { PageHeaderComponent } from '../shared/page-header/page-header.component';
+import { formatDateBr } from '../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-hr-vacation-requests',
@@ -117,7 +118,7 @@ export class HrVacationRequestsComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   statusLabel(status: VacationRequestStatus): string {

--- a/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
+++ b/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
@@ -12,6 +12,7 @@ import { CalendarService } from '../../../../infrastructure/services/hr/calendar
 import { CompanyStore, TeamStore } from '../../../../infrastructure/state/org-structure.store';
 import { CalendarEvent, CalendarEventStatus } from '../../../../domain/models/hr/calendar.model';
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-hr-calendar',
@@ -100,7 +101,7 @@ export class HrCalendarComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   private toIsoDate(date: Date): string {

--- a/src/app/components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component.ts
+++ b/src/app/components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component.ts
@@ -15,6 +15,7 @@ import { EquipmentAssignmentService } from '../../../../infrastructure/services/
 import { EmployeeStore } from '../../../../infrastructure/state/employee.store';
 import { EquipmentAssignment } from '../../../../domain/models/hr/equipment-assignment.model';
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-hr-equipment-assignments',
@@ -97,7 +98,7 @@ export class HrEquipmentAssignmentsComponent implements OnInit, TabDirtyCheck {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso + 'T00:00:00').toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   // ---- Entregar ----

--- a/src/app/components/auth/rh/medical-certificates-manager/medical-certificates-manager.component.ts
+++ b/src/app/components/auth/rh/medical-certificates-manager/medical-certificates-manager.component.ts
@@ -10,6 +10,7 @@ import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table
 import { MedicalCertificateService } from '../../../../infrastructure/services/hr/medical-certificate.service';
 import { MedicalCertificate } from '../../../../domain/models/hr/medical-certificate.model';
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 @Component({
   selector: 'app-medical-certificates-manager',
@@ -48,7 +49,7 @@ export class MedicalCertificatesManagerComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso + 'T00:00:00').toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   formatDateTime(iso: string): string {

--- a/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
+++ b/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
@@ -15,6 +15,7 @@ import { Reimbursement, ReimbursementStatus } from '../../../../domain/models/hr
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 import {ButtonDirective} from "primeng/button";
 import {Tooltip} from "primeng/tooltip";
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 type ReviewAction = 'approve' | 'reject';
 
@@ -91,7 +92,7 @@ export class ReimbursementsManagerComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   baixarComprovante(r: Reimbursement): void {

--- a/src/app/components/auth/rh/rh-hub/rh-hub.component.ts
+++ b/src/app/components/auth/rh/rh-hub/rh-hub.component.ts
@@ -15,6 +15,7 @@ import { CalendarService } from '../../../../infrastructure/services/hr/calendar
 import { HrDashboardService } from '../../../../infrastructure/services/hr/hr-dashboard.service';
 import { CalendarEvent } from '../../../../domain/models/hr/calendar.model';
 import { HrDashboardSummary } from '../../../../domain/models/hr/dashboard-summary.model';
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 type ToolKey =
   | 'vacation' | 'reimbursements' | 'employees' | 'orgStructure' | 'career'
@@ -375,7 +376,7 @@ export class RhHubComponent implements OnInit {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso + 'T00:00:00').toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   formatDateObj(d: Date): string {

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
@@ -19,6 +19,7 @@ import { EmployeeStore } from '../../../../infrastructure/state/employee.store';
 import { VacationAlert, VacationRequest, VacationRequestStatus } from '../../../../domain/models/hr/vacation-request.model';
 import { countBusinessDays, getHolidaysInRange, HolidayInfo } from '../../../../domain/utils/brazilian-business-days';
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
+import { formatDateBr } from '../../../../domain/utils/date-only';
 
 type ReviewAction = 'approve' | 'reject';
 
@@ -119,7 +120,7 @@ export class VacationRequestsManagerComponent implements OnInit, TabDirtyCheck {
   }
 
   formatDate(iso: string): string {
-    return new Date(iso).toLocaleDateString('pt-BR');
+    return formatDateBr(iso);
   }
 
   openReview(request: VacationRequest, action: ReviewAction): void {

--- a/src/app/domain/utils/date-only.ts
+++ b/src/app/domain/utils/date-only.ts
@@ -25,6 +25,22 @@ export function parseDateOnly(value: Date | string | null | undefined): Date | n
 }
 
 /**
+ * Formata uma data-only para exibição (`dd/MM/yyyy`).
+ *
+ * Substitui o `new Date(iso).toLocaleDateString('pt-BR')` que estava copiado
+ * em nove telas: com `"2026-08-10"` aquilo é lido como meia-noite UTC e a tela
+ * mostra **09/08**. Três telas já tinham contornado com `iso + 'T00:00:00'`,
+ * cada uma por conta própria — sinal de que o lugar certo era um só.
+ *
+ * Só para campo `LocalDate`. Para `LocalDateTime` (que vem com hora e é lido
+ * como horário local) o `new Date(iso)` já está correto.
+ */
+export function formatDateBr(value: Date | string | null | undefined): string {
+  const date = parseDateOnly(value);
+  return date ? date.toLocaleDateString('pt-BR') : '—';
+}
+
+/**
  * Formata para `yyyy-MM-dd` usando o fuso local.
  *
  * `toISOString()` converte para UTC antes de cortar a string: dependendo do


### PR DESCRIPTION
new Date("2026-08-10") e lido como meia-noite UTC, entao no Brasil vira
09/08 as 21h e a tela mostra o dia anterior. O helper estava copiado em
onze telas, e tres delas ja tinham contornado por conta propria com
iso + "T00:00:00" -- tres pessoas bateram na mesma parede e remendaram o
proprio canto em vez da causa.

Seis telas estavam realmente erradas: atestados, reembolsos e ferias do
funcionario, calendario de RH, gestor de reembolsos e gestor de ferias.
Toda data lida nelas vinha um dia antes.

As nove agora usam formatDateBr, no mesmo util do conserto do aniversario.
Ficam de fora as oito que formatam LocalDateTime, onde new Date(iso) e lido
como hora local e ja esta certo.

Nota para a proxima vez: o pipe date do Angular nunca teve esse bug -- ele
detecta string sem hora e monta data local de proposito. So o parsing na
mao quebra.
