### PR TITLE
feat(produtos): escolher a foto do produto na galeria

### DIFF
--- a/src/app/components/auth/company/products/website/website.component.html
+++ b/src/app/components/auth/company/products/website/website.component.html
@@ -371,13 +371,34 @@
       <div class="form-grid">
         <div class="form-field field-full">
           <label for="imagemEdit">Trocar imagem</label>
-          <input
-            id="imagemEdit"
-            type="file"
-            accept="image/*"
-            class="file-input"
-            (change)="onEditImageSelected($event)" />
+          <!--
+            Duas portas para a mesma coisa. Escolher da galeria não aponta o
+            produto para lá: a API copia os bytes para /upload/images, que é a
+            pasta pública e a que o guia lê do disco.
+          -->
+          <div class="imagem-origens">
+            <input
+              #inputImagemEdit
+              id="imagemEdit"
+              type="file"
+              accept="image/*"
+              class="file-input"
+              (change)="onEditImageSelected($event)" />
+
+            <pk-button
+              pkType="filter"
+              pkSize="sm"
+              pkLabel="Escolher da galeria"
+              (clicked)="galeriaEditAberta.set(true)" />
+          </div>
         </div>
+
+        <app-gallery-picker
+          [visible]="galeriaEditAberta()"
+          categoria="PRODUCT"
+          titulo="Fotos de produto na galeria"
+          (visibleChange)="galeriaEditAberta.set($event)"
+          (escolhido)="onGaleriaEscolhidaEdit($event)" />
 
         @if (editingProduct()?.imagem && !editImagePreview) {
           <div class="form-field field-full">
@@ -620,13 +641,34 @@
       <div class="form-grid">
         <div class="form-field field-full">
           <label for="imagemCreate">Adicionar imagem</label>
-          <input
-            id="imagemCreate"
-            type="file"
-            accept="image/*"
-            class="file-input"
-            (change)="onCreateImageSelected($event)" />
+          <!--
+            Duas portas para a mesma coisa. Escolher da galeria não aponta o
+            produto para lá: a API copia os bytes para /upload/images, que é a
+            pasta pública e a que o guia lê do disco.
+          -->
+          <div class="imagem-origens">
+            <input
+              #inputImagemCreate
+              id="imagemCreate"
+              type="file"
+              accept="image/*"
+              class="file-input"
+              (change)="onCreateImageSelected($event)" />
+
+            <pk-button
+              pkType="filter"
+              pkSize="sm"
+              pkLabel="Escolher da galeria"
+              (clicked)="galeriaCreateAberta.set(true)" />
+          </div>
         </div>
+
+        <app-gallery-picker
+          [visible]="galeriaCreateAberta()"
+          categoria="PRODUCT"
+          titulo="Fotos de produto na galeria"
+          (visibleChange)="galeriaCreateAberta.set($event)"
+          (escolhido)="onGaleriaEscolhidaCreate($event)" />
 
         @if (createImagePreview) {
           <div class="form-field field-full">

--- a/src/app/components/auth/company/products/website/website.component.scss
+++ b/src/app/components/auth/company/products/website/website.component.scss
@@ -116,3 +116,12 @@
   background: var(--app-surface);
 }
 
+// As duas origens da foto lado a lado: enviar arquivo ou escolher da galeria.
+.imagem-origens {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  flex-wrap: wrap;
+
+  .file-input { flex: 1 1 260px; }
+}

--- a/src/app/components/auth/company/products/website/website.component.ts
+++ b/src/app/components/auth/company/products/website/website.component.ts
@@ -3,9 +3,10 @@ import { FormScreenComponent } from '../../../shared/form-screen/form-screen.com
 import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
 import { PkCheckboxComponent } from '../../../../theme/ProautoKimium/pk-checkbox/pk-checkbox.component';
 import { PkColorPickerComponent } from '../../../../theme/ProautoKimium/pk-color-picker/pk-color-picker.component';
+import { GalleryEscolha, GalleryPickerComponent } from '../../../shared/gallery-picker/gallery-picker.component';
 import { PkSegmentedComponent, PkSegmentedOption } from '../../../../theme/ProautoKimium/pk-segmented/pk-segmented.component';
 import { TabDirtyCheck } from '../../../../../infrastructure/routing/tab-dirty-check';
-import { Component, OnInit, signal, computed, inject } from '@angular/core';
+import { Component, ElementRef, OnInit, signal, computed, inject, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
 
@@ -65,6 +66,7 @@ export type FiltroProduto = 'todos' | 'publicados' | 'ocultos';
     ToolbarComponent,
     FormScreenComponent,
     PkButtonComponent,
+    GalleryPickerComponent,
     PkCheckboxComponent,
     PkColorPickerComponent,
     PkSegmentedComponent,
@@ -103,6 +105,25 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
   selectedEditImage: File | null = null;
   createImagePreview: string | null = null;
   editImagePreview: string | null = null;
+
+  /**
+   * O diálogo da galeria, um por formulário.
+   *
+   * Os dois formulários coexistem no template — `mode()` decide qual aparece —
+   * então um sinal só faria o diálogo abrir nos dois ao mesmo tempo.
+   */
+  readonly galeriaCreateAberta = signal(false);
+  readonly galeriaEditAberta = signal(false);
+
+  /**
+   * Referência ao `<input type="file">` para poder zerar o valor dele.
+   *
+   * Escolher da galeria depois de ter escolhido um arquivo precisa apagar o
+   * nome que o navegador mostra ao lado do botão — senão a tela afirma que vai
+   * subir um arquivo que já foi descartado.
+   */
+  private readonly inputImagemCreate = viewChild<ElementRef<HTMLInputElement>>('inputImagemCreate');
+  private readonly inputImagemEdit = viewChild<ElementRef<HTMLInputElement>>('inputImagemEdit');
 
   /** Equipamentos disponíveis para vincular ao produto (1 por produto). */
   equipamentos = signal<EquipmentResponseDTO[]>([]);
@@ -178,6 +199,9 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
       descricao: ['', Validators.required],
       descricaoGuia: [''],
       equipmentId: [null],
+      // Só é preenchido quando a foto vem da galeria. A API copia os bytes a
+      // partir daqui; arquivo enviado tem precedência sobre este campo.
+      galleryDocumentId: [null],
     });
   }
 
