### PR TITLE
feat(tema): componentes de painel e Hub do Estoque consumindo eles

### DIFF
--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.html
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.html
@@ -6,18 +6,14 @@
     subtitle="Entradas, saídas e o que está parado"
     size="lg">
     <div actions class="hub__actions">
-      <div class="period">
-        @for (days of periodOptions; track days) {
-          <button type="button"
-                  class="period__btn"
-                  [class.period__btn--on]="periodDays() === days"
-                  (click)="setPeriod(days)">{{ days }} dias</button>
-        }
-      </div>
-      <button type="button" class="period__btn" [disabled]="loading()" (click)="load()">
-        <i class="pi" [class.pi-refresh]="!loading()" [class.pi-spin]="loading()" [class.pi-spinner]="loading()"></i>
-        Atualizar
-      </button>
+      <pk-segmented
+        [options]="periodSegments"
+        [value]="periodDays()"
+        (valueChange)="setPeriod($event)"
+        ariaLabel="Período dos indicadores" />
+
+      <pk-button pkType="refresh" pkSize="sm" pkLabel="Atualizar"
+                 [pkLoading]="loading()" (clicked)="load()" />
     </div>
   </app-page-header>
 
@@ -50,51 +46,34 @@
 
   <!-- ─── KPIs ────────────────────────────────────────────────────────────── -->
   <div class="kpi-row">
-    <a class="kpi" routerLink="/stock/products">
-      <span class="kpi__label">Produtos ativos</span>
-      <span class="kpi__value">{{ activeCount() }}</span>
+    <a class="kpi-link" routerLink="/stock/products">
+      <pk-kpi label="Produtos ativos" [value]="activeCount()" [loading]="loading()" />
     </a>
 
-    <div class="kpi">
-      <span class="kpi__label">Itens em estoque</span>
-      <span class="kpi__value">{{ totalItems() }}</span>
-    </div>
+    <pk-kpi label="Itens em estoque" [value]="totalItems()" [loading]="loading()" />
 
-    <div class="kpi" [class.kpi--hero]="belowMinimum().length > 0">
-      <span class="kpi__label">Abaixo do mínimo</span>
-      <span class="kpi__value kpi__value--warn">{{ belowMinimum().length }}</span>
-    </div>
+    <pk-kpi label="Abaixo do mínimo"
+            [value]="belowMinimum().length"
+            tone="warning"
+            [hero]="belowMinimum().length > 0"
+            [loading]="loading()" />
 
-    <div class="kpi">
-      <span class="kpi__label">Sem estoque</span>
-      <span class="kpi__value kpi__value--bad">{{ outOfStock().length }}</span>
-    </div>
+    <pk-kpi label="Sem estoque" [value]="outOfStock().length" tone="danger" [loading]="loading()" />
 
-    <div class="kpi">
-      <span class="kpi__label">Entradas no período</span>
-      <span class="kpi__value kpi__value--ok">+{{ totalIn() }}</span>
-    </div>
+    <pk-kpi label="Entradas no período" [value]="'+' + totalIn()" tone="success" [loading]="loading()" />
 
-    <div class="kpi">
-      <span class="kpi__label">Saídas no período</span>
-      <span class="kpi__value kpi__value--bad">−{{ totalOut() }}</span>
-    </div>
+    <pk-kpi label="Saídas no período" [value]="'−' + totalOut()" tone="danger" [loading]="loading()" />
 
-    <div class="kpi">
-      <span class="kpi__label">Saldo do período</span>
-      <span class="kpi__value" [class.kpi__value--ok]="balance() > 0" [class.kpi__value--bad]="balance() < 0">
-        {{ balance() > 0 ? '+' : '' }}{{ balance() }}
-      </span>
-    </div>
+    <pk-kpi label="Saldo do período"
+            [value]="(balance() > 0 ? '+' : '') + balance()"
+            [tone]="balance() > 0 ? 'success' : balance() < 0 ? 'danger' : 'default'"
+            [loading]="loading()" />
   </div>
 
   <!-- ─── Fluxo diário ────────────────────────────────────────────────────── -->
-  <section class="card">
-    <h2 class="card__title">Entradas e saídas por dia</h2>
-    <p class="card__hint">
-      A base guarda o estoque resultante, não a diferença — entrada e saída aqui
-      são a variação de um movimento para o anterior.
-    </p>
+  <pk-card
+    title="Entradas e saídas por dia"
+    hint="A base guarda o estoque resultante, não a diferença — entrada e saída aqui são a variação de um movimento para o anterior.">
 
     <div class="flow">
       @for (day of dailyFlow(); track day.key) {
@@ -107,7 +86,9 @@
           </span>
         </div>
       } @empty {
-        <p class="card__empty">Nenhuma movimentação no período.</p>
+        <pk-empty [compact]="true" icon="pi pi-chart-bar"
+                  title="Nenhuma movimentação no período"
+                  subtitle="Aumente o período ou lance uma entrada em Movimentações." />
       }
     </div>
 
