### PR TITLE
feat(home): direção A — o topo carrega os números, e a cor volta

### DIFF
--- a/src/app/components/auth/auth-home/auth-home.component.html
+++ b/src/app/components/auth/auth-home/auth-home.component.html
@@ -1,29 +1,48 @@
 <div class="home">
 
   <!--
-    Faixa de uma linha. Era um banner de ~180px com gradiente e emoji, dizendo
-    "Boa tarde, Murillo" todo dia — a única informação da página que nunca muda,
-    ocupando o topo.
+    O topo é conteúdo, não enfeite: os números moram dentro dele.
+    Já foi um banner de gradiente que dizia "Boa tarde" e mais nada, e depois
+    uma linha de texto sobre uma borda. O primeiro não informava, o segundo não
+    ancorava a página. Este faz as duas coisas — e continua cheio no dia em que
+    não há pendência nenhuma, que é o dia mais comum.
   -->
-  <header class="topo">
-    <div class="topo__saudacao">
-      <h1 class="topo__titulo">{{ greeting }}@if (firstName) {, {{ firstName }}}</h1>
-      <p class="topo__data">{{ currentDate | date:'EEEE, d \'de\' MMMM':'':'pt-BR' }}</p>
-    </div>
+  <header class="hero">
+    <p class="hero__eyebrow">{{ currentDate | date:'EEEE, d \'de\' MMMM':'':'pt-BR' }}</p>
 