@@ -199,6 +223,7 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
       descricao: ['', Validators.required],
       descricaoGuia: [''],
       equipmentId: [null],
+      galleryDocumentId: [null],
     });
   }
 
@@ -238,6 +263,7 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
       descricao: '',
       descricaoGuia: '',
       equipmentId: null,
+      galleryDocumentId: null,
     });
 
     this.selectedCreateImage = null;
@@ -268,6 +294,9 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
       descricao: product.descricao,
       descricaoGuia: product.descricaoGuia ?? '',
       equipmentId: product.equipmentId ?? null,
+      // Sempre nulo ao abrir: escolher da galeria é uma ação desta edição, não
+      // um estado do produto. O produto guarda a cópia, não a origem.
+      galleryDocumentId: null,
     });
 
     this.mode.set('edit');
@@ -410,6 +439,32 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
 
     this.selectedCreateImage = file;
     this.createImagePreview = file ? URL.createObjectURL(file) : null;
+
+    // A API daria precedência ao arquivo de qualquer forma, mas deixar os dois
+    // marcados na tela é mentira: some com a escolha da galeria.
+    if (file) this.createForm.get('galleryDocumentId')?.setValue(null);
+  }
+
+  onGaleriaEscolhidaCreate(escolha: GalleryEscolha): void {
+    this.createForm.get('galleryDocumentId')?.setValue(escolha.documento.id);
+    this.createForm.markAsDirty();
+
+    this.selectedCreateImage = null;
+    this.createImagePreview = escolha.previewUrl;
+
+    const input = this.inputImagemCreate();
+    if (input) input.nativeElement.value = '';
+  }
+
+  onGaleriaEscolhidaEdit(escolha: GalleryEscolha): void {
+    this.editForm.get('galleryDocumentId')?.setValue(escolha.documento.id);
+    this.editForm.markAsDirty();
+
+    this.selectedEditImage = null;
+    this.editImagePreview = escolha.previewUrl;
+
+    const input = this.inputImagemEdit();
+    if (input) input.nativeElement.value = '';
   }
 
   onEditImageSelected(event: Event): void {
@@ -418,16 +473,26 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
 
     this.selectedEditImage = file;
     this.editImagePreview = file ? URL.createObjectURL(file) : null;
+
+    if (file) this.editForm.get('galleryDocumentId')?.setValue(null);
   }
 
   removerImagemCreate(): void {
     this.selectedCreateImage = null;
     this.createImagePreview = null;
+    this.createForm.get('galleryDocumentId')?.setValue(null);
+
+    const input = this.inputImagemCreate();
+    if (input) input.nativeElement.value = '';
   }
 
   removerImagemEdit(): void {
     this.selectedEditImage = null;
     this.editImagePreview = null;
+    this.editForm.get('galleryDocumentId')?.setValue(null);
+
+    const input = this.inputImagemEdit();
+    if (input) input.nativeElement.value = '';
   }
 
   isFieldInvalid(field: string): boolean {

--- a/src/app/components/auth/shared/gallery-picker/gallery-picker.component.html
+++ b/src/app/components/auth/shared/gallery-picker/gallery-picker.component.html
@@ -1,0 +1,99 @@
+<pk-dialog
+  [header]="titulo()"
+  [visible]="visible()"
+  width="820px"
+  (visibleChange)="fechar()">
+
+  <!-- pk-dialog zera o padding do conteúdo de propósito: o respiro vem daqui. -->
+  <div pkDialogContent class="pk-form-section">
+
+    <div class="gp-busca">
+      <i class="pi pi-search gp-busca__icone"></i>
+      <input
+        pInputText
+        class="gp-busca__campo"
+        placeholder="Buscar por título, descrição ou arquivo..."
+        [(ngModel)]="termo"
+        (input)="aplicarBusca()" />
+      @if (termo) {
+        <button type="button" class="gp-busca__limpar" (click)="limparBusca()">
+          <i class="pi pi-times"></i>
+        </button>
+      }
+    </div>
+
+    @if (carregando()) {
+      <div class="gp-grade">
+        @for (i of [1,2,3,4,5,6,7,8]; track i) {
+          <p-skeleton height="130px" borderRadius="10px" />
+        }
+      </div>
+    }
+
+    @if (erro()) {
+      <div class="gp-vazio">
+        <i class="pi pi-exclamation-triangle"></i>
+        <p>Não foi possível carregar a galeria.</p>
+      </div>
+    }
+
+    @if (!carregando() && !erro() && filtrados().length === 0) {
+      <div class="gp-vazio">
+        <i class="pi pi-images"></i>
+        @if (documentos().length === 0) {
+          <p>Nenhuma imagem nesta categoria da galeria ainda.</p>
+        } @else {
+          <p>Nada encontrado para "{{ termo }}".</p>
+        }
+      </div>
+    }
+
+    @if (!carregando() && filtrados().length > 0) {
+      <div class="gp-grade" role="listbox" [attr.aria-label]="titulo()">
+        @for (doc of filtrados(); track doc.id) {
+          <button
+            type="button"
+            class="gp-item"
+            role="option"
+            [class.gp-item--on]="selecionado() === doc.id"
+            [class.gp-item--quebrado]="quebrados().has(doc.id)"
+            [attr.aria-selected]="selecionado() === doc.id"
+            [disabled]="quebrados().has(doc.id)"
+            [title]="doc.title"
+            (click)="selecionar(doc)"
+            (dblclick)="selecionar(doc); confirmar()">
+
+            @if (quebrados().has(doc.id)) {
+              <!-- Registro no banco sem arquivo no disco. Dizer isso é melhor
+                   que um card em branco que parece uma imagem que não carregou. -->
+              <div class="gp-item__falha">
+                <i class="pi pi-image"></i>
+                <small>Arquivo ausente</small>
+              </div>
+            } @else if (miniaturas()[doc.id]) {
+              <img [src]="miniaturas()[doc.id]" [alt]="doc.title" class="gp-item__img" />
+            } @else {
+              <p-skeleton height="100%" borderRadius="0" />
+            }
+
+            <span class="gp-item__nome">{{ doc.title || doc.originalFilename }}</span>
+
+            @if (selecionado() === doc.id) {
+              <span class="gp-item__marca"><i class="pi pi-check"></i></span>
+            }
+          </button>
+        }
+      </div>
+    }
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" pkSize="sm" pkLabel="Cancelar" (clicked)="fechar()" />
+    <pk-button
+      pkType="save"
+      pkSize="sm"
+      pkLabel="Usar esta imagem"
+      [pkDisabled]="!selecionado()"
+      (clicked)="confirmar()" />
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/shared/gallery-picker/gallery-picker.component.scss
+++ b/src/app/components/auth/shared/gallery-picker/gallery-picker.component.scss
@@ -1,0 +1,147 @@
+@use 'variables' as v;
+
+.gp-busca {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.gp-busca__icone {
+  position: absolute;
+  left: .75rem;
+  font-size: .85rem;
+  color: var(--app-text-subtle);
+  pointer-events: none;
+}
+
+.gp-busca__campo {
+  width: 100%;
+  padding-left: 2.2rem;
+  padding-right: 2.2rem;
+}
+
+.gp-busca__limpar {
+  position: absolute;
+  right: .5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--app-text-subtle);
+  cursor: pointer;
+
+  &:hover { background: var(--app-surface-2); }
+}
+
+.gp-grade {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: .75rem;
+  // A galeria pode ter dezenas de artes: o diálogo tem altura fixa e quem rola
+  // é a grade. Sem isto o rodapé com o botão sai da tela.
+  max-height: 52vh;
+  overflow-y: auto;
+  padding: 2px;
+
+  @media (max-width: 520px) {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+}
+
+.gp-item {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border: 2px solid var(--app-border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--app-surface);
+  cursor: pointer;
+  transition: border-color .12s ease, transform .12s ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--app-action);
+    transform: translateY(-2px);
+  }
+
+  &--on {
+    border-color: var(--app-action);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--app-action) 22%, transparent);
+  }
+
+  &--quebrado {
+    cursor: not-allowed;
+    opacity: .6;
+  }
+}
+
+.gp-item__img {
+  width: 100%;
+  height: 110px;
+  object-fit: cover;
+  display: block;
+  background: var(--app-surface-2);
+}
+
+.gp-item__falha {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: .3rem;
+  height: 110px;
+  color: var(--app-text-subtle);
+  background: var(--app-surface-2);
+
+  i { font-size: 1.4rem; opacity: .5; }
+  small { font-size: .68rem; }
+}
+
+.gp-item__nome {
+  padding: .4rem .5rem;
+  font-size: .72rem;
+  line-height: 1.25;
+  text-align: left;
+  color: var(--app-action);
+  // Título longo não pode empurrar a altura do card e desalinhar a grade.
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.gp-item__marca {
+  position: absolute;
+  top: .35rem;
+  right: .35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--app-action);
+  color: #fff;
+
+  i { font-size: .7rem; }
+}
+
+.gp-vazio {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: .6rem;
+  padding: 3rem 1rem;
+  color: var(--app-text-subtle);
+
+  i { font-size: 2.2rem; opacity: .4; }
+  p { margin: 0; font-size: .88rem; }
+}

