### PR TITLE
feature/certificados em lote

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,6 +17,11 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
+            "allowedCommonJsDependencies": [
+              "@stomp/stompjs",
+              "qrcode",
+              "quill-delta"
+            ],
             "outputPath": {
               "base": "dist/proauto-kimium"
             },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -103,6 +103,7 @@ export const routes: Routes = [
       { path: 'tools/pdf', loadComponent: () => import('./components/auth/tools/pdf/pdf-hub/pdf-hub.component').then(m => m.PdfHubComponent) },
       { path: 'tools/pdf/unlock', loadComponent: () => import('./components/auth/tools/pdf/pdf-unlock/pdf-unlock.component').then(m => m.PdfUnlockComponent) },
       { path: 'tools/pdf/nfse-rename', loadComponent: () => import('./components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component').then(m => m.PdfNfseRenameComponent) },
+      { path: 'tools/certificados', loadComponent: () => import('./components/auth/tools/certificates/certificate-batch/certificate-batch.component').then(m => m.CertificateBatchComponent), data: { roles: ['ADMIN'] } },
 
       // ── Empresa ──────────────────────────────────────────────────────────
       { path: 'company/nfe-collector', loadComponent: () => import('./components/auth/documents/nfe-data-collector/nfe-data-collector.component').then(m => m.NfeDataCollectorComponent), data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.html
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.html
@@ -1,0 +1,89 @@
+<p-toast position="top-right" />
+
+<div class="tool-screen">
+
+  <app-page-header
+    icon="pi pi-verified"
+    title="Certificados em lote"
+    subtitle="Um nome por linha, um certificado para cada, tudo num ZIP" />
+
+  <div class="tool-screen__panel">
+
+    <div class="lote-campo">
+      <label for="nomes">Nomes</label>
+      <textarea
+        id="nomes"
+        pTextarea
+        rows="12"
+        class="lote-campo__texto"
+        placeholder="Ana Souza&#10;Bruno Lima&#10;Carla Dias"
+        [ngModel]="texto()"
+        (ngModelChange)="aoDigitar($event)"
+        [disabled]="gerando()"></textarea>
+      <small class="lote-campo__dica">
+        Cole a coluna direto do Excel. Uma linha, um nome.
+      </small>
+    </div>
+
+    <!--
+      O que a tela entendeu, antes de gerar. Colar uma coluna traz linha em
+      branco e nome repetido sem ninguém ver, e sem isto o erro só apareceria
+      dentro do ZIP — depois da espera.
+    -->
+    @if (analise().nomes.length > 0) {
+      <div class="lote-resumo">
+        <span class="lote-resumo__total">
+          <i class="pi pi-users"></i>
+          {{ analise().nomes.length }} {{ analise().nomes.length === 1 ? 'nome' : 'nomes' }}
+        </span>
+
+        @if (analise().linhasEmBranco > 0) {
+          <span class="lote-resumo__aviso">
+            <i class="pi pi-minus-circle"></i>
+            {{ analise().linhasEmBranco }} linha(s) em branco ignorada(s)
+          </span>
+        }
+
+        @if (analise().repetidos > 0) {
+          <span class="lote-resumo__aviso">
+            <i class="pi pi-clone"></i>
+            {{ analise().repetidos }} nome(s) repetido(s) — cada um gera o seu arquivo
+          </span>
+        }
+      </div>
+    }
+
+    @if (analise().excedente > 0) {
+      <p class="lote-erro">
+        <i class="pi pi-exclamation-triangle"></i>
+        {{ analise().nomes.length }} nomes, e o limite é {{ LIMITE }}.
+        Tire {{ analise().excedente }} ou gere em duas partes.
+      </p>
+    }
+
+    <div class="tool-screen__form">
+      <pk-button
+        pkType="download"
+        pkLabel="Gerar {{ analise().nomes.length || '' }} certificado(s) e baixar ZIP"
+        [pkDisabled]="!podeGerar()"
+        [pkLoading]="gerando()"
+        (clicked)="gerar()" />
+
+      @if (texto()) {
+        <pk-button
+          pkType="cancel"
+          pkLabel="Limpar"
+          [pkDisabled]="gerando()"
+          (clicked)="limpar()" />
+      }
+    </div>
+
+    <p class="tool-screen__note">
+      <i class="pi pi-info-circle"></i>
+      Estes certificados <strong>não geram registro</strong> — servem para
+      emissão em massa de treinamento. O certificado com validação continua na
+      página pública, um de cada vez.
+    </p>
+
+  </div>
+</div>

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.html
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.html
@@ -7,83 +7,97 @@
     title="Certificados em lote"
     subtitle="Um nome por linha, um certificado para cada, tudo num ZIP" />
 
-  <div class="tool-screen__panel">
+  <!--
+    Duas colunas no monitor, uma no celular. A entrada é alta e o resumo muda
+    enquanto se digita: lado a lado, a contagem fica no campo de visão de quem
+    está colando a lista, em vez de embaixo dela.
+  -->
+  <div class="tool-screen__panel lote-grade">
 
-    <div class="lote-campo">
+    <div class="lote-entrada">
       <label for="nomes">Nomes</label>
       <textarea
         id="nomes"
         pTextarea
-        rows="12"
-        class="lote-campo__texto"
+        class="lote-entrada__texto"
         placeholder="Ana Souza&#10;Bruno Lima&#10;Carla Dias"
         [ngModel]="texto()"
         (ngModelChange)="aoDigitar($event)"
         [disabled]="gerando()"></textarea>
-      <small class="lote-campo__dica">
+      <small class="lote-entrada__dica">
         Cole a coluna direto do Excel. Uma linha, um nome.
       </small>
     </div>
 
-    <!--
-      O que a tela entendeu, antes de gerar. Colar uma coluna traz linha em
-      branco e nome repetido sem ninguém ver, e sem isto o erro só apareceria
-      dentro do ZIP — depois da espera.
-    -->
-    @if (analise().nomes.length > 0) {
+    <aside class="lote-lateral">
+
+      <!--
+        O que a tela entendeu, antes de gerar. Colar uma coluna traz linha em
+        branco e nome repetido sem ninguém ver, e sem isto o erro só apareceria
+        dentro do ZIP — depois da espera.
+      -->
       <div class="lote-resumo">
-        <span class="lote-resumo__total">
-          <i class="pi pi-users"></i>
-          {{ analise().nomes.length }} {{ analise().nomes.length === 1 ? 'nome' : 'nomes' }}
-        </span>
+        <div class="lote-resumo__total">
+          <span class="lote-resumo__numero">{{ analise().nomes.length }}</span>
+          <span class="lote-resumo__rotulo">
+            {{ analise().nomes.length === 1 ? 'certificado' : 'certificados' }}
+          </span>
+        </div>
 
         @if (analise().linhasEmBranco > 0) {
-          <span class="lote-resumo__aviso">
+          <p class="lote-resumo__aviso">
             <i class="pi pi-minus-circle"></i>
             {{ analise().linhasEmBranco }} linha(s) em branco ignorada(s)
-          </span>
+          </p>
         }
 
         @if (analise().repetidos > 0) {
-          <span class="lote-resumo__aviso">
+          <p class="lote-resumo__aviso">
             <i class="pi pi-clone"></i>
             {{ analise().repetidos }} nome(s) repetido(s) — cada um gera o seu arquivo
-          </span>
+          </p>
+        }
+
+        @if (analise().nomes.length === 0) {
+          <p class="lote-resumo__aviso">
+            <i class="pi pi-arrow-left"></i>
+            Cole ou digite os nomes ao lado
+          </p>
         }
       </div>
-    }
 
-    @if (analise().excedente > 0) {
-      <p class="lote-erro">
-        <i class="pi pi-exclamation-triangle"></i>
-        {{ analise().nomes.length }} nomes, e o limite é {{ LIMITE }}.
-        Tire {{ analise().excedente }} ou gere em duas partes.
-      </p>
-    }
-
-    <div class="tool-screen__form">
-      <pk-button
-        pkType="download"
-        pkLabel="Gerar {{ analise().nomes.length || '' }} certificado(s) e baixar ZIP"
-        [pkDisabled]="!podeGerar()"
-        [pkLoading]="gerando()"
-        (clicked)="gerar()" />
-
-      @if (texto()) {
-        <pk-button
-          pkType="cancel"
-          pkLabel="Limpar"
-          [pkDisabled]="gerando()"
-          (clicked)="limpar()" />
+      @if (analise().excedente > 0) {
+        <p class="lote-erro">
+          <i class="pi pi-exclamation-triangle"></i>
+          {{ analise().nomes.length }} nomes, e o limite é {{ LIMITE }}.
+          Tire {{ analise().excedente }} ou gere em duas partes.
+        </p>
       }
-    </div>
 
-    <p class="tool-screen__note">
-      <i class="pi pi-info-circle"></i>
-      Estes certificados <strong>não geram registro</strong> — servem para
-      emissão em massa de treinamento. O certificado com validação continua na
-      página pública, um de cada vez.
-    </p>
+      <div class="lote-acoes">
+        <pk-button
+          pkType="download"
+          pkLabel="Gerar e baixar ZIP"
+          [pkDisabled]="!podeGerar()"
+          [pkLoading]="gerando()"
+          (clicked)="gerar()" />
 
+        @if (texto()) {
+          <pk-button
+            pkType="cancel"
+            pkLabel="Limpar"
+            [pkDisabled]="gerando()"
+            (clicked)="limpar()" />
+        }
+      </div>
+
+      <p class="tool-screen__note">
+        <i class="pi pi-info-circle"></i>
+        Estes certificados <strong>não geram registro</strong> — servem para
+        emissão em massa de treinamento. O certificado com validação continua na
+        página pública, um de cada vez.
+      </p>
+
+    </aside>
   </div>
 </div>

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
@@ -1,0 +1,76 @@
+@use 'variables' as v;
+@use 'tool-screen';
+
+.lote-campo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  label {
+    font-size: var(--text-ui-sm);
+    font-weight: 600;
+    color: var(--app-action);
+  }
+}
+
+.lote-campo__texto {
+  width: 100%;
+  // Nome é linha curta: quebrar automaticamente esconderia que a pessoa colou
+  // uma célula inteira numa linha só.
+  white-space: pre;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: var(--text-ui-sm);
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.lote-campo__dica {
+  color: var(--app-text-muted);
+  font-size: var(--text-ui-sm);
+}
+
+.lote-resumo {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: v.$space-4;
+  padding: 10px 14px;
+  border-radius: var(--radius-control);
+  background: var(--app-surface-2);
+  font-size: var(--text-ui-sm);
+
+  i { margin-right: 6px; }
+}
+
+.lote-resumo__total {
+  font-weight: 700;
+  color: var(--app-action);
+}
+
+.lote-resumo__aviso {
+  color: var(--app-text-muted);
+}
+
+.lote-erro {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: var(--radius-control);
+  background: var(--app-danger-soft, var(--app-surface-2));
+  color: var(--app-danger);
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+
+  i { margin-top: 2px; flex-shrink: 0; }
+}
+
+// O botão de gerar e o de limpar ficam lado a lado; o `tool-screen__form`
+// empilha por padrão, porque as outras ferramentas têm um controle só.
+.tool-screen__form {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: v.$space-3;
+}

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
@@ -48,10 +48,6 @@
   min-height: 260px;
   resize: vertical;
 
-  @media (min-width: v.$bp-lg) {
-    min-height: 420px;
-  }
-
   // Nome é linha curta. Quebrar automaticamente esconderia que a pessoa colou
   // uma célula inteira numa linha só.
   white-space: pre;
@@ -59,6 +55,13 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--text-ui-sm);
   line-height: 1.6;
+
+  // Regra aninhada por último, sempre. Declaração depois de bloco aninhado é o
+  // `mixed-decls` do Sass 1.77: a saída deixa de sair na ordem do código-fonte,
+  // e o que vem depois do @media pode acabar aplicado antes dele.
+  @media (min-width: v.$bp-lg) {
+    min-height: 420px;
+  }
 }
 
 .lote-entrada__dica {

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.scss
@@ -1,10 +1,38 @@
 @use 'variables' as v;
 @use 'tool-screen';
 
-.lote-campo {
+// A casca padrão é uma coluna de 720px centralizada. Isso funciona no celular,
+// onde ela ocupa a tela inteira, e numa ferramenta de um controle só. Aqui não:
+// no monitor, 720px no meio de 1920px lê como tela inacabada, não como
+// minimalismo — sobra espaço e o olho cobra o que fazer com ele.
+//
+// Esta tela tem duas coisas: uma entrada alta e um resumo que muda enquanto se
+// digita. Duas coisas cabem lado a lado quando há largura.
+.tool-screen {
+  @media (min-width: v.$bp-lg) {
+    max-width: 1120px;
+  }
+}
+
+// Mobile-first de verdade: a base é a coluna única, e a segunda coluna é o que
+// se acrescenta quando existe espaço — não o contrário.
+.lote-grade {
+  display: grid;
+  gap: v.$space-6;
+
+  @media (min-width: v.$bp-lg) {
+    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+// ─── Entrada ───────────────────────────────────────────────────────────────
+
+.lote-entrada {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  min-width: 0;
 
   label {
     font-size: var(--text-ui-sm);
@@ -13,43 +41,86 @@
   }
 }
 
-.lote-campo__texto {
+.lote-entrada__texto {
   width: 100%;
-  // Nome é linha curta: quebrar automaticamente esconderia que a pessoa colou
+  // Altura fixa em vez de `rows`: no monitor a lista tem que caber sem rolar a
+  // página, e no celular 14 linhas seriam a tela inteira.
+  min-height: 260px;
+  resize: vertical;
+
+  @media (min-width: v.$bp-lg) {
+    min-height: 420px;
+  }
+
+  // Nome é linha curta. Quebrar automaticamente esconderia que a pessoa colou
   // uma célula inteira numa linha só.
   white-space: pre;
   overflow-x: auto;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--text-ui-sm);
   line-height: 1.6;
-  resize: vertical;
 }
 
-.lote-campo__dica {
+.lote-entrada__dica {
   color: var(--app-text-muted);
   font-size: var(--text-ui-sm);
+}
+
+// ─── Lateral ───────────────────────────────────────────────────────────────
+
+.lote-lateral {
+  display: flex;
+  flex-direction: column;
+  gap: v.$space-5;
+  min-width: 0;
+
+  // Acompanha a rolagem quando a lista é longa: com 200 nomes, o botão sairia
+  // da tela e a pessoa rolaria de volta só para clicar.
+  @media (min-width: v.$bp-lg) {
+    position: sticky;
+    top: v.$space-6;
+  }
 }
 
 .lote-resumo {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: v.$space-4;
-  padding: 10px 14px;
-  border-radius: var(--radius-control);
+  flex-direction: column;
+  gap: v.$space-3;
+  padding: v.$space-5;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
   background: var(--app-surface-2);
-  font-size: var(--text-ui-sm);
-
-  i { margin-right: 6px; }
 }
 
 .lote-resumo__total {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.lote-resumo__numero {
+  font-size: 2.4rem;
   font-weight: 700;
+  line-height: 1;
   color: var(--app-action);
+  font-variant-numeric: tabular-nums;
+}
+
+.lote-resumo__rotulo {
+  font-size: var(--text-ui-sm);
+  color: var(--app-text-muted);
 }
 
 .lote-resumo__aviso {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
   color: var(--app-text-muted);
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+
+  i { margin-top: 3px; flex-shrink: 0; }
 }
 
 .lote-erro {
@@ -67,10 +138,15 @@
   i { margin-top: 2px; flex-shrink: 0; }
 }
 
-// O botão de gerar e o de limpar ficam lado a lado; o `tool-screen__form`
-// empilha por padrão, porque as outras ferramentas têm um controle só.
-.tool-screen__form {
-  flex-direction: row;
+.lote-acoes {
+  display: flex;
   flex-wrap: wrap;
   gap: v.$space-3;
+
+  // No celular o botão principal ocupa a linha: alvo grande, e a ordem de
+  // leitura já diz qual é o principal.
+  @media (max-width: v.$bp-sm) {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.ts
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.ts
@@ -1,0 +1,184 @@
+import { Component, computed, inject, signal } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { FormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { Toast } from 'primeng/toast';
+import { TextareaModule } from 'primeng/textarea';
+
+import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PageHeaderComponent } from '../../../shared/page-header/page-header.component';
+import { CertificateService } from '../../../../../infrastructure/services/certificate/certificate.service';
+import { downloadFileResponse } from '../../../../../infrastructure/services/tools/pdf-tools.service';
+
+/** O que a tela entendeu da lista colada, antes de mandar qualquer coisa. */
+interface AnaliseDaLista {
+  nomes: string[];
+  linhasEmBranco: number;
+  repetidos: number;
+  excedente: number;
+}
+
+/**
+ * Gera um certificado por nome e devolve tudo num ZIP.
+ *
+ * A entrada é um `textarea` de propósito: a lista quase sempre vem colada de
+ * uma coluna do Excel, e um campo por nome transformaria isso em cinquenta
+ * cliques. Uma linha, um nome.
+ *
+ * **A tela mostra o que entendeu antes de gerar.** Colar uma coluna traz linha
+ * em branco e nome repetido sem ninguém perceber, e o erro só apareceria no
+ * ZIP — depois de esperar a geração. Aqui a contagem aparece enquanto se
+ * digita, e o botão diz quantos certificados vai produzir.
+ *
+ * O limite de 200 é o mesmo da API. Ele existe porque o ZIP é montado em
+ * memória e PDF com imagem de fundo não comprime: o arquivo final é a soma dos
+ * PDFs. A tela bloqueia antes de chegar lá, mas a API recusa de qualquer
+ * forma — validação de tela é conforto, não defesa.
+ */
+@Component({
+  selector: 'app-certificate-batch',
+  standalone: true,
+  imports: [FormsModule, Toast, TextareaModule, PageHeaderComponent, PkButtonComponent],
+  templateUrl: './certificate-batch.component.html',
+  styleUrl: './certificate-batch.component.scss',
+  providers: [MessageService],
+})
+export class CertificateBatchComponent {
+
+  private readonly service = inject(CertificateService);
+  private readonly messageService = inject(MessageService);
+
+  /** O mesmo teto do `@Size` no CertificateBatchDTO. Mudou lá, muda aqui. */
+  readonly LIMITE = 200;
+
+  readonly texto = signal('');
+  readonly gerando = signal(false);
+
+  /**
+   * `texto` é signal, e não campo comum, porque este `computed` lê ele.
+   *
+   * `computed` só recalcula quando um **signal** que ele leu muda. Sobre um
+   * campo comum ele avaliaria uma vez, guardaria o primeiro valor e nunca mais
+   * atualizaria — sem erro de build e sem aviso no console. A tela ficaria
+   * parada mostrando "0 nomes" para sempre.
+   */
+  readonly analise = computed<AnaliseDaLista>(() => {
+    // `trim()` antes de dividir: quase toda colagem termina em Enter, e sem
+    // isso a tela acusaria uma linha em branco que ninguém digitou.
+    const linhas = this.texto().trim().split(/\r?\n/);
+
+    const nomes: string[] = [];
+    let linhasEmBranco = 0;
+
+    for (const linha of linhas) {
+      const nome = linha.trim();
+      if (!nome) {
+        linhasEmBranco++;
+        continue;
+      }
+      nomes.push(nome);
+    }
+
+    // Repetido não é erro: dois homônimos na mesma turma existem, e a API dá
+    // nome distinto para cada arquivo. É só um aviso, para o caso de a pessoa
+    // ter colado a mesma coluna duas vezes.
+    const vistos = new Set<string>();
+    let repetidos = 0;
+
+    for (const nome of nomes) {
+      const chave = nome.toLowerCase();
+      if (vistos.has(chave)) {
+        repetidos++;
+      } else {
+        vistos.add(chave);
+      }
+    }
+
+    return {
+      nomes,
+      linhasEmBranco,
+      repetidos,
+      excedente: Math.max(0, nomes.length - this.LIMITE),
+    };
+  });
+
+  readonly podeGerar = computed(() => {
+    const { nomes, excedente } = this.analise();
+    return nomes.length > 0 && excedente === 0 && !this.gerando();
+  });
+
+  aoDigitar(valor: string): void {
+    this.texto.set(valor);
+  }
+
+  limpar(): void {
+    this.texto.set('');
+  }
+
+  gerar(): void {
+    if (!this.podeGerar()) return;
+
+    const nomes = this.analise().nomes;
+    this.gerando.set(true);
+
+    this.service.generateBatch(nomes).subscribe({
+      next: (response) => {
+        this.gerando.set(false);
+
+        if (!downloadFileResponse(response, 'certificados.zip')) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Nenhum arquivo retornado',
+            detail: 'O servidor respondeu vazio. Nada foi baixado.',
+          });
+          return;
+        }
+
+        this.messageService.add({
+          severity: 'success',
+          summary: 'Certificados gerados',
+          detail: `${nomes.length} certificado(s) no ZIP. O download começou.`,
+        });
+      },
+      error: (err: HttpErrorResponse) => {
+        this.gerando.set(false);
+        this.mensagemDeErro(err).then(detail =>
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Não foi possível gerar',
+            detail,
+          })
+        );
+      },
+    });
+  }
+
+  /**
+   * A resposta é `blob`, então o corpo de erro também chega como Blob.
+   *
+   * Sem ler o Blob, um 400 viraria "dados inválidos" genérico e a mensagem que
+   * a API escreveu — "Máximo de 200 nomes por lote" — se perderia. Um 400 aqui
+   * significa que a conta da tela discordou da do servidor, e é justamente a
+   * hora de mostrar o que ele disse.
+   */
+  private async mensagemDeErro(err: HttpErrorResponse): Promise<string> {
+    if (err.status === 400 && err.error instanceof Blob) {
+      try {
+        const corpo = JSON.parse(await err.error.text());
+        if (corpo?.message) return corpo.message;
+      } catch {
+        // Corpo não era o ErrorResponse esperado: cai no texto por status.
+      }
+    }
+
+    switch (err.status) {
+      case 0:   return 'Sem conexão com o servidor.';
+      case 400: return 'A lista foi recusada pelo servidor.';
+      case 401:
+      case 403: return 'Só um administrador pode gerar certificados em lote.';
+      case 413: return 'O lote ficou grande demais. Tente em partes menores.';
+      case 503: return 'O gerador de certificados está indisponível. Tente em alguns minutos.';
+      default:  return 'Falha inesperada ao gerar os certificados.';
+    }
+  }
+}

--- a/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.html
+++ b/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.html
@@ -1,13 +1,13 @@
 <p-toast position="top-right" />
 
-<div class="pdf-tool">
+<div class="tool-screen">
 
   <app-page-header
     [icon]="tool.icon"
     [title]="tool.label"
     [subtitle]="tool.description" />
 
-  <div class="pdf-tool__panel">
+  <div class="tool-screen__panel">
 
     <pk-fileUpload
       mode="dropzone"
@@ -24,7 +24,7 @@
       (cleared)="onCleared()" />
 
     @if (files().length > 0) {
-      <div class="pdf-tool__form">
+      <div class="tool-screen__form">
         <pk-button
           pkType="download"
           pkLabel="Renomear e baixar ZIP"
@@ -34,7 +34,7 @@
       </div>
     }
 
-    <p class="pdf-tool__note">
+    <p class="tool-screen__note">
       <i class="pi pi-info-circle"></i>
       O nome de cada arquivo é montado a partir do conteúdo da própria nota, e o
       resultado volta num ZIP só. Os originais não são alterados.

--- a/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.scss
+++ b/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.scss
@@ -1,1 +1,1 @@
-@use 'pdf-tool';
+@use 'tool-screen';

--- a/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.html
+++ b/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.html
@@ -1,13 +1,13 @@
 <p-toast position="top-right" />
 
-<div class="pdf-tool">
+<div class="tool-screen">
 
   <app-page-header
     [icon]="tool.icon"
     [title]="tool.label"
     [subtitle]="tool.description" />
 
-  <div class="pdf-tool__panel">
+  <div class="tool-screen__panel">
 
     <pk-fileUpload
       mode="dropzone"
@@ -23,7 +23,7 @@
       (cleared)="onCleared()" />
 
     @if (file()) {
-      <div class="pdf-tool__form">
+      <div class="tool-screen__form">
         <!-- `new-password`, não `off`: o Chrome ignora `off` em campo de senha
              (sites abusaram disso) e preencheria a senha DA CONTA do usuário
              aqui. Se ele enviasse sem reparar, a senha pessoal iria para a API
@@ -44,7 +44,7 @@
       </div>
     }
 
-    <p class="pdf-tool__note">
+    <p class="tool-screen__note">
       <i class="pi pi-info-circle"></i>
       O arquivo é processado e devolvido na hora — nada fica guardado no servidor.
       Você precisa saber a senha: a ferramenta remove a proteção, não a descobre.

--- a/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.scss
+++ b/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.scss
@@ -1,1 +1,1 @@
-@use 'pdf-tool';
+@use 'tool-screen';

--- a/src/app/infrastructure/services/certificate/certificate.service.ts
+++ b/src/app/infrastructure/services/certificate/certificate.service.ts
@@ -30,4 +30,26 @@ export class CertificateService {
         }
       );
     }
+
+    /**
+     * Um certificado por nome, tudo num ZIP.
+     *
+     * `observe: 'response'` porque o nome do arquivo vem no Content-Disposition,
+     * e `responseType: 'blob'` porque o corpo é binário — inclusive quando dá
+     * erro, então a mensagem de validação chega como Blob e precisa ser lida.
+     *
+     * Só ADMIN: a API recusa o resto com 403. Os outros dois endpoints daqui
+     * são públicos, este não é — lista aberta ao público é derrubar o servidor
+     * com um `curl`.
+     */
+    generateBatch(names: string[]) {
+      return this.http.post(
+        `${environment.apiUrl}/certificate/batch`,
+        { names },
+        {
+          responseType: 'blob',
+          observe: 'response'
+        }
+      );
+    }
 }

--- a/src/app/layouts/auth-layout/menu.config.ts
+++ b/src/app/layouts/auth-layout/menu.config.ts
@@ -143,6 +143,7 @@ export const APP_MENU: AppMenuItem[] = [
     icon: 'pi pi-fw pi-wrench',
     items: [
       { label: 'PDF', icon: 'pi pi-fw pi-file-pdf', routerLink: ['tools/pdf'] },
+      { label: 'Certificados em lote', icon: 'pi pi-fw pi-verified', routerLink: ['tools/certificados'], roles: ['ADMIN'] },
     ],
   },
   {

--- a/src/styles/_tool-screen.scss
+++ b/src/styles/_tool-screen.scss
@@ -1,15 +1,18 @@
 @use 'variables' as v;
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Casca das telas de ferramenta de PDF
+// Casca das telas de ferramenta
 //
 // As ferramentas têm a mesma forma: cabeçalho, um painel estreito com a área
-// de upload e o controle da vez, e uma nota no rodapé. Fica aqui para as telas
-// não repetirem o mesmo SCSS — e para uma ferramenta nova nascer só com o que
-// tem de próprio.
+// de entrada e o controle da vez, e uma nota no rodapé. Fica aqui para as
+// telas não repetirem o mesmo SCSS — e para uma ferramenta nova nascer só com
+// o que tem de próprio.
+//
+// Chamava-se `pdf-tool` até a terceira ferramenta não ser de PDF. A forma
+// nunca teve nada de PDF; só o nome tinha.
 // ═══════════════════════════════════════════════════════════════════════════
 
-.pdf-tool {
+.tool-screen {
   max-width: 720px;
   margin: 0 auto;
   padding: v.$space-8;
@@ -17,7 +20,7 @@
   @media (max-width: v.$bp-md) { padding: v.$space-5; }
 }
 
-.pdf-tool__panel {
+.tool-screen__panel {
   display: flex;
   flex-direction: column;
   gap: v.$space-5;
@@ -30,7 +33,7 @@
 
 // O controle da vez só aparece depois do arquivo escolhido: sem arquivo, não
 // há o que configurar.
-.pdf-tool__form {
+.tool-screen__form {
   display: flex;
   flex-direction: column;
   gap: v.$space-4;
@@ -38,7 +41,7 @@
   pk-button { align-self: flex-start; }
 }
 
-.pdf-tool__note {
+.tool-screen__note {
   display: flex;
   align-items: flex-start;
   gap: 8px;
@@ -53,7 +56,7 @@
   i { margin-top: 2px; flex-shrink: 0; }
 }
 
-.pdf-tool__result {
+.tool-screen__result {
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
- **refactor(estilos): a casca de ferramenta deixa de se chamar pdf-tool**
- **feat(certificados): tela de geração em lote a partir de uma lista de nomes**
- **feat(certificados): duas colunas no monitor, uma no celular**
- **chore: zera os avisos do build de produção**