@@ -121,60 +102,43 @@
         <span><i class="dot dot--danger"></i> saídas</span>
       </div>
     }
-  </section>
+  </pk-card>
 
   <div class="two-col">
     <!-- ─── Mais movimentados ─────────────────────────────────────────────── -->
-    <section class="card">
-      <h2 class="card__title">Mais movimentados</h2>
-      <p class="card__hint">Entradas e saídas somadas no período.</p>
-
+    <pk-card title="Mais movimentados" hint="Entradas e saídas somadas no período.">
       @for (row of topMoved(); track row.product.systemCode) {
-        <div class="rank">
-          <span class="rank__label" [pTooltip]="row.product.systemCode" tooltipPosition="left">
-            {{ row.product.name }}
-          </span>
-          <span class="rank__track">
-            <span class="rank__bar" [style.width.%]="row.percent"></span>
-          </span>
-          <span class="rank__value">{{ row.moved }}</span>
-        </div>
+        <pk-bar [label]="row.product.name"
+                [sub]="row.product.systemCode"
+                [percent]="row.percent"
+                [value]="row.moved" />
       } @empty {
-        <p class="card__empty">Nenhuma movimentação no período.</p>
+        <pk-empty [compact]="true" title="Nenhuma movimentação no período" />
       }
-    </section>
+    </pk-card>
 
     <!-- ─── Situação do estoque ───────────────────────────────────────────── -->
-    <section class="card">
-      <h2 class="card__title">Situação do estoque</h2>
-      <p class="card__hint">Posição de hoje, independente do período escolhido.</p>
-
+    <pk-card title="Situação do estoque" hint="Posição de hoje, independente do período escolhido.">
       @for (slice of healthSlices(); track slice.label) {
-        <div class="rank">
-          <span class="rank__label">{{ slice.label }}</span>
-          <span class="rank__track">
-            <span class="rank__bar" [class]="'rank__bar rank__bar--' + slice.tone" [style.width.%]="slice.percent"></span>
-          </span>
-          <span class="rank__value">{{ slice.count }}</span>
-        </div>
+        <pk-bar [label]="slice.label"
+                [percent]="slice.percent"
+                [value]="slice.count"
+                [tone]="slice.tone" />
       } @empty {
-        <p class="card__empty">Nenhum produto cadastrado.</p>
+        <pk-empty [compact]="true" title="Nenhum produto cadastrado" />
       }
 
       @if (belowMinimum().length > 0) {
-        <a class="card__link" routerLink="/stock/movements">
+        <a class="card-link" routerLink="/stock/movements">
           <i class="pi pi-arrow-right"></i> Repor os {{ belowMinimum().length }} abaixo do mínimo
         </a>
       }
-    </section>
+    </pk-card>
   </div>
 
   <div class="two-col">
     <!-- ─── Estoque parado ────────────────────────────────────────────────── -->
-    <section class="card">
-      <h2 class="card__title">Estoque parado</h2>
-      <p class="card__hint">Tem saldo, mas não movimenta há 90 dias ou mais.</p>
-
+    <pk-card title="Estoque parado" hint="Tem saldo, mas não movimenta há 90 dias ou mais.">
       @for (item of idle(); track item.product.systemCode) {
         <div class="idle">
           <span class="idle__name">{{ item.product.name }}</span>
@@ -182,15 +146,14 @@
           <span class="idle__when">{{ idleLabel(item.idleDays) }}</span>
         </div>
       } @empty {
-        <p class="card__empty">Nada parado — todo produto com saldo girou nos últimos 90 dias.</p>
+        <pk-empty [compact]="true" icon="pi pi-check-circle"
+                  title="Nada parado"
+                  subtitle="Todo produto com saldo girou nos últimos 90 dias." />
       }
-    </section>
+    </pk-card>
 
     <!-- ─── Últimas movimentações ─────────────────────────────────────────── -->
-    <section class="card">
-      <h2 class="card__title">Últimas movimentações</h2>
-      <p class="card__hint">De todos os produtos, mais recentes primeiro.</p>
-
+    <pk-card title="Últimas movimentações" hint="De todos os produtos, mais recentes primeiro.">
       @for (item of feed(); track item.product + item.date) {
         <div class="feed">
           <span class="feed__delta" [class.feed__delta--out]="item.delta < 0">
@@ -202,9 +165,9 @@
           </span>
         </div>
       } @empty {
-        <p class="card__empty">Nenhuma movimentação registrada.</p>
+        <pk-empty [compact]="true" title="Nenhuma movimentação registrada" />
       }
-    </section>
+    </pk-card>
   </div>
 
 </div>

