### PR TITLE
feat(rh): décimo terceiro em duas parcelas

### DIFF
--- a/src/app/components/auth/documents/holerite-envio/holerite-envio.component.html
+++ b/src/app/components/auth/documents/holerite-envio/holerite-envio.component.html
@@ -17,18 +17,15 @@
     <div class="envio__campo">
       <label>Tipo</label>
       <div class="envio__tipos">
-        <button type="button"
-                class="envio__tipo"
-                [class.envio__tipo--ativo]="tipo() === 'SALARIO'"
-                (click)="tipo.set('SALARIO'); voltarParaEscolha()">
-          Salário
-        </button>
-        <button type="button"
-                class="envio__tipo"
-                [class.envio__tipo--ativo]="tipo() === 'ADIANTAMENTO'"
-                (click)="tipo.set('ADIANTAMENTO'); voltarParaEscolha()">
-          Adiantamento
-        </button>
+        @for (item of tipos; track item.value) {
+          <button type="button"
+                  class="envio__tipo"
+                  [class.envio__tipo--ativo]="tipo() === item.value"
+                  [title]="item.label"
+                  (click)="tipo.set(item.value); voltarParaEscolha()">
+            <i [class]="item.icon"></i> {{ item.curto }}
+          </button>
+        }
       </div>
     </div>
 