--- a/src/app/components/auth/shared/gallery-picker/gallery-picker.component.ts
+++ b/src/app/components/auth/shared/gallery-picker/gallery-picker.component.ts
@@ -1,0 +1,177 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, computed, effect, inject, input, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { InputTextModule } from 'primeng/inputtext';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import { GalleryCategory, GalleryDocument } from '../../../../domain/models/gallery.model';
+import { GalleryService } from '../../../../infrastructure/services/gallery/gallery.service';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+
+/** O que o pai recebe ao escolher: o id que vai para a API e o que mostrar na tela. */
+export interface GalleryEscolha {
+  documento: GalleryDocument;
+  previewUrl: string;
+}
+
+/**
+ * Escolher uma imagem já existente na galeria, em vez de subir a mesma arte
+ * duas vezes.
+ *
+ * **A miniatura não é uma URL, é um blob.** `GET /api/gallery/{id}/file` exige
+ * autenticação e responde `Content-Disposition: attachment` — um `<img src>`
+ * apontado para lá não renderiza nada. Por isso cada imagem é baixada pelo
+ * HttpClient (que carrega o token) e vira um object URL. É o mesmo caminho que
+ * a tela da galeria já faz.
+ *
+ * O filtro por categoria é feito aqui e não na API de propósito: o
+ * `GalleryDocumentResponseDTO` já devolve `category`, e o que trafega é
+ * metadado — as imagens são requisições separadas, e só as da categoria
+ * escolhida são baixadas.
+ *
+ * **Escolher aqui não aponta o produto para a galeria.** A API copia os bytes
+ * para o acervo do produto. Quem depende disso é a vitrine pública, que serve
+ * `/upload/images` sem autenticação, e o guia, que lê a imagem do disco.
+ */
+@Component({
+  selector: 'app-gallery-picker',
+  standalone: true,
+  imports: [CommonModule, FormsModule, InputTextModule, SkeletonModule,
+            PkDialogComponent, PkButtonComponent],
+  templateUrl: './gallery-picker.component.html',
+  styleUrl: './gallery-picker.component.scss',
+})
+export class GalleryPickerComponent implements OnDestroy {
+
+  private readonly galleryService = inject(GalleryService);
+
+  visible = input<boolean>(false);
+  categoria = input<GalleryCategory>('PRODUCT');
+  titulo = input<string>('Escolher da galeria');
+
+  visibleChange = output<boolean>();
+  escolhido = output<GalleryEscolha>();
+
+  readonly carregando = signal(false);
+  readonly erro = signal(false);
+  readonly documentos = signal<GalleryDocument[]>([]);
+  readonly miniaturas = signal<Record<string, string>>({});
+
+  /** Registro que existe no banco e não no disco — o card fica cinza em vez de girar para sempre. */
+  readonly quebrados = signal<Set<string>>(new Set());
+
+  readonly selecionado = signal<string | null>(null);
+
+  termo = '';
+  private readonly buscaTrigger = signal(0);
+
+  private jaCarregou = false;
+
+  constructor() {
+    // Carrega só ao abrir pela primeira vez. Baixar a galeria inteira no
+    // ngOnInit custaria uma requisição por imagem numa tela onde talvez
+    // ninguém clique no botão.
+    effect(() => {
+      if (this.visible() && !this.jaCarregou) {
+        this.jaCarregou = true;
+        this.carregar();
+      }
+    });
+  }
+
+  readonly filtrados = computed(() => {
+    this.buscaTrigger();
+
+    const termo = this.termo.toLowerCase().trim();
+    const lista = this.documentos();
+    if (!termo) return lista;
+
+    return lista.filter(d =>
+      (d.title ?? '').toLowerCase().includes(termo) ||
+      (d.description ?? '').toLowerCase().includes(termo) ||
+      (d.originalFilename ?? '').toLowerCase().includes(termo)
+    );
+  });
+
+  private carregar(): void {
+    this.carregando.set(true);
+    this.erro.set(false);
+
+    this.galleryService.list().subscribe({
+      next: (todos) => {
+        const daCategoria = (todos ?? []).filter(d =>
+          d.category === this.categoria() && this.ehImagem(d)
+        );
+
+        this.documentos.set(daCategoria);
+        this.carregando.set(false);
+        this.baixarMiniaturas(daCategoria);
+      },
+      error: () => {
+        this.erro.set(true);
+        this.carregando.set(false);
+      },
+    });
+  }
+
+  private baixarMiniaturas(docs: GalleryDocument[]): void {
+    for (const doc of docs) {
+      this.galleryService.download(doc.id).subscribe({
+        next: (blob) => {
+          const url = URL.createObjectURL(blob);
+          this.miniaturas.update(mapa => ({ ...mapa, [doc.id]: url }));
+        },
+        error: () => this.quebrados.update(set => new Set(set).add(doc.id)),
+      });
+    }
+  }
+
+  private ehImagem(doc: GalleryDocument): boolean {
+    return !!doc.contentType?.startsWith('image/');
+  }
+
+  selecionar(doc: GalleryDocument): void {
+    if (this.quebrados().has(doc.id)) return;
+    this.selecionado.set(doc.id);
+  }
+
+  confirmar(): void {
+    const id = this.selecionado();
+    if (!id) return;
+
+    const documento = this.documentos().find(d => d.id === id);
+    const previewUrl = this.miniaturas()[id];
+    if (!documento || !previewUrl) return;
+
+    this.escolhido.emit({ documento, previewUrl });
+    this.fechar();
+  }
+
+  fechar(): void {
+    this.selecionado.set(null);
+    this.visibleChange.emit(false);
+  }
+
+  aplicarBusca(): void {
+    this.buscaTrigger.update(v => v + 1);
+  }
+
+  limparBusca(): void {
+    this.termo = '';
+    this.aplicarBusca();
+  }
+
+  /**
+   * Object URL é memória presa até alguém soltar.
+   *
+   * A escolhida não é revogada aqui: o pai está usando ela como preview, e
+   * revogar deixaria a imagem quebrada na tela dele.
+   */
+  ngOnDestroy(): void {
+    const escolhida = this.selecionado();
+    for (const [id, url] of Object.entries(this.miniaturas())) {
+      if (id !== escolhida) URL.revokeObjectURL(url);
+    }
+  }
+}