--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.scss
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.scss
@@ -1,5 +1,10 @@
 @use 'variables' as v;
 
+// Cartão, indicador, barra, estado vazio, período e botão são componentes do
+// tema (`pk-card`, `pk-kpi`, `pk-bar`, `pk-empty`, `pk-segmented`, `pk-button`).
+// Aqui ficam só o esqueleto da página e os dois blocos que ainda não têm
+// componente: o gráfico de colunas e as duas listas.
+
 :host {
   display: block;
   background: var(--app-bg);
@@ -32,45 +37,21 @@
   font-weight: 600;
 }
 
-// ─── Período e atualizar ────────────────────────────────────────────────────
-.period {
+.hub__warn {
   display: flex;
-  gap: 4px;
-  padding: 3px;
-  border: 1px solid var(--app-border);
-  border-radius: var(--radius-pill);
-  background: var(--app-surface);
-}
-
-.period__btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: 30px;
-  padding: 0 14px;
-  border: none;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--app-text-muted);
+  align-items: flex-start;
+  gap: 8px;
+  margin: 18px 0 0;
+  padding: 12px 16px;
+  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--app-warning-soft);
+  color: var(--app-text);
   font-size: var(--text-ui-sm);
-  font-weight: 700;
-  cursor: pointer;
-  transition: background .15s ease, color .15s ease;
+  line-height: 1.45;
 
-  &:hover:not(:disabled) { color: var(--app-action); }
-  &:disabled { opacity: .5; cursor: default; }
-
-  &--on {
-    background: var(--app-action);
-    color: var(--app-action-contrast, #fff);
-  }
-}
-
-// O botão Atualizar fica fora do grupo de período: precisa da própria borda.
-.hub__actions > .period__btn {
-  border: 1px solid var(--app-border);
-  background: var(--app-surface);
-  height: 36px;
+  i { color: var(--app-warning); margin-top: 2px; }
+  em { font-style: normal; font-weight: 700; }
 }
 
 // ─── Progresso da carga ─────────────────────────────────────────────────────
@@ -99,7 +80,7 @@
   }
 }
 
-// ─── KPIs ───────────────────────────────────────────────────────────────────
+// ─── Grades ─────────────────────────────────────────────────────────────────
 .kpi-row {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -107,47 +88,17 @@
   margin: 22px 0;
 }
 
-.kpi {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 18px 20px;
-  border: 1px solid var(--app-border);
-  border-radius: var(--radius-surface);
-  background: var(--app-surface);
-  box-shadow: var(--app-shadow-sm);
+// O indicador que leva para outra tela: a âncora só carrega o pk-kpi, para o
+// componente não precisar saber que às vezes é link.
+.kpi-link {
+  display: block;
   text-decoration: none;
-  transition: border-color .15s ease;
+  border-radius: var(--radius-surface);
 
-  &:is(a):hover { border-color: var(--app-action); }
-
-  &--hero {
-    background: linear-gradient(135deg, var(--app-warning-soft), var(--app-surface));
-    border-color: color-mix(in srgb, var(--app-warning) 40%, transparent);
-  }
-
-  &__label {
-    font-size: 0.76rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--app-text-subtle);
-  }
-
-  &__value {
-    font-size: 2rem;
-    font-weight: 800;
-    line-height: 1.1;
-    color: var(--app-text);
-    font-variant-numeric: tabular-nums;
-
-    &--ok   { color: var(--app-success); }
-    &--warn { color: var(--app-warning); }
-    &--bad  { color: var(--app-danger); }
-  }
+  &:hover pk-kpi { filter: brightness(0.99); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
 }
 
-// ─── Cartões ────────────────────────────────────────────────────────────────
 .two-col {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
@@ -155,53 +106,30 @@
   margin-bottom: 22px;
 }
 
-.card {
-  padding: 16px 18px;
-  border: 1px solid var(--app-border);
-  border-radius: var(--radius-surface);
-  background: var(--app-surface);
-  box-shadow: var(--app-shadow-sm);
+// O espaçamento entre cartões é da página, não do cartão.
+pk-card {
+  display: block;
   margin-bottom: 22px;
 
   .two-col & { margin-bottom: 0; }
+}
 
-  &__title {
-    margin: 0 0 4px;
-    font-family: v.$font-heading;
-    font-size: 0.9rem;
-    font-weight: 700;
-    color: var(--app-text);
-  }
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: var(--text-ui-sm);
+  font-weight: 700;
+  color: var(--app-action);
+  text-decoration: none;
 
-  &__hint {
-    margin: 0 0 12px;
-    font-size: var(--text-ui-sm);
-    color: var(--app-text-muted);
-  }
-
-  &__empty {
-    margin: 8px 0 0;
-    font-size: var(--text-ui-sm);
-    color: var(--app-text-subtle);
-  }
-
-  &__link {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: 12px;
-    font-size: var(--text-ui-sm);
-    font-weight: 700;
-    color: var(--app-action);
-    text-decoration: none;
-
-    &:hover { text-decoration: underline; }
-  }
+  &:hover { text-decoration: underline; }
 }
 
 // ─── Fluxo diário ───────────────────────────────────────────────────────────
-// Colunas em CSS puro, como as barras do Painel de RH: o projeto não tem
-// biblioteca de gráfico e não vale acrescentar uma por causa de um cartão.
+// Colunas em CSS puro: o projeto não tem biblioteca de gráfico. Ainda sem
+// componente porque só duas telas usam — vira `pk-columns` na terceira.
 .flow {
   display: flex;
   align-items: flex-end;
@@ -269,49 +197,6 @@
 
   &--success { background: var(--app-success); }
   &--danger  { background: var(--app-danger); }
-}
-
-// ─── Barras horizontais ─────────────────────────────────────────────────────
-.rank {
-  display: grid;
-  grid-template-columns: minmax(0, 150px) 1fr 44px;
-  align-items: center;
-  gap: 10px;
-  padding: 5px 0;
-
-  &__label {
-    font-size: 0.78rem;
-    color: var(--app-text-muted);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__track {
-    height: 8px;
-    border-radius: var(--radius-pill);
-    background: var(--app-surface-2);
-    overflow: hidden;
-  }
-
-  &__bar {
-    display: block;
-    height: 100%;
-    border-radius: var(--radius-pill);
-    background: var(--app-action);
-
-    &--success { background: var(--app-success); }
-    &--warning { background: var(--app-warning); }
-    &--danger  { background: var(--app-danger); }
-  }
-
-  &__value {
-    font-size: 0.8rem;
-    font-weight: 700;
-    color: var(--app-text);
-    text-align: right;
-    font-variant-numeric: tabular-nums;
-  }
 }
 
 // ─── Parados ────────────────────────────────────────────────────────────────
@@ -382,20 +267,9 @@
   }
 }
 
