### PR TITLE
fix(shell): remove a media query duplicada do auth-layout

### DIFF
--- a/src/app/layouts/auth-layout/auth-layout.component.scss
+++ b/src/app/layouts/auth-layout/auth-layout.component.scss
@@ -42,13 +42,8 @@
   }
 }
 
-@media (max-width: v.$bp-md) {
-  .app-content {
-    padding-bottom: calc(var(--bottom-nav-h) + env(safe-area-inset-bottom));
-  }
-}
-
-// Respiro para o conteúdo não ficar atrás do bottom nav no mobile.
+// No mobile a barra de abas some e entra o bottom nav; o respiro embaixo é
+// para o conteúdo não ficar atrás dele.
 @media (max-width: v.$bp-md) {
   .app-content {
     padding-bottom: calc(var(--bottom-nav-h) + env(safe-area-inset-bottom));


### PR DESCRIPTION
O mesmo `@media (max-width: $bp-md)` com o mesmo `padding-bottom` aparecia duas
vezes seguidas no auth-layout. Cópia byte a byte — a segunda tinha o comentário
explicando o porquê, a primeira não tinha nada.

Sem efeito visual: duas regras idênticas na mesma especificidade produzem o
mesmo resultado. O que ela custava era leitura — quem fosse ajustar o respiro do
bottom nav mexeria numa e continuaria vendo o valor antigo aplicado pela outra.

Ficou uma, com o comentário.
