### PR TITLE
feat(newsletter): aceita csv no upload da planilha

### DIFF
--- a/src/app/components/auth/communication/newsletter/newsletter.component.html
+++ b/src/app/components/auth/communication/newsletter/newsletter.component.html
@@ -41,8 +41,8 @@
               [customUpload]="true"
               (uploadHandler)="onUpload($event)"
               fileLimit="1"
-              accept=".xlsx"
-              maxFileSize="1000000"
+              accept=".xlsx,.csv"
+              maxFileSize="5000000"
               mode="advanced"
               chooseLabel="Selecionar Arquivos"
               uploadLabel="Enviar"
@@ -53,7 +53,7 @@
                   <div class="p-text-center">
                     <i class="pi pi-upload" style="font-size: 2em; color: #888;"></i>
                     <p class="p-mt-2" style="color: #888;">Arraste e solte os arquivos aqui ou clique para selecionar</p>
-                    <p style="color: #888; font-size: 0.9em;">(Máx. 1 arquivos .xlsx)</p>
+                    <p style="color: #888; font-size: 0.9em;">(1 arquivo .xlsx ou .csv)</p>
                   </div>
                 </div>
               </ng-template>


### PR DESCRIPTION
A API passou a ler os dois formatos pela mesma fonte, mas a tela só deixava
escolher .xlsx — o csv nem aparecia no seletor de arquivos.

O limite subiu de 1 MB para 5 MB porque csv é texto puro: o arquivo de julho
tem 894 clientes e ocupa 260 KB em csv contra 116 KB em xlsx, então o teto
antigo travaria por volta de 3.500 clientes.
