### PR TITLE
feat(fuelsupply): hub de abastecimento com indicadores e gráficos

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -104,6 +104,7 @@ export const routes: Routes = [
       { path: 'company/products', redirectTo: 'stock/products', pathMatch: 'full' },
       { path: 'company/inventory', redirectTo: 'stock/movements', pathMatch: 'full' },
       { path: 'company/customers', loadComponent: () => import('./components/auth/partners/customer/customer.component').then(m => m.CustomerComponent), data: { roles: ['ADMIN', 'RH', 'MARKETING'] } },
+      { path: 'company/fuel-hub', loadComponent: () => import('./components/auth/company/vehicle/fuel-hub/fuel-hub.component').then(m => m.FuelHubComponent), data: { roles: ['ADMIN', 'COMPRADOR'] } },
       { path: 'company/fuel-supply', loadComponent: () => import('./components/auth/company/vehicle/fuel-supply/fuel-supply.component').then(m => m.FuelSupplyComponent), data: { roles: ['ADMIN', 'COMPRADOR'] } },
       { path: 'company/guide', loadComponent: () => import('./components/auth/guide/guide.component').then(m => m.GuideComponent), data: { roles: ['ADMIN', 'CONTRATOS'] } },
       { path: 'company/equipments', loadComponent: () => import('./components/auth/company/equipments/equipments.component').then(m => m.EquipmentsComponent), data: { roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] } },