-    <div class="topo__chips">
-      @if (saldoFerias() !== null) {
-        <span class="topo__papel" title="Saldo de férias">
-          <i class="pi pi-sun"></i>{{ saldoFerias() }} dias de férias
-        </span>
+    <h1 class="hero__nome">
+      {{ greeting }}@if (firstName) {, <em>{{ firstName }}</em>}
+    </h1>
+
+    <div class="hero__nums">
+      <!--
+        Zero não vira "0 precisa de você". Vira "tudo em dia" — a mesma
+        informação, dita como estado desejado em vez de contagem vazia.
+      -->
+      @if (totalPendencias() > 0) {
+        <div class="hnum">
+          <span class="hnum__v">{{ totalPendencias() }}</span>
+          <span class="hnum__l">{{ totalPendencias() === 1 ? 'precisa de você' : 'precisam de você' }}</span>
+        </div>
+      } @else if (!resumoCarregando()) {
+        <div class="hnum">
+          <span class="hnum__v hnum__v--ok"><i class="pi pi-check"></i></span>
+          <span class="hnum__l">tudo em dia</span>
+        </div>
       }
 
       @if (notifications.unreadCount() > 0) {
-        <a routerLink="/notificacoes" class="topo__pendencia">
-          <i class="pi pi-bell"></i>
-          {{ notifications.unreadCount() }}
-          {{ notifications.unreadCount() === 1 ? 'não lida' : 'não lidas' }}
+        <a routerLink="/notificacoes" class="hnum hnum--link">
+          <span class="hnum__v">{{ notifications.unreadCount() }}</span>
+          <span class="hnum__l">{{ notifications.unreadCount() === 1 ? 'não lida' : 'não lidas' }}</span>
         </a>
+      }
+
+      @if (saldoFerias() !== null) {
+        <div class="hnum">
+          <span class="hnum__v">{{ saldoFerias() }}</span>
+          <span class="hnum__l">dias de férias</span>
+        </div>
       }
     </div>
   </header>
@@ -45,7 +64,9 @@
       <div class="pend-lista">
         @for (item of minhasPendencias(); track item.title + item.since) {
           <a [routerLink]="info(item).rota" class="pend-linha">
-            <span class="pend-linha__icone"><i [class]="info(item).icon"></i></span>
+            <span class="pend-linha__icone" [class]="'pend-linha__icone pend-linha__icone--' + info(item).accent">
+              <i [class]="info(item).icon"></i>
+            </span>
             <span class="pend-linha__corpo">
               <span class="pend-linha__titulo">{{ item.title }}</span>
               <span class="pend-linha__detalhe">{{ item.detail }}</span>
@@ -73,7 +94,9 @@
       <div class="pend-lista">
         @for (item of aprovacoes(); track item.title + item.detail + item.since) {
           <a [routerLink]="info(item).rota" class="pend-linha">
-            <span class="pend-linha__icone"><i [class]="info(item).icon"></i></span>
+            <span class="pend-linha__icone" [class]="'pend-linha__icone pend-linha__icone--' + info(item).accent">
+              <i [class]="info(item).icon"></i>
+            </span>
             <span class="pend-linha__corpo">
               <span class="pend-linha__titulo">{{ item.title }}</span>
               <span class="pend-linha__detalhe">{{ item.detail }}</span>

--- a/src/app/components/auth/auth-home/auth-home.component.scss
+++ b/src/app/components/auth/auth-home/auth-home.component.scss
@@ -1,13 +1,31 @@
 @use 'variables.scss' as v;
 
-// Sem `max-width`. A home era uma coluna de 1200px centralizada: num monitor
-// largo sobrava metade da tela vazia, e as notificações — a informação mais
-// perecível — ficavam abaixo da dobra, porque tudo era uma pilha vertical.
+// Cores por assunto nas pendências. Férias é âmbar, dinheiro é teal, documento
+// é navy — a mesma família de tokens do resto do sistema, só que usada.
+:host {
+  --pend-navy:  var(--app-action);
+  --pend-amber: var(--app-warning);
+  --pend-teal:  var(--app-success);
+}
+
+// A identidade da marca, cravada como no `client-dashboard`: degradê é
+// identidade, não tema, e por isso não sai dos tokens.
+:host {
+  --hero-gradiente: linear-gradient(148deg, #0e1538 0%, #202a65 52%, #14707f 100%);
+  --hero-teal: #00b9b3;
+}
+
+// O `max-width` tinha saído quando a página tinha dezenove cartões para
+// preencher. Sem eles, os painéis se esticavam por um monitor inteiro
+// segurando cinco linhas curtas. Voltou, e o `clamp` no padding é o mesmo
+// recurso do `client-dashboard`: respiro que acompanha a tela.
 .home {
-  padding: v.$space-8;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: v.$space-6 clamp(14px, 3vw, 40px) v.$space-8;
   display: flex;
   flex-direction: column;
-  gap: v.$space-8;
+  gap: v.$space-6;
 }
 
 // Notificações e avisos ocupam a faixa de cima, meia página cada.
@@ -26,10 +44,12 @@
   }
 }
 
-// Altura mínima igual nos dois: sem ela, "nenhum aviso" encolhe uma coluna e
-// as duas ficam desalinhadas justamente no caso mais comum.
+// O `min-height: 240px` saiu daqui. Ele existia para alinhar as duas colunas,
+// e o preço era vazio forçado dentro de caixa que já estava vazia — o painel
+// com dois avisos ficava com metade de ar. `align-items: start` no grid resolve
+// o alinhamento sem inventar altura.
 .painel__corpo {
-  min-height: 240px;
+  min-height: 0;
 }
 
 // Contador ao lado do título, onde o olho já está quando lê "Notificações".
@@ -50,88 +70,94 @@
 }
 
 // ═══════════════════════════════════════════════════════════════
-// TOPO — era um banner de ~180px com gradiente e emoji
+// HERO — o topo carrega os números
 //
-// Ele dizia "Boa tarde, Murillo 👋" e mais nada, todo dia, ocupando o espaço
-// que a informação útil queria. Virou uma faixa de uma linha, e ganhou o que
-// faltava: uma frase que só aparece quando há algo esperando por você.
+// Já foi um banner de gradiente que só dizia "Boa tarde", e depois uma linha de
+// texto sobre uma borda. O primeiro não informava; o segundo não ancorava a
+// página. Este faz as duas coisas, e é o único lugar da home que rompe com os
+// tokens do ERP: o degradê é identidade da marca, como no `client-dashboard`.
+//
+// O rompimento fica contido nesta faixa de propósito. Tudo abaixo dela continua
+// com raio 12px e as cores do sistema, senão a home deixaria de parecer com as
+// outras sessenta telas.
 // ═══════════════════════════════════════════════════════════════
-.topo {
+.hero {
+  padding: v.$space-6 v.$space-6 v.$space-5;
+  border-radius: 18px;
+  background: var(--hero-gradiente);
+  color: #fff;
+}
+
+.hero__eyebrow {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: v.$space-4;
-  padding-bottom: v.$space-5;
-  border-bottom: 1px solid var(--app-border);
+  gap: 9px;
+  margin: 0 0 10px;
+  font-size: .6rem;
+  font-weight: 700;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--hero-teal);
+
+  &::before {
+    content: '';
+    width: 20px;
+    height: 1px;
+    flex: 0 0 auto;
+    background: var(--hero-teal);
+  }
 }
 
-.topo__saudacao {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-}
-
-.topo__titulo {
+.hero__nome {
   margin: 0;
   font-family: v.$font-heading;
-  font-size: 1.35rem;
-  font-weight: 700;
-  color: var(--app-text);
-  line-height: 1.2;
+  font-size: clamp(1.35rem, 3vw, 1.7rem);
+  font-weight: 800;
+  letter-spacing: -.03em;
+  line-height: 1.05;
+
+  em { font-style: normal; color: var(--hero-teal); }
 }
 
-.topo__data {
-  margin: 0;
-  font-size: var(--text-ui-sm);
-  color: var(--app-text-subtle);
-  text-transform: capitalize;
-}
-
-// Só aparece quando há algo. Faixa sem pendência nenhuma não vira "0
-// notificações" — vira nada, e a linha fica limpa.
-.topo__pendencia {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  border-radius: var(--radius-pill, 999px);
-  border: 1px solid var(--app-danger);
-  background: var(--app-danger-soft, transparent);
-  color: var(--app-danger);
-  font-size: var(--text-ui-sm);
-  font-weight: 600;
-  text-decoration: none;
-
-  &:hover { filter: brightness(.95); }
-}
-
-.topo__chips {
+.hero__nums {
   display: flex;
-  align-items: center;
-  gap: v.$space-3;
   flex-wrap: wrap;
+  gap: v.$space-6;
+  margin-top: v.$space-5;
+  padding-top: v.$space-4;
+  border-top: 1px solid rgba(255, 255, 255, .22);
 }
 
-.topo__papel {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: var(--radius-pill, 999px);
-  background: var(--app-surface-2);
-  color: var(--app-text-muted);
-  font-size: var(--text-ui-sm);
-  font-weight: 600;
+.hnum {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  text-decoration: none;
+  color: inherit;
 }
 
-@media (max-width: v.$bp-sm) {
-  .topo { align-items: flex-start; }
+.hnum--link:hover .hnum__v { color: var(--hero-teal); }
 
-  // O saldo de férias sai: numa linha estreita ele empurra a pílula de
-  // notificação para baixo, e a não lida é a mais urgente das duas.
-  .topo__papel { display: none; }
+.hnum__v {
+  font-family: v.$font-heading;
+  font-size: 1.7rem;
+  font-weight: 800;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  transition: color .15s ease;
+
+  // Zero pendência não vira "0": vira um visto. A mesma informação, dita como
+  // estado desejado em vez de contagem vazia.
+  &--ok {
+    color: var(--hero-teal);
+    font-size: 1.4rem;
+  }
+}
+
+.hnum__l {
+  font-size: .68rem;
+  letter-spacing: .04em;
+  color: rgba(255, 255, 255, .72);
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -341,6 +367,9 @@
   }
 }
 
+// Era cinza com ícone navy para todo tipo — holerite, férias e reembolso
+// ficavam idênticos. A cor é por assunto, não por urgência: urgência já é a
+// ordem da lista.
 .pend-linha__icone {
   flex-shrink: 0;
   width: 38px;
@@ -348,9 +377,13 @@
   border-radius: var(--radius-control);
   display: grid;
   place-items: center;
-  background: var(--app-surface-2);
+  background: color-mix(in srgb, var(--pend-cor, var(--app-action)) 14%, transparent);
 
-  i { font-size: 1rem; color: var(--app-action); }
+  i { font-size: 1rem; color: var(--pend-cor, var(--app-action)); }
+
+  &--navy  { --pend-cor: var(--pend-navy); }
+  &--amber { --pend-cor: var(--pend-amber); }
+  &--teal  { --pend-cor: var(--pend-teal); }
 }
 
 .pend-linha__corpo {

--- a/src/app/components/auth/auth-home/auth-home.component.ts
+++ b/src/app/components/auth/auth-home/auth-home.component.ts
@@ -7,7 +7,7 @@ import { NotificationService } from '../../../infrastructure/services/notificati
 import { AnnouncementService } from '../../../infrastructure/services/hr/announcement.service';
 import { HomeService } from '../../../infrastructure/services/home/home.service';
 import { Announcement } from '../../../domain/models/hr/announcement.model';
-import { HomeSummary, PENDING_INFO, PendingItem } from '../../../domain/models/home/home-summary.model';
+import { HomeSummary, PENDING_INFO, PendingAccent, PendingItem } from '../../../domain/models/home/home-summary.model';
 
 /**
  * Home da área autenticada — o que está esperando você.
@@ -87,9 +87,20 @@ export class AuthHomeComponent implements OnInit {
   }
 
   /** Tipo desconhecido não quebra a tela: cai num ícone genérico e na home. */
-  info(item: PendingItem): { icon: string; rota: string } {
-    return PENDING_INFO[item.type] ?? { icon: 'pi pi-circle', rota: '/home' };
+  info(item: PendingItem): { icon: string; rota: string; accent: PendingAccent } {
+    return PENDING_INFO[item.type] ?? { icon: 'pi pi-circle', rota: '/home', accent: 'navy' };
   }
+
+  /**
+   * Quantas linhas a faixa do topo anuncia.
+   *
+   * Soma as duas listas porque, para quem está olhando, "três coisas te
+   * esperam" é um número só — separar em "1 sua e 2 para aprovar" é detalhe
+   * que as seções abaixo já dão.
+   */
+  readonly totalPendencias = computed(() =>
+    this.minhasPendencias().length + this.aprovacoes().length
+  );
 
   // ─── Saudação ─────────────────────────────────────────────────────────────
 

--- a/src/app/domain/models/home/home-summary.model.ts
+++ b/src/app/domain/models/home/home-summary.model.ts
@@ -25,17 +25,25 @@ export interface HomeSummary {
   vacationBalanceDays: number | null;
 }
 
+/** Cor de cada assunto. Férias é âmbar, dinheiro é teal, documento é navy. */
+export type PendingAccent = 'navy' | 'amber' | 'teal';
+
 /**
- * Ícone e destino de cada tipo.
+ * Ícone, cor e destino de cada tipo.
  *
  * A rota mora aqui e não na API: o servidor não deve conhecer o roteador do
- * Angular. Tipo novo na API sem entrada aqui cai no `?` e vai para a home —
- * feio, mas não quebra a tela.
+ * Angular. Tipo novo na API sem entrada aqui cai no genérico e vai para a home
+ * — feio, mas não quebra a tela.
+ *
+ * O `accent` existe porque a primeira versão pintava tudo do mesmo cinza com o
+ * mesmo ícone navy: holerite, férias e reembolso ficavam idênticos e o olho não
+ * tinha onde pousar. A cor aqui é por **assunto**, não por urgência — urgência
+ * é o que a ordenação já diz.
  */
-export const PENDING_INFO: Record<PendingType, { icon: string; rota: string }> = {
-  HOLERITE_NAO_CONFIRMADO: { icon: 'pi pi-receipt',  rota: '/documentos/holerites' },
-  FERIAS_AGUARDANDO:       { icon: 'pi pi-sun',      rota: '/documentos/rh/vacation-requests' },
-  REEMBOLSO_AGUARDANDO:    { icon: 'pi pi-wallet',   rota: '/documentos/rh/reimbursements' },
-  APROVACAO_FERIAS:        { icon: 'pi pi-sun',      rota: '/rh/vacation-requests' },
-  APROVACAO_REEMBOLSO:     { icon: 'pi pi-wallet',   rota: '/rh/reimbursements' },
+export const PENDING_INFO: Record<PendingType, { icon: string; rota: string; accent: PendingAccent }> = {
+  HOLERITE_NAO_CONFIRMADO: { icon: 'pi pi-receipt',  rota: '/documentos/holerites',              accent: 'navy'  },
+  FERIAS_AGUARDANDO:       { icon: 'pi pi-sun',      rota: '/documentos/rh/vacation-requests',   accent: 'amber' },
+  REEMBOLSO_AGUARDANDO:    { icon: 'pi pi-wallet',   rota: '/documentos/rh/reimbursements',      accent: 'teal'  },
+  APROVACAO_FERIAS:        { icon: 'pi pi-sun',      rota: '/rh/vacation-requests',              accent: 'amber' },
+  APROVACAO_REEMBOLSO:     { icon: 'pi pi-wallet',   rota: '/rh/reimbursements',                 accent: 'teal'  },
 };


### PR DESCRIPTION
Ele escolheu a direção A do mockup, mas disse que ficou indeciso — e o motivo
da dúvida é o custo real dela: romper com os tokens do ERP faz a home deixar de
parecer com as outras sessenta telas.

Por isso **o rompimento fica contido na faixa do topo**. O degradê navy→teal é
identidade de marca, cravado como no `client-dashboard`; tudo abaixo dele
continua com raio 12px e as cores do sistema.

**O topo vira conteúdo.** Já foi um banner que só dizia "Boa tarde", e depois
uma linha de texto sobre uma borda: o primeiro não informava, o segundo não
ancorava. Agora carrega os números — quantas pendências, quantas não lidas,
quantos dias de férias. Continua cheio no dia sem pendência nenhuma, que é o
dia mais comum.

E zero não vira "0 precisa de você": vira um visto e "tudo em dia". Mesma
informação, dita como estado desejado em vez de contagem vazia. É a ideia da
direção B, que resolvia o vazio melhor que a A.

**Cor por assunto nas pendências**, que é o que a direção C tinha de melhor.
Férias é âmbar, dinheiro é teal, documento é navy. Antes era o mesmo círculo
cinza com o mesmo ícone navy para os três, e o olho não tinha onde pousar.
A cor é por assunto e não por urgência — urgência já é a ordem da lista.

Duas correções de layout que valiam para qualquer direção:

- **O `max-width` voltou** (1240px, com `clamp` no padding como no
  `client-dashboard`). Ele tinha saído quando a página tinha dezenove cartões
  para preencher; sem eles, dois painéis se esticavam por um monitor inteiro
  segurando cinco linhas curtas.
- **O `min-height: 240px` saiu** dos painéis. Existia para alinhar as colunas, e
  o preço era ar forçado dentro de caixa que já estava vazia.