--- a/src/app/domain/models/products.model.ts
+++ b/src/app/domain/models/products.model.ts
@@ -58,6 +58,14 @@ export interface ProductWebSiteCreateDTO{
   descricao: string;
   descricaoGuia?: string;
   equipmentId?: string | null;
+  /**
+   * Preenchido só quando a foto veio da galeria.
+   *
+   * A API copia os bytes para o acervo do produto a partir daqui — o produto
+   * guarda a cópia, nunca um ponteiro para a galeria. Arquivo enviado no
+   * multipart tem precedência sobre este campo.
+   */
+  galleryDocumentId?: string | null;
 }
 
 export interface ProductWebSiteUpdateDTO{
@@ -71,6 +79,7 @@ export interface ProductWebSiteUpdateDTO{
   descricao: string;
   descricaoGuia?: string;
   equipmentId?: string | null;
+  galleryDocumentId?: string | null;
 }
 
 export interface ProductWebSiteResponseDTO{


### PR DESCRIPTION
A mesma arte era enviada duas vezes: uma para a galeria, outra para o produto.
Agora o formulário tem duas portas para a foto — enviar arquivo, como sempre,
ou escolher uma imagem que já está na galeria.

A miniatura não é uma URL, e essa é a razão de existir um componente em vez de
uma tag <img>. O `GET /api/gallery/{id}/file` exige autenticação e responde
Content-Disposition: attachment — um src apontado para lá não renderiza nada.
Cada imagem é baixada pelo HttpClient, que carrega o token, e vira object URL.
É o mesmo caminho que a tela da galeria já faz.

O filtro por categoria fica aqui: o DTO da galeria já devolve `category`, e o
que trafega é metadado. Só as imagens da categoria escolhida são baixadas.

As duas origens se excluem na tela. A API dá precedência ao arquivo enviado de
qualquer forma, mas deixar as duas marcadas seria mentira: escolher da galeria
limpa o input de arquivo, e escolher um arquivo limpa o galleryDocumentId.

`galleryDocumentId` nasce nulo ao abrir a edição de propósito — escolher da
galeria é uma ação daquela edição, não um estado do produto. O produto guarda
a cópia dos bytes, nunca a origem.

Registro órfão (existe no banco, não no disco) aparece marcado como "Arquivo
ausente" e não é clicável, em vez de virar um card branco que parece imagem
que não carregou.
