### PR TITLE
fix(prostock): hub do estoque não conta produto cujo histórico falhou

### DIFF
--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.html
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.html
@@ -36,6 +36,18 @@
     </p>
   }
 
+  <!-- Números incompletos precisam dizer que estão incompletos. -->
+  @if (brokenCodes().length > 0 && !loading()) {
+    <p class="hub__warn">
+      <i class="pi pi-exclamation-triangle"></i>
+      <span>
+        {{ brokenCodes().length }} produto(s) fora das contas — a API não devolveu o
+        histórico deles: <em>{{ brokenCodes().join(', ') }}</em>.
+        Código de produto repetido no cadastro costuma ser a causa.
+      </span>
+    </p>
+  }
+
   <!-- ─── KPIs ────────────────────────────────────────────────────────────── -->
   <div class="kpi-row">
     <a class="kpi" routerLink="/stock/products">

--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.scss
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.scss
@@ -381,3 +381,21 @@
     white-space: nowrap;
   }
 }
+
+// Aviso de dado incompleto — precisa ser visível sem ser um erro de tela.
+.hub__warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding: 12px 16px;
+  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--app-warning-soft);
+  color: var(--app-text);
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+
+  i { color: var(--app-warning); margin-top: 2px; }
+  em { font-style: normal; font-weight: 700; }
+}

--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
@@ -72,6 +72,12 @@ export class InventoryHubComponent implements OnInit {
   readonly total = signal(0);
   readonly failed = signal(false);
 
+  /**
+   * Produtos cujo histórico a API recusou. Ficam de fora das contas: entrar
+   * como estoque zero seria pior que faltar, porque o número mentiria.
+   */
+  readonly brokenCodes = signal<string[]>([]);
+
   readonly products = signal<InventoryProductResponse[]>([]);
   private readonly histories = signal<Map<string, InventoryMovement[]>>(new Map());
 
@@ -94,8 +100,9 @@ export class InventoryHubComponent implements OnInit {
     const histories = this.histories();
     const from = this.periodStart();
     const today = startOfToday();
+    const broken = new Set(this.brokenCodes());
 
-    return this.products().map(product => {
+    return this.products().filter(product => !broken.has(product.systemCode)).map(product => {
       const history = [...(histories.get(product.systemCode) ?? [])]
         .sort((a, b) => a.movementDate.localeCompare(b.movementDate));
 
@@ -291,13 +298,19 @@ export class InventoryHubComponent implements OnInit {
    */
   private loadHistories(products: InventoryProductResponse[]): void {
     const histories = new Map<string, InventoryMovement[]>();
+    const broken: string[] = [];
 
     from(products)
       .pipe(
         mergeMap(product => this.service.getInventoryMovementsByProduct(product.systemCode).pipe(
-          catchError(() => of([] as InventoryMovement[])),
+          // Produto que falha entraria como estoque zero, o que é mentira.
+          // Fica de fora da conta e vai para o aviso.
+          catchError(() => {
+            broken.push(product.systemCode);
+            return of(null);
+          }),
           tap(list => {
-            histories.set(product.systemCode, list ?? []);
+            if (list) histories.set(product.systemCode, list);
             this.loaded.update(value => value + 1);
           }),
         ), CONCURRENCY),
@@ -306,6 +319,7 @@ export class InventoryHubComponent implements OnInit {
       )
       .subscribe(() => {
         this.histories.set(histories);
+        this.brokenCodes.set(broken);
         this.loading.set(false);
       });
   }


### PR DESCRIPTION
A API responde 500 em produtos com código repetido no cadastro
(`findBySystemCode` espera um e recebe três). O hub engolia o erro e tratava
o produto como estoque zero — número errado com cara de número certo.

Agora esses produtos ficam fora de todas as contas e um aviso no topo diz
quais são e qual costuma ser a causa. Melhor faltar do que mentir.