--- a/src/app/components/auth/documents/holerite-envio/holerite-envio.component.ts
+++ b/src/app/components/auth/documents/holerite-envio/holerite-envio.component.ts
@@ -7,6 +7,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { RouterLink } from '@angular/router';
 
 import {
+  HOLERITE_TIPOS,
   HOLERITE_TIPO_LABEL,
   HoleritePreviewItem,
   HoleritePreviewStatus,
@@ -59,6 +60,7 @@ export class HoleriteEnvioComponent {
 
   readonly statusInfo = PREVIEW_STATUS_INFO;
   readonly tipoLabel = HOLERITE_TIPO_LABEL;
+  readonly tipos = HOLERITE_TIPOS;
 
   /** Quantas páginas em cada situação — alimenta o resumo e o texto da confirmação. */
   readonly contagem = computed(() => {

--- a/src/app/components/auth/holerites/holerites.component.html
+++ b/src/app/components/auth/holerites/holerites.component.html
@@ -20,16 +20,14 @@
               (click)="setFiltro('TODOS')">
         Todos
       </button>
-      <button class="hl-filter"
-              [class.hl-filter--active]="filtro() === 'SALARIO'"
-              (click)="setFiltro('SALARIO')">
-        <i class="pi pi-wallet"></i> Salário
-      </button>
-      <button class="hl-filter"
-              [class.hl-filter--active]="filtro() === 'ADIANTAMENTO'"
-              (click)="setFiltro('ADIANTAMENTO')">
-        <i class="pi pi-calendar"></i> Adiantamento
-      </button>
+      @for (item of tipos; track item.value) {
+        <button class="hl-filter"
+                [class.hl-filter--active]="filtro() === item.value"
+                [title]="item.label"
+                (click)="setFiltro(item.value)">
+          <i [class]="item.icon"></i> {{ item.curto }}
+        </button>
+      }
     </div>
   }
 
@@ -80,7 +78,8 @@
                   <span class="hl-card__comp">{{ mesLabel(h.competencia) }}</span>
                   <span class="hl-card__meta">
                     <span class="hl-card__badge"
-                          [class.hl-card__badge--adiant]="h.tipo === 'ADIANTAMENTO'">
+                          [class.hl-card__badge--adiant]="h.tipo === 'ADIANTAMENTO'"
+                          [class.hl-card__badge--decimo]="h.tipo.startsWith('DECIMO')">
                       {{ tipoLabel(h.tipo) }}
                     </span>
                     <span class="hl-card__date">{{ h.createdAt | date:'dd/MM/yyyy' }}</span>

--- a/src/app/components/auth/holerites/holerites.component.scss
+++ b/src/app/components/auth/holerites/holerites.component.scss
@@ -257,6 +257,13 @@
       background: color-mix(in srgb, var(--app-warning) 16%, transparent);
       color: var(--app-warning);
     }
+
+    // O 13º precisa de cor própria: sem isso ele sai verde, igual a salário, e
+    // na lista do ano os dois ficam indistinguíveis de relance.
+    &--decimo {
+      background: color-mix(in srgb, var(--app-action) 14%, transparent);
+      color: var(--app-action);
+    }
   }
 
   &__date {

--- a/src/app/components/auth/holerites/holerites.component.ts
+++ b/src/app/components/auth/holerites/holerites.component.ts
@@ -4,17 +4,14 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { animate, style, transition, trigger, query, stagger } from '@angular/animations';
 import { PageHeaderComponent } from '../shared/page-header/page-header.component';
+import {
+  HOLERITE_TIPOS,
+  HOLERITE_TIPO_LABEL,
+  Holerite,
+  HoleriteTipo,
+} from '../../../domain/models/hr/holerite.model';
 
-type HoleriteTipo = 'ADIANTAMENTO' | 'SALARIO';
 type Filtro = 'TODOS' | HoleriteTipo;
-
-interface Holerite {
-  id: string;
-  competencia: string;
-  tipo: HoleriteTipo;
-  originalFilename: string;
-  createdAt: string;
-}
 
 interface GrupoAno {
   ano: string;
@@ -46,6 +43,9 @@ export class HoleritesComponent implements OnInit {
   erro = signal(false);
   baixandoId = signal<string | null>(null);
   filtro = signal<Filtro>('TODOS');
+
+  /** Os mesmos tipos do envio, na mesma ordem — uma lista só para as duas telas. */
+  readonly tipos = HOLERITE_TIPOS;
 
   private readonly meses = [
     'Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho',
@@ -98,7 +98,7 @@ export class HoleritesComponent implements OnInit {
   }
 
   tipoLabel(tipo: HoleriteTipo): string {
-    return tipo === 'ADIANTAMENTO' ? 'Adiantamento' : 'Salário';
+    return HOLERITE_TIPO_LABEL[tipo] ?? tipo;
   }
 
   setFiltro(f: Filtro): void {

--- a/src/app/domain/models/hr/holerite.model.ts
+++ b/src/app/domain/models/hr/holerite.model.ts
@@ -6,12 +6,38 @@
  * quebrava.
  */
 
-export type HoleriteTipo = 'SALARIO' | 'ADIANTAMENTO';
+export type HoleriteTipo =
+  | 'SALARIO'
+  | 'ADIANTAMENTO'
+  | 'DECIMO_TERCEIRO_1'
+  | 'DECIMO_TERCEIRO_2';
 
-export const HOLERITE_TIPO_LABEL: Record<HoleriteTipo, string> = {
-  SALARIO: 'Salário',
-  ADIANTAMENTO: 'Adiantamento',
-};
+/**
+ * Os tipos na ordem em que aparecem para escolher, com o rótulo curto do botão
+ * e o completo do resto.
+ *
+ * Uma lista só: o seletor do envio, o filtro do funcionário e o texto da
+ * confirmação leem daqui. Antes eram três lugares com o mesmo ternário, e o do
+ * aviso de notificação já chamava qualquer coisa de "salário".
+ *
+ * O mês de cada parcela do 13º não está aqui de propósito — quem diz o mês é a
+ * competência escolhida no envio. Fixar novembro e dezembro no código quebraria
+ * no ano em que o RH pagar as duas juntas.
+ */
+export const HOLERITE_TIPOS: ReadonlyArray<{
+  value: HoleriteTipo;
+  label: string;
+  curto: string;
+  icon: string;
+}> = [
+  { value: 'SALARIO',           label: 'Salário',          curto: 'Salário',      icon: 'pi pi-wallet' },
+  { value: 'ADIANTAMENTO',      label: 'Adiantamento',     curto: 'Adiantamento', icon: 'pi pi-calendar' },
+  { value: 'DECIMO_TERCEIRO_1', label: '13º — 1ª parcela', curto: '13º · 1ª',     icon: 'pi pi-gift' },
+  { value: 'DECIMO_TERCEIRO_2', label: '13º — 2ª parcela', curto: '13º · 2ª',     icon: 'pi pi-gift' },
+];
+
+export const HOLERITE_TIPO_LABEL: Record<HoleriteTipo, string> =
+  Object.fromEntries(HOLERITE_TIPOS.map(t => [t.value, t.label])) as Record<HoleriteTipo, string>;
 
 /**
  * O que vai acontecer com cada página do PDF, decidido pelo servidor.


### PR DESCRIPTION
Os dois tipos novos entram na mesma lista que o seletor do envio, o filtro do
funcionário e o texto da confirmação já leem. Eram três lugares repetindo o
mesmo ternário de dois valores — acrescentar um terceiro tipo em três lugares é
como o aviso de notificação passou a chamar qualquer coisa de "salário".

O mês de cada parcela não está no código de propósito. Quem diz o mês é a
competência escolhida no envio: fixar novembro e dezembro quebraria no ano em
que o RH pagar as duas juntas — e nesse ano as duas linhas continuam distintas,
porque o unique é por tipo.

O 13º ganha cor própria no badge do funcionário. Sem isso ele herdava o verde do
salário, e na lista do ano os dois ficavam iguais de relance.

A tela do funcionário passa a usar o modelo compartilhado: ela declarava o tipo,
a interface e o rótulo por conta própria, e ficaria dois tipos atrás sem
ninguém perceber.