--- a/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.html
+++ b/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.html
@@ -1,0 +1,200 @@
+<div class="hub">
+
+  <app-page-header
+    icon="pi pi-gauge"
+    title="Hub de Abastecimento"
+    subtitle="Gasto, consumo e o que foge da média da frota"
+    size="lg">
+    <div actions class="hub__actions">
+      <div class="period">
+        @for (days of periodOptions; track days) {
+          <button type="button"
+                  class="period__btn"
+                  [class.period__btn--on]="periodDays() === days"
+                  (click)="setPeriod(days)">
+            {{ days === 365 ? '12 meses' : days + ' dias' }}
+          </button>
+        }
+      </div>
+      <button type="button" class="period__btn" [disabled]="loading()" (click)="load()">
+        <i class="pi" [class.pi-refresh]="!loading()" [class.pi-spin]="loading()" [class.pi-spinner]="loading()"></i>
+        Atualizar
+      </button>
+    </div>
+  </app-page-header>
+
+  @if (error()) {
+    <p class="hub__empty">
+      <i class="pi pi-exclamation-triangle"></i>
+      {{ error() }}
+    </p>
+  }
+
+  @if (!loading() && !error() && count() === 0) {
+    <p class="hub__warn">
+      <i class="pi pi-info-circle"></i>
+      <span>
+        Nenhum abastecimento no período. Os dados entram por planilha em
+        <a routerLink="/company/fuel-supply">Abastecimento</a> — se o mês ainda não
+        foi importado, ele não aparece aqui.
+      </span>
+    </p>
+  }
+
+  <!-- ─── KPIs ────────────────────────────────────────────────────────────── -->
+  <div class="kpi-row">
+    <div class="kpi kpi--hero">
+      <span class="kpi__label">Gasto no período</span>
+      <span class="kpi__value">{{ money(totalSpent()) }}</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Litros</span>
+      <span class="kpi__value">{{ decimal(totalLiters()) }}</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Preço médio do litro</span>
+      <span class="kpi__value">{{ money(avgPrice()) }}</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Km rodados</span>
+      <span class="kpi__value">{{ decimal(totalKm(), 0) }}</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Consumo da frota</span>
+      <span class="kpi__value kpi__value--ok">{{ decimal(avgConsumption(), 2) }}<small> km/l</small></span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Custo por km</span>
+      <span class="kpi__value">{{ money(costPerKm()) }}</span>
+    </div>
+
+    <div class="kpi">
+      <span class="kpi__label">Abastecimentos</span>
+      <span class="kpi__value">{{ count() }}<small> em {{ vehicleCount() }} veículo(s)</small></span>
+    </div>
+  </div>
+
+  <!-- ─── Gasto por mês ───────────────────────────────────────────────────── -->
+  <section class="card">
+    <h2 class="card__title">Gasto por mês</h2>
+    <p class="card__hint">Total abastecido em cada mês do período.</p>
+
+    <div class="flow">
+      @for (month of byMonth(); track month.key) {
+        <div class="flow__col"
+             [pTooltip]="month.label + ': ' + money(month.total) + ' · ' + decimal(month.liters) + ' L'"
+             tooltipPosition="top">
+          <span class="flow__bar" [style.height.%]="month.percent"></span>
+          <span class="flow__label">{{ month.label }}</span>
+        </div>
+      } @empty {
+        <p class="card__empty">Sem dados no período.</p>
+      }
+    </div>
+  </section>
+
+  <div class="two-col">
+    <!-- ─── Por departamento ──────────────────────────────────────────────── -->
+    <section class="card">
+      <h2 class="card__title">Por departamento</h2>
+      <p class="card__hint">O departamento vem do funcionário vinculado ao motorista.</p>
+
+      @for (slice of byDepartment(); track slice.label) {
+        <div class="rank">
+          <span class="rank__label">{{ departmentLabel(slice.label) }}</span>
+          <span class="rank__track">
+            <span class="rank__bar" [style.width.%]="slice.percent"></span>
+          </span>
+          <span class="rank__value">{{ money(slice.total) }}</span>
+        </div>
+      } @empty {
+        <p class="card__empty">Sem dados no período.</p>
+      }
+    </section>
+
+    <!-- ─── Por combustível ───────────────────────────────────────────────── -->
+    <section class="card">
+      <h2 class="card__title">Por combustível</h2>
+      <p class="card__hint">Quanto de cada tipo, em reais e litros.</p>
+
+      @for (slice of byFuelType(); track slice.label) {
+        <div class="rank">
+          <span class="rank__label">{{ slice.label }}</span>
+          <span class="rank__track">
+            <span class="rank__bar rank__bar--alt" [style.width.%]="slice.percent"></span>
+          </span>
+          <span class="rank__value" [pTooltip]="decimal(slice.liters) + ' L'" tooltipPosition="left">
+            {{ money(slice.total) }}
+          </span>
+        </div>
+      } @empty {
+        <p class="card__empty">Sem dados no período.</p>
+      }
+    </section>
+  </div>
+
+  <div class="two-col">
+    <!-- ─── Veículos que mais gastam ──────────────────────────────────────── -->
+    <section class="card">
+      <h2 class="card__title">Veículos que mais gastam</h2>
+      <p class="card__hint">Os oito primeiros, por valor abastecido.</p>
+
+      @for (row of topVehicles(); track row.plate) {
+        <div class="rank">
+          <span class="rank__label">
+            {{ row.plate }}
+            <small>{{ row.consumption ? decimal(row.consumption, 2) + ' km/l' : 'sem km' }}</small>
+          </span>
+          <span class="rank__track">
+            <span class="rank__bar" [style.width.%]="row.percent"></span>
+          </span>
+          <span class="rank__value">{{ money(row.total) }}</span>
+        </div>
+      } @empty {
+        <p class="card__empty">Sem dados no período.</p>
+      }
+    </section>
+
+    <!-- ─── Consumo abaixo da média ───────────────────────────────────────── -->
+    <section class="card">
+      <h2 class="card__title">Consumo abaixo da média</h2>
+      <p class="card__hint">
+        Pelo menos 15% pior que a frota ({{ decimal(avgConsumption(), 2) }} km/l),
+        com três ou mais abastecimentos no período.
+      </p>
+
+      @for (row of thirsty(); track row.plate) {
+        <div class="thirsty">
+          <span class="thirsty__plate">{{ row.plate }}</span>
+          <span class="thirsty__consumption">{{ decimal(row.consumption ?? 0, 2) }} km/l</span>
+          <span class="thirsty__meta">{{ decimal(row.km, 0) }} km · {{ money(row.total) }}</span>
+        </div>
+      } @empty {
+        <p class="card__empty">Nenhum veículo destoando da frota.</p>
+      }
+    </section>
+  </div>
+
+  <!-- ─── Últimos abastecimentos ──────────────────────────────────────────── -->
+  <section class="card">
+    <h2 class="card__title">Últimos abastecimentos</h2>
+
+    @for (item of recent(); track item.plate + item.fuelSupplyDate + item.liters) {
+      <div class="feed">
+        <span class="feed__date">{{ item.fuelSupplyDate.slice(8, 10) }}/{{ item.fuelSupplyDate.slice(5, 7) }}</span>
+        <span class="feed__plate">{{ item.plate }}</span>
+        <span class="feed__driver">{{ item.driverName || '—' }}</span>
+        <span class="feed__liters">{{ decimal(item.liters) }} L</span>
+        <span class="feed__total">{{ money(item.totalValue) }}</span>
+      </div>
+    } @empty {
+      <p class="card__empty">Sem dados no período.</p>
+    }
+  </section>
+
+</div>