-// Aviso de dado incompleto — precisa ser visível sem ser um erro de tela.
-.hub__warn {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  margin: 18px 0 0;
-  padding: 12px 16px;
-  border: 1px solid color-mix(in srgb, var(--app-warning) 40%, transparent);
-  border-radius: var(--radius-control);
-  background: var(--app-warning-soft);
-  color: var(--app-text);
-  font-size: var(--text-ui-sm);
-  line-height: 1.45;
-
-  i { color: var(--app-warning); margin-top: 2px; }
-  em { font-style: normal; font-weight: 700; }
+@media (max-width: v.$bp-sm) {
+  .idle { grid-template-columns: minmax(0, 1fr) auto; }
+  .idle__when { grid-column: 1 / -1; text-align: left; font-size: var(--text-micro); }
+  .feed { grid-template-columns: 48px minmax(0, 1fr); }
+  .feed__meta { grid-column: 2; }
 }

--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
@@ -8,6 +8,12 @@ import { catchError, from, mergeMap, of, tap, toArray } from 'rxjs';
 import { InventoryMovement, InventoryProductResponse } from '../../../../domain/models/products.model';
 import { InventoryProductService } from '../../../../infrastructure/services/company/inventory/inventory-product.service';
 import { PageHeaderComponent } from '../../shared/page-header/page-header.component';
+import { PkBarComponent, PkBarTone } from '../../../theme/ProautoKimium/pk-bar/pk-bar.component';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkCardComponent } from '../../../theme/ProautoKimium/pk-card/pk-card.component';
+import { PkEmptyComponent } from '../../../theme/ProautoKimium/pk-empty/pk-empty.component';
+import { PkKpiComponent } from '../../../theme/ProautoKimium/pk-kpi/pk-kpi.component';
+import { PkSegmentedComponent } from '../../../theme/ProautoKimium/pk-segmented/pk-segmented.component';
 
 /** Requisições simultâneas ao buscar o histórico produto a produto. */
 const CONCURRENCY = 6;
@@ -58,7 +64,11 @@ interface FeedItem {
 @Component({
   selector: 'app-inventory-hub',
   standalone: true,
-  imports: [CommonModule, RouterLink, Tooltip, PageHeaderComponent],
+  imports: [
+    CommonModule, RouterLink, Tooltip, PageHeaderComponent,
+    PkBarComponent, PkButtonComponent, PkCardComponent, PkEmptyComponent,
+    PkKpiComponent, PkSegmentedComponent,
+  ],
   templateUrl: './inventory-hub.component.html',
   styleUrl: './inventory-hub.component.scss',
 })
@@ -83,7 +93,11 @@ export class InventoryHubComponent implements OnInit {
 
   /** Janela dos indicadores de fluxo. O estoque atual não depende dela. */
   readonly periodDays = signal(30);
-  readonly periodOptions = [7, 30, 90];
+  readonly periodSegments = [
+    { label: '7 dias', value: 7 },
+    { label: '30 dias', value: 30 },
+    { label: '90 dias', value: 90 },
+  ];
 
   readonly progress = computed(() => {
     const total = this.total();
@@ -165,17 +179,21 @@ export class InventoryHubComponent implements OnInit {
       .slice(0, 8));
 
   /** Situação do estoque, para a barra de distribuição. */
-  readonly healthSlices = computed(() => {
+  readonly healthSlices = computed<{ label: string; count: number; percent: number; tone: PkBarTone }[]>(() => {
     const total = this.summaries().length || 1;
     const zero = this.outOfStock().length;
     const below = this.belowMinimum().filter(item => item.stock > 0).length;
     const ok = this.summaries().length - zero - below;
 
-    return [
+    // Tipado antes do filter: o `.filter` corta a inferência contextual e o
+    // literal 'success' voltaria a ser um string qualquer.
+    const slices: { label: string; count: number; percent: number; tone: PkBarTone }[] = [
       { label: 'Dentro do mínimo', count: ok, percent: Math.round((ok / total) * 100), tone: 'success' },
       { label: 'Abaixo do mínimo', count: below, percent: Math.round((below / total) * 100), tone: 'warning' },
       { label: 'Sem estoque', count: zero, percent: Math.round((zero / total) * 100), tone: 'danger' },
-    ].filter(slice => slice.count > 0);
+    ];
+
+    return slices.filter(slice => slice.count > 0);
   });
 
   /** Os oito que mais giraram no período — entradas e saídas somadas. */

--- a/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.html
+++ b/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.html
@@ -1,0 +1,15 @@
+<div class="pk-bar">
+
+  <span class="pk-bar__label">
+    <span class="pk-bar__name">{{ label() }}</span>
+    @if (sub()) { <small class="pk-bar__sub">{{ sub() }}</small> }
+  </span>
+
+  <span class="pk-bar__track">
+    <span class="pk-bar__fill"
+          [class]="'pk-bar__fill pk-bar__fill--' + tone()"
+          [style.width.%]="width()"></span>
+  </span>
+
+  <span class="pk-bar__value">{{ value() }}</span>
+</div>

--- a/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.scss
@@ -1,0 +1,83 @@
+@use 'variables' as v;
+
+:host { display: block; }
+
+.pk-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 150px) 1fr minmax(44px, auto);
+  align-items: center;
+  gap: 10px;
+  padding: 5px 0;
+}
+
+.pk-bar__label {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.pk-bar__name {
+  font-size: 0.78rem;
+  color: var(--app-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pk-bar__sub {
+  font-size: var(--text-micro);
+  color: var(--app-text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pk-bar__track {
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--app-surface-2);
+  overflow: hidden;
+}
+
+.pk-bar__fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--app-action);
+  transition: width .25s ease;
+
+  &--success { background: var(--app-success); }
+  &--warning { background: var(--app-warning); }
+  &--danger  { background: var(--app-danger); }
+  &--neutral { background: var(--app-text-muted); }
+}
+
+.pk-bar__value {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--app-text);
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+// Em tela estreita o rótulo sobe e a barra usa a linha inteira: 150px de nome
+// mais barra mais valor não cabem em 390px sem cortar os três.
+@media (max-width: v.$bp-xs) {
+  .pk-bar {
+    grid-template-columns: 1fr auto;
+    gap: 4px 10px;
+  }
+
+  .pk-bar__label { grid-column: 1; }
+  .pk-bar__value { grid-column: 2; }
+
+  .pk-bar__track {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pk-bar__fill { transition: none; }
+}

--- a/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-bar/pk-bar.component.ts
@@ -1,0 +1,37 @@
+import { Component, computed, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type PkBarTone = 'action' | 'success' | 'warning' | 'danger' | 'neutral';
+
+/**
+ * Barra horizontal de comparação — rótulo, trilho e valor.
+ *
+ * O projeto desenha gráfico em CSS puro, sem biblioteca, e essa barra já existe
+ * três vezes com três nomes: `.rank` no Estoque e no Abastecimento, `.dist` nas
+ * Máquinas e `.dist-item` no RH. Este componente é o nome único.
+ *
+ * `percent` é o tamanho da barra e `value` é o texto à direita, **já
+ * formatado** — a mesma barra mostra "12 un.", "R$ 1.470,00" ou "38%" sem o
+ * componente precisar saber qual é.
+ */
+@Component({
+  selector: 'pk-bar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pk-bar.component.html',
+  styleUrl: './pk-bar.component.scss',
+})
+export class PkBarComponent {
+
+  label = input.required<string>();
+
+  /** Segunda linha do rótulo, para contexto que não cabe no nome. */
+  sub = input<string>('');
+
+  percent = input<number>(0);
+  value = input<string | number>('');
+  tone = input<PkBarTone>('action');
+
+  /** Fora de 0–100 a barra vazaria o trilho ou sumiria. */
+  readonly width = computed(() => Math.max(0, Math.min(100, this.percent())));
+}

--- a/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.html
+++ b/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.html
@@ -1,0 +1,24 @@
+<section class="pk-card" [class.pk-card--flush]="flush()">
+
+  @if (title() || icon()) {
+    <header class="pk-card__head">
+      <div class="pk-card__heading">
+        <h2 class="pk-card__title">
+          @if (icon()) { <i [class]="icon()"></i> }
+          {{ title() }}
+        </h2>
+        @if (hint()) {
+          <p class="pk-card__hint">{{ hint() }}</p>
+        }
+      </div>
+
+      <div class="pk-card__actions">
+        <ng-content select="[actions]" />
+      </div>
+    </header>
+  }
+
+  <div class="pk-card__body">
+    <ng-content />
+  </div>
+</section>

--- a/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.scss
@@ -1,0 +1,65 @@
+@use 'variables' as v;
+
+:host { display: block; }
+
+.pk-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 16px 18px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow-sm);
+
+  &--flush {
+    padding: 0;
+
+    .pk-card__head { padding: 16px 18px 0; }
+  }
+}
+
+.pk-card__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.pk-card__heading { min-width: 0; }
+
+.pk-card__title {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0;
+  font-family: v.$font-heading;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--app-text);
+
+  i { color: var(--app-text-muted); font-size: 0.85rem; }
+}
+
+.pk-card__hint {
+  margin: 4px 0 0;
+  font-size: var(--text-ui-sm);
+  color: var(--app-text-muted);
+  line-height: 1.4;
+}
+
+.pk-card__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-control);
+  flex: 0 0 auto;
+
+  &:empty { display: none; }
+}
+
+.pk-card__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}

--- a/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-card/pk-card.component.ts
@@ -1,0 +1,29 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Superfície de conteúdo — título, dica e um canto para ações.
+ *
+ * Existe porque quatro hubs (RH, Máquinas, Estoque, Abastecimento) repetem o
+ * mesmo bloco `.card` + `.card__title` + `.card__hint` em CSS próprio, cada um
+ * com a sua cópia. Aqui é um só, e o dark mode vem junto porque tudo é token.
+ *
+ * O `.app-card` global continua valendo para caixa simples sem cabeçalho; este
+ * componente é para quando há título, dica ou ação.
+ */
+@Component({
+  selector: 'pk-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pk-card.component.html',
+  styleUrl: './pk-card.component.scss',
+})
+export class PkCardComponent {
+
+  title = input<string>('');
+  hint = input<string>('');
+  icon = input<string>('');
+
+  /** `flush` tira o respiro interno: para tabela ou lista que já tem o seu. */
+  flush = input<boolean>(false);
+}

--- a/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.html
+++ b/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.html
@@ -1,0 +1,12 @@
+<div class="pk-empty" [class.pk-empty--compact]="compact()">
+  <i class="pk-empty__icon" [class]="'pk-empty__icon ' + icon()"></i>
+  <p class="pk-empty__title">{{ title() }}</p>
+
+  @if (subtitle()) {
+    <p class="pk-empty__subtitle">{{ subtitle() }}</p>
+  }
+
+  <div class="pk-empty__actions">
+    <ng-content />
+  </div>
+</div>

--- a/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.scss
@@ -1,0 +1,47 @@
+@use 'variables' as v;
+
+:host { display: block; }
+
+.pk-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 36px 20px;
+  text-align: center;
+
+  &--compact { padding: 18px 12px; }
+}
+
+.pk-empty__icon {
+  font-size: 1.75rem;
+  color: var(--app-text-subtle);
+  margin-bottom: 4px;
+
+  .pk-empty--compact & { font-size: 1.25rem; }
+}
+
+.pk-empty__title {
+  margin: 0;
+  font-family: v.$font-heading;
+  font-size: var(--text-ui);
+  font-weight: 700;
+  color: var(--app-text);
+}
+
+.pk-empty__subtitle {
+  margin: 0;
+  max-width: 42ch;
+  font-size: var(--text-ui-sm);
+  color: var(--app-text-muted);
+  line-height: 1.45;
+}
+
+.pk-empty__actions {
+  display: flex;
+  gap: var(--gap-control);
+  margin-top: 10px;
+
+  &:empty { display: none; }
+}

--- a/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-empty/pk-empty.component.ts
@@ -1,0 +1,29 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Estado vazio — ícone, título e uma linha que diz o que fazer.
+ *
+ * O `pk-table` já tem o seu embutido; este é para tudo que não é tabela: um
+ * cartão sem dado no período, uma lista de unidades sem resultado de busca.
+ *
+ * O subtítulo não é enfeite: "Nenhum registro" sozinho deixa o usuário sem
+ * saber se está quebrado, se está carregando ou se ele é que precisa fazer
+ * alguma coisa.
+ */
+@Component({
+  selector: 'pk-empty',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pk-empty.component.html',
+  styleUrl: './pk-empty.component.scss',
+})
+export class PkEmptyComponent {
+
+  icon = input<string>('pi pi-inbox');
+  title = input<string>('Nenhum registro encontrado');
+  subtitle = input<string>('');
+
+  /** `compact` cabe dentro de um cartão; o padrão ocupa a área toda. */
+  compact = input<boolean>(false);
+}

--- a/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.html
+++ b/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.html
@@ -1,0 +1,19 @@
+<div class="pk-kpi" [class.pk-kpi--hero]="hero()">
+
+  <span class="pk-kpi__label">
+    @if (icon()) { <i [class]="icon()"></i> }
+    {{ label() }}
+  </span>
+
+  <span class="pk-kpi__value" [class]="'pk-kpi__value pk-kpi__value--' + tone()">
+    @if (loading()) {
+      <span class="pk-kpi__skeleton" aria-label="Carregando">—</span>
+    } @else {
+      {{ value() }}@if (unit()) { <small class="pk-kpi__unit">{{ unit() }}</small> }
+    }
+  </span>
+
+  @if (sub()) {
+    <span class="pk-kpi__sub">{{ sub() }}</span>
+  }
+</div>

--- a/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.scss
@@ -1,0 +1,70 @@
+@use 'variables' as v;
+
+:host { display: block; }
+
+.pk-kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 18px 20px;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  background: var(--app-surface);
+  box-shadow: var(--app-shadow-sm);
+
+  &--hero {
+    background: linear-gradient(135deg, var(--app-action-soft), var(--app-surface));
+    border-color: color-mix(in srgb, var(--app-action) 35%, transparent);
+  }
+}
+
+.pk-kpi__label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-head);
+  color: var(--app-text-subtle);
+
+  i { font-size: 0.8rem; }
+}
+
+.pk-kpi__value {
+  font-size: 1.75rem;
+  font-weight: 800;
+  line-height: 1.15;
+  color: var(--app-text);
+  // Números de tamanhos diferentes não podem dançar quando o valor muda.
+  font-variant-numeric: tabular-nums;
+
+  &--success { color: var(--app-success); }
+  &--warning { color: var(--app-warning); }
+  &--danger  { color: var(--app-danger); }
+}
+
+.pk-kpi__unit {
+  margin-left: 4px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--app-text-subtle);
+}
+
+.pk-kpi__skeleton { color: var(--app-text-subtle); }
+
+.pk-kpi__sub {
+  font-size: var(--text-ui-sm);
+  color: var(--app-text-muted);
+  line-height: 1.35;
+}
+
+// No celular o número não precisa ser tão grande quanto no desktop: o cartão
+// ocupa a largura toda e o rótulo já dá o contexto.
+@media (max-width: v.$bp-sm) {
+  .pk-kpi { padding: 14px 16px; }
+  .pk-kpi__value { font-size: 1.5rem; }
+}