--- a/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.scss
+++ b/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.scss
@@ -1,0 +1,339 @@
+@use 'variables' as v;
+
+// Estrutura (hub, kpi, card, rank) repete a do Hub do Estoque e a do Hub das
+// Máquinas. Vale extrair um mixin em `styles/mixins.scss` quando os três
+// estiverem estáveis — fazer isso agora mexeria em duas telas ainda não
+// testadas contra a API.
+
+:host {
+  display: block;
+  background: var(--app-bg);
+  min-height: 100%;
+}
+
+.hub {
+  width: 100%;
+  padding: 28px clamp(16px, 3vw, 40px) 56px;
+  box-sizing: border-box;
+}
+
+.hub__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.hub__empty {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding: 12px 16px;
+  border-radius: var(--radius-control);
+  background: var(--app-danger-soft);
+  color: var(--app-danger);
+  font-size: var(--text-ui-sm);
+  font-weight: 600;
+}
+
+.hub__warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding: 12px 16px;
+  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--app-warning-soft);
+  color: var(--app-text);
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+
+  i { color: var(--app-warning); margin-top: 2px; }
+  a { color: var(--app-action); font-weight: 700; }
+}
+
+// ─── Período ────────────────────────────────────────────────────────────────
+.period {
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-pill);
+  background: var(--app-surface);
+}
+
+.period__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 14px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--app-text-muted);
+  font-size: var(--text-ui-sm);
+  font-weight: 700;
+  cursor: pointer;
+  transition: background .15s ease, color .15s ease;
+
+  &:hover:not(:disabled) { color: var(--app-action); }
+  &:disabled { opacity: .5; cursor: default; }
+
+  &--on {
+    background: var(--app-action);
+    color: var(--app-action-contrast, #fff);
+  }
+}
+
+.hub__actions > .period__btn {
+  border: 1px solid var(--app-border);
+  background: var(--app-surface);
+  height: 36px;
+}
+
+// ─── KPIs ───────────────────────────────────────────────────────────────────
+.kpi-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 14px;
+  margin: 22px 0;
+}
+
+.kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 18px 20px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow-sm);
+
+  &--hero {
+    background: linear-gradient(135deg, var(--app-action-soft, var(--app-surface-2)), var(--app-surface));
+    border-color: color-mix(in srgb, var(--app-action) 35%, transparent);
+  }
+
+  &__label {
+    font-size: 0.76rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--app-text-subtle);
+  }
+
+  &__value {
+    font-size: 1.6rem;
+    font-weight: 800;
+    line-height: 1.15;
+    color: var(--app-text);
+    font-variant-numeric: tabular-nums;
+
+    small {
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--app-text-subtle);
+      letter-spacing: 0;
+    }
+
+    &--ok { color: var(--app-success); }
+  }
+}
+
+// ─── Cartões ────────────────────────────────────────────────────────────────
+.two-col {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 14px;
+  margin-bottom: 22px;
+}
+
+.card {
+  padding: 16px 18px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow-sm);
+  margin-bottom: 22px;
+
+  .two-col & { margin-bottom: 0; }
+
+  &__title {
+    margin: 0 0 4px;
+    font-family: v.$font-heading;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--app-text);
+  }
+
+  &__hint {
+    margin: 0 0 12px;
+    font-size: var(--text-ui-sm);
+    color: var(--app-text-muted);
+  }
+
+  &__empty {
+    margin: 8px 0 0;
+    font-size: var(--text-ui-sm);
+    color: var(--app-text-subtle);
+  }
+}
+
+// ─── Colunas por mês ────────────────────────────────────────────────────────
+// CSS puro, como nos outros hubs: nenhuma biblioteca de gráfico no projeto.
+.flow {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 190px;
+  padding-top: 8px;
+}
+
+.flow__col {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+}
+
+.flow__bar {
+  width: 100%;
+  max-width: 46px;
+  min-height: 2px;
+  border-radius: 5px 5px 0 0;
+  background: var(--app-action);
+  transition: height .2s ease;
+}
+
+.flow__label {
+  font-size: var(--text-micro);
+  color: var(--app-text-subtle);
+  white-space: nowrap;
+}
+
+// ─── Barras horizontais ─────────────────────────────────────────────────────
+.rank {
+  display: grid;
+  grid-template-columns: minmax(0, 160px) 1fr 110px;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+
+  &__label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.78rem;
+    color: var(--app-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    small {
+      font-size: var(--text-micro);
+      color: var(--app-text-subtle);
+    }
+  }
+
+  &__track {
+    height: 8px;
+    border-radius: var(--radius-pill);
+    background: var(--app-surface-2);
+    overflow: hidden;
+  }
+
+  &__bar {
+    display: block;
+    height: 100%;
+    border-radius: var(--radius-pill);
+    background: var(--app-action);
+
+    &--alt { background: var(--app-success); }
+  }
+
+  &__value {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--app-text);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+// ─── Consumo abaixo da média ────────────────────────────────────────────────
+.thirsty {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 90px minmax(0, 160px);
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--app-border);
+  font-size: var(--text-ui-sm);
+
+  &:last-child { border-bottom: none; }
+
+  &__plate {
+    font-weight: 700;
+    color: var(--app-text);
+  }
+
+  &__consumption {
+    text-align: right;
+    font-weight: 700;
+    color: var(--app-warning);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__meta {
+    text-align: right;
+    color: var(--app-text-subtle);
+    font-size: var(--text-micro);
+  }
+}
+
+// ─── Últimos abastecimentos ─────────────────────────────────────────────────
+.feed {
+  display: grid;
+  grid-template-columns: 52px 90px minmax(0, 1fr) 90px 110px;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--app-border);
+  font-size: var(--text-ui-sm);
+
+  &:last-child { border-bottom: none; }
+
+  &__date {
+    color: var(--app-text-subtle);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__plate {
+    font-weight: 700;
+    color: var(--app-text);
+  }
+
+  &__driver {
+    color: var(--app-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__liters,
+  &__total {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__total {
+    font-weight: 700;
+    color: var(--app-text);
+  }
+}

--- a/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.ts
+++ b/src/app/components/auth/company/vehicle/fuel-hub/fuel-hub.component.ts
@@ -1,0 +1,278 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { Tooltip } from 'primeng/tooltip';
+
+import { FuelSupply } from '../../../../../domain/models/fuel-supply.model';
+import { FuelSuppyService } from '../../../../../infrastructure/services/company/vehicle/fuelSupply/fuel-suppy.service';
+import { PageHeaderComponent } from '../../../shared/page-header/page-header.component';
+
+interface Slice {
+  label: string;
+  total: number;
+  liters: number;
+  count: number;
+  percent: number;
+}
+
+interface VehicleRow {
+  plate: string;
+  total: number;
+  liters: number;
+  km: number;
+  count: number;
+  /** km/l do veículo no período; `null` quando não dá para calcular. */
+  consumption: number | null;
+  percent: number;
+}
+
+interface MonthBar {
+  key: string;
+  label: string;
+  total: number;
+  liters: number;
+  percent: number;
+}
+
+/**
+ * Hub de Abastecimento.
+ *
+ * Lê `GET api/fuelsupply?start=&end=` e calcula tudo no cliente, como os
+ * outros hubs. Os dados chegam por planilha mensal, então o período padrão é
+ * de um ano: com 30 dias, um mês ainda não importado deixaria a tela vazia e
+ * pareceria defeito.
+ *
+ * O consumo é recalculado por `km / litros` em vez de usar o `averageKm` da
+ * planilha: a média por linha não pode ser somada nem tirada média de médias
+ * sem distorcer, e há linhas que vêm sem ela.
+ */
+@Component({
+  selector: 'app-fuel-hub',
+  standalone: true,
+  imports: [CommonModule, RouterLink, Tooltip, PageHeaderComponent],
+  templateUrl: './fuel-hub.component.html',
+  styleUrl: './fuel-hub.component.scss',
+})
+export class FuelHubComponent implements OnInit {
+
+  private readonly service = inject(FuelSuppyService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly loading = signal(false);
+  readonly error = signal('');
+  readonly supplies = signal<FuelSupply[]>([]);
+
+  readonly periodDays = signal(365);
+  readonly periodOptions = [30, 90, 365];
+
+  // ─── Indicadores ──────────────────────────────────────────────────────────
+
+  readonly count = computed(() => this.supplies().length);
+  readonly totalSpent = computed(() => this.sum(item => item.totalValue));
+  readonly totalLiters = computed(() => this.sum(item => item.liters));
+
+  /** Só a quilometragem plausível entra: ver {@link validKm}. */
+  readonly totalKm = computed(() => this.sum(item => validKm(item)));
+
+  readonly avgPrice = computed(() => {
+    const liters = this.totalLiters();
+    return liters > 0 ? this.totalSpent() / liters : 0;
+  });
+
+  /**
+   * Consumo da frota: km total sobre litros totais. Média de médias daria peso
+   * igual a um abastecimento de 5 litros e a um de 60.
+   */
+  readonly avgConsumption = computed(() => {
+    const liters = this.totalLiters();
+    return liters > 0 ? this.totalKm() / liters : 0;
+  });
+
+  readonly costPerKm = computed(() => {
+    const km = this.totalKm();
+    return km > 0 ? this.totalSpent() / km : 0;
+  });
+
+  readonly vehicleCount = computed(() => new Set(this.supplies().map(item => item.plate)).size);
+
+  // ─── Distribuições ────────────────────────────────────────────────────────
+
+  readonly byDepartment = computed(() => this.groupBy(item => item.department || 'SEM_DEPARTAMENTO'));
+  readonly byFuelType = computed(() => this.groupBy(item => item.fuelType || 'Não informado'));
+
+  /** Gasto por mês, para as colunas. */
+  readonly byMonth = computed<MonthBar[]>(() => {
+    const buckets = new Map<string, { total: number; liters: number }>();
+
+    for (const item of this.supplies()) {
+      const key = (item.fuelSupplyDate ?? '').slice(0, 7);
+      if (!key) continue;
+
+      const bucket = buckets.get(key) ?? { total: 0, liters: 0 };
+      bucket.total += item.totalValue;
+      bucket.liters += item.liters;
+      buckets.set(key, bucket);
+    }
+
+    const rows = [...buckets.entries()].sort(([a], [b]) => a.localeCompare(b));
+    const max = Math.max(1, ...rows.map(([, bucket]) => bucket.total));
+
+    return rows.map(([key, bucket]) => ({
+      key,
+      label: `${key.slice(5, 7)}/${key.slice(2, 4)}`,
+      total: bucket.total,
+      liters: bucket.liters,
+      percent: Math.round((bucket.total / max) * 100),
+    }));
+  });
+
+  /** Um veículo por placa, do que mais gasta para o que menos gasta. */
+  readonly byVehicle = computed<VehicleRow[]>(() => {
+    const buckets = new Map<string, VehicleRow>();
+
+    for (const item of this.supplies()) {
+      const plate = item.plate || 'Sem placa';
+      const row = buckets.get(plate)
+        ?? { plate, total: 0, liters: 0, km: 0, count: 0, consumption: null, percent: 0 };
+
+      row.total += item.totalValue;
+      row.liters += item.liters;
+      row.km += validKm(item);
+      row.count += 1;
+      buckets.set(plate, row);
+    }
+
+    const rows = [...buckets.values()]
+      .map(row => ({ ...row, consumption: row.liters > 0 && row.km > 0 ? row.km / row.liters : null }))
+      .sort((a, b) => b.total - a.total);
+
+    const max = rows.length ? rows[0].total : 1;
+    return rows.map(row => ({ ...row, percent: Math.round((row.total / max) * 100) }));
+  });
+
+  readonly topVehicles = computed(() => this.byVehicle().slice(0, 8));
+
+  /**
+   * Veículos rodando abaixo da média da frota. É o insight que o relatório em
+   * PDF não dá: consumo pior costuma ser manutenção atrasada, não motorista.
+   */
+  readonly thirsty = computed(() => {
+    const fleet = this.avgConsumption();
+    if (fleet <= 0) return [];
+
+    return this.byVehicle()
+      .filter(row => row.consumption !== null && row.consumption < fleet * 0.85 && row.count >= 3)
+      .sort((a, b) => (a.consumption ?? 0) - (b.consumption ?? 0))
+      .slice(0, 6);
+  });
+
+  /** Últimos abastecimentos, do mais recente para o mais antigo. */
+  readonly recent = computed(() =>
+    [...this.supplies()]
+      .sort((a, b) => (b.fuelSupplyDate ?? '').localeCompare(a.fuelSupplyDate ?? ''))
+      .slice(0, 12));
+
+  // ─── Carga ────────────────────────────────────────────────────────────────
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  load(): void {
+    this.loading.set(true);
+    this.error.set('');
+
+    const end = new Date();
+    const start = new Date();
+    start.setDate(start.getDate() - this.periodDays() + 1);
+
+    this.service.listByPeriod(dayKey(start), dayKey(end))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: list => {
+          this.supplies.set(list ?? []);
+          this.loading.set(false);
+        },
+        error: err => {
+          this.supplies.set([]);
+          this.loading.set(false);
+          // 404/405 aqui quer dizer endpoint ausente, não período sem dado.
+          this.error.set(err.status === 404 || err.status === 405
+            ? 'A API ainda não tem o endpoint de consulta de abastecimentos (GET api/fuelsupply).'
+            : 'Não foi possível carregar os abastecimentos.');
+        },
+      });
+  }
+
+  setPeriod(days: number): void {
+    this.periodDays.set(days);
+    this.load();
+  }
+
+  // ─── Formatação ───────────────────────────────────────────────────────────
+  // Intl direto em vez do pipe `currency`: o app não registra `LOCALE_ID`, e
+  // sem ele o pipe agrupa no padrão americano (R$1,234.50).
+
+  money(value: number): string {
+    return new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value || 0);
+  }
+
+  decimal(value: number, digits = 1): string {
+    return new Intl.NumberFormat('pt-BR', {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(value || 0);
+  }
+
+  departmentLabel(value: string): string {
+    return (value ?? '').replace(/_/g, ' ').toLowerCase().replace(/^./, letter => letter.toUpperCase());
+  }
+
+  private sum(pick: (item: FuelSupply) => number): number {
+    return this.supplies().reduce((total, item) => total + (pick(item) || 0), 0);
+  }
+
+  private groupBy(key: (item: FuelSupply) => string): Slice[] {
+    const buckets = new Map<string, { total: number; liters: number; count: number }>();
+
+    for (const item of this.supplies()) {
+      const bucket = buckets.get(key(item)) ?? { total: 0, liters: 0, count: 0 };
+      bucket.total += item.totalValue;
+      bucket.liters += item.liters;
+      bucket.count += 1;
+      buckets.set(key(item), bucket);
+    }
+
+    const total = this.totalSpent() || 1;
+    return [...buckets.entries()]
+      .map(([label, bucket]) => ({
+        label,
+        total: bucket.total,
+        liters: bucket.liters,
+        count: bucket.count,
+        percent: Math.round((bucket.total / total) * 100),
+      }))
+      .sort((a, b) => b.total - a.total);
+  }
+}
+
+/**
+ * Quilometragem confiável de um abastecimento.
+ *
+ * A planilha traz hodômetro digitado à mão: troca de veículo, zero esquecido e
+ * dígito a mais produzem diferenças absurdas ou negativas. Acima de 5.000 km
+ * entre dois abastecimentos é erro de digitação, não viagem — e um único
+ * desses estraga o consumo da frota inteira.
+ */
+function validKm(item: FuelSupply): number {
+  const km = item.diferenceHodometer;
+  return km > 0 && km < 5000 ? km : 0;
+}
+
+/** Chave local `2026-08-11`. `toISOString` viraria o dia em fuso negativo. */
+function dayKey(date: Date): string {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}

--- a/src/app/domain/models/fuel-supply.model.ts
+++ b/src/app/domain/models/fuel-supply.model.ts
@@ -1,0 +1,25 @@
+/**
+ * Abastecimento — uma linha da planilha importada em `POST api/fuelsupply/upload`.
+ *
+ * Os nomes saem do `FuelSupplyDTO` da API, inclusive `diferenceHodometer`, que
+ * está escrito assim lá. Renomear aqui faria o campo chegar vazio.
+ *
+ * `diferenceHodometer` é a quilometragem desde o abastecimento anterior, e
+ * `averageKm` o consumo que a planilha já calculou. O hub recalcula o consumo
+ * a partir de km e litros: quando a planilha vem sem a média, a conta ainda sai.
+ */
+export interface FuelSupply {
+  fuelSupplyDate: string;
+  uf: string;
+  plate: string;
+  driverName: string;
+  department: string;
+  actualHodometer: number;
+  lastHodometer: number;
+  diferenceHodometer: number;
+  averageKm: number;
+  fuelType: string;
+  liters: number;
+  price: number;
+  totalValue: number;
+}

--- a/src/app/infrastructure/services/company/vehicle/fuelSupply/fuel-suppy.service.ts
+++ b/src/app/infrastructure/services/company/vehicle/fuelSupply/fuel-suppy.service.ts
@@ -3,6 +3,7 @@ import {FuelSupplyReportRequest, ReportFormat} from "../../../../../domain/model
 import {environment} from "../../../../../../environments/environment";
 import {Observable} from "rxjs";
 import {HttpClient} from "@angular/common/http";
+import {FuelSupply} from "../../../../../domain/models/fuel-supply.model";
 import {file} from "@primeuix/themes/aura/fileupload";
 
 @Injectable({
@@ -10,6 +11,18 @@ import {file} from "@primeuix/themes/aura/fileupload";
 })
 export class FuelSuppyService {
   constructor(private http: HttpClient) {}
+
+  /**
+   * Abastecimentos de um período, para o Hub montar os indicadores.
+   *
+   * Datas em `yyyy-MM-dd` — a API recebe `LocalDate`, e o intervalo inclui as
+   * duas pontas (`findByFuelSupplyDateBetween`).
+   */
+  listByPeriod(start: string, end: string): Observable<FuelSupply[]> {
+    return this.http.get<FuelSupply[]>(`${environment.apiUrl}/fuelsupply`, {
+      params: { start, end },
+    });
+  }
 
   generateReport(request: FuelSupplyReportRequest): Observable<Blob> {
     return this.http.post(`${environment.apiUrl}/fuelsupply`, request, {

--- a/src/app/layouts/auth-layout/menu.config.ts
+++ b/src/app/layouts/auth-layout/menu.config.ts
@@ -110,6 +110,7 @@ export const APP_MENU: AppMenuItem[] = [
       { label: 'Coletar Dados NFe', icon: 'pi pi-fw pi-file', routerLink: ['company/nfe-collector'], roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] },
       { label: 'Remover Senha do Excel', icon: 'pi pi-fw pi-lock', routerLink: ['company/excel'] },
       { label: 'Abastecimento', icon: 'pi pi-fw pi-gauge', routerLink: ['company/fuel-supply'], roles: ['ADMIN', 'COMPRADOR'] },
+      { label: 'Hub de Abastecimento', icon: 'pi pi-fw pi-chart-line', routerLink: ['company/fuel-hub'], roles: ['ADMIN', 'COMPRADOR'] },
       { label: 'Guia de Utilização', icon: 'pi pi-fw pi-file-pdf', routerLink: ['company/guide'], roles: ['ADMIN', 'CONTRATOS'] },
       { label: 'Equipamentos', icon: 'pi pi-fw pi-wrench', routerLink: ['company/equipments'], roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] },
     ],


### PR DESCRIPTION
Gasto, litros, preço médio do litro, km rodados, consumo da frota e custo por
km; gasto por mês, por departamento e por combustível; os veículos que mais
gastam e os que rodam abaixo da média.

Duas decisões que mudam os números. O consumo é recalculado por km/litros em
vez do averageKm da planilha: média de médias dá o mesmo peso a um
abastecimento de 5 litros e a um de 60. E diferença de hodômetro acima de
5.000 km entre dois abastecimentos é descartada — é erro de digitação, e uma
só estraga o consumo da frota inteira.

Valores formatados com Intl e não com o pipe currency: o app registra o
locale pt-BR mas não provê LOCALE_ID, então o pipe agrupa no padrão
americano. Corrigir isso de vez mexe em todas as telas e merece branch
própria.

Depende do GET api/fuelsupply. Sem ele a tela diz que o endpoint falta, em
vez de mostrar zero como se fosse dado.