--- a/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-kpi/pk-kpi.component.ts
@@ -1,0 +1,41 @@
+import { Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export type PkKpiTone = 'default' | 'success' | 'warning' | 'danger';
+
+/**
+ * Indicador de topo — rótulo, número grande, unidade e uma linha de apoio.
+ *
+ * O bloco existe copiado em quatro hubs com nomes diferentes (`.kpi`, `.stat`,
+ * `.m-stats`). Aqui vira um só, e o valor chega **já formatado**: quem sabe se
+ * é moeda, litro ou hora é a tela, não o componente.
+ *
+ * `loading` mostra um traço no lugar do número. Zero e "carregando" são coisas
+ * diferentes, e um painel que mostra 0 antes de responder mente por um segundo.
+ */
+@Component({
+  selector: 'pk-kpi',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pk-kpi.component.html',
+  styleUrl: './pk-kpi.component.scss',
+})
+export class PkKpiComponent {
+
+  label = input.required<string>();
+  value = input.required<string | number>();
+
+  /** Sufixo pequeno colado no número: "km/l", "litros", "un". */
+  unit = input<string>('');
+
+  /** Linha de apoio abaixo do número. */
+  sub = input<string>('');
+
+  icon = input<string>('');
+  tone = input<PkKpiTone>('default');
+
+  /** Destaque: o indicador que a tela quer que seja lido primeiro. */
+  hero = input<boolean>(false);
+
+  loading = input<boolean>(false);
+}

--- a/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.html
+++ b/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.html
@@ -1,0 +1,19 @@
+<div class="pk-seg"
+     [class.pk-seg--fill]="fill()"
+     [class.pk-seg--sm]="size() === 'sm'"
+     role="tablist"
+     [attr.aria-label]="ariaLabel() || null">
+
+  @for (option of options(); track option.value) {
+    <button
+      type="button"
+      class="pk-seg__btn"
+      role="tab"
+      [class.pk-seg__btn--on]="option.value === value()"
+      [attr.aria-selected]="option.value === value()"
+      [disabled]="option.disabled"
+      (click)="select(option)">
+      {{ option.label }}
+    </button>
+  }
+</div>

--- a/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.scss
@@ -1,0 +1,69 @@
+@use 'variables' as v;
+
+:host { display: inline-block; max-width: 100%; }
+
+.pk-seg {
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+  box-sizing: border-box;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-pill);
+  background: var(--app-surface);
+  max-width: 100%;
+  // Com muitas opções em tela estreita, rola em vez de estourar a linha.
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar { display: none; }
+
+  &--fill {
+    display: flex;
+    width: 100%;
+
+    .pk-seg__btn { flex: 1 1 0; }
+  }
+}
+
+.pk-seg__btn {
+  flex: 0 0 auto;
+  height: 30px;
+  padding: 0 16px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--app-text-muted);
+  font-family: v.$font-body;
+  font-size: var(--text-ui-sm);
+  font-weight: 700;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background .15s ease, color .15s ease;
+
+  &:hover:not(:disabled):not(.pk-seg__btn--on) {
+    color: var(--app-action);
+    background: var(--app-surface-2);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--app-focus-ring);
+  }
+
+  &:disabled { opacity: .45; cursor: default; }
+
+  &--on {
+    background: var(--app-action);
+    color: var(--app-on-action, #fff);
+  }
+
+  .pk-seg--sm & {
+    height: 26px;
+    padding: 0 12px;
+    font-size: var(--text-micro);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pk-seg__btn { transition: none; }
+}

--- a/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-segmented/pk-segmented.component.ts
@@ -1,0 +1,47 @@
+import { Component, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+export interface PkSegmentedOption {
+  label: string;
+  value: any;
+  disabled?: boolean;
+}
+
+/**
+ * Alternador de um valor entre poucas opções — período, escopo, recorte.
+ *
+ * É o seletor de mês do design da Área do Cliente (Mai · Jun · Jul · Ago) e
+ * serve também para os "7 / 30 / 90 dias" que os hubs internos escrevem à mão.
+ *
+ * Não é `ControlValueAccessor` de propósito: isto controla o estado de uma
+ * tela, não um campo de formulário. `[(value)]` funciona pelo par
+ * `value`/`valueChange`, sem trazer o peso de um campo junto.
+ *
+ * Para muitas opções, use `pk-combobox` — uma tira com dez botões não cabe em
+ * celular e vira rolagem horizontal escondida.
+ */
+@Component({
+  selector: 'pk-segmented',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './pk-segmented.component.html',
+  styleUrl: './pk-segmented.component.scss',
+})
+export class PkSegmentedComponent {
+
+  options = input<PkSegmentedOption[]>([]);
+  value = input<any>(null);
+
+  /** Ocupa a largura toda, dividindo igualmente — o padrão no celular. */
+  fill = input<boolean>(false);
+
+  size = input<'sm' | 'md'>('md');
+  ariaLabel = input<string>('');
+
+  valueChange = output<any>();
+
+  select(option: PkSegmentedOption): void {
+    if (option.disabled || option.value === this.value()) return;
+    this.valueChange.emit(option.value);
+  }
+}


### PR DESCRIPTION
Cartão, indicador, barra, seletor de período e estado vazio existiam copiados
em CSS nos quatro hubs, com três vocabulários diferentes para a mesma barra
(.rank no estoque e no abastecimento, .dist nas máquinas, .dist-item no RH).
Viram pk-card, pk-kpi, pk-bar, pk-segmented e pk-empty.

O Hub do Estoque passa a consumi-los e perde 120 linhas de CSS. Isso não é só
limpeza: componente que ninguém importa não é compilado pelo Angular, então
sem um consumidor real o build passa mesmo com o template quebrado — testei
trocando uma propriedade por uma inexistente e a compilação seguiu verde.

pk-kpi recebe o valor já formatado: quem sabe se é moeda, litro ou hora é a
tela. E `loading` mostra traço em vez de zero, porque zero e "ainda não
respondeu" são coisas diferentes para quem está lendo.

pk-bar e pk-kpi quebram a linha no celular em vez de espremer três colunas em
390px — o desenho da área do cliente é mobile primeiro e essas peças são a
base dele.
