### PR TITLE
chore(newsletter): remove o upload de quatro arquivos, que a API não atende mais

### DIFF
--- a/src/app/components/auth/communication/newsletter/newsletter.component.html
+++ b/src/app/components/auth/communication/newsletter/newsletter.component.html
@@ -44,7 +44,7 @@
               accept=".xlsx,.csv"
               maxFileSize="5000000"
               mode="advanced"
-              chooseLabel="Selecionar Arquivos"
+              chooseLabel="Selecionar Arquivo"
               uploadLabel="Enviar"
               cancelLabel="Cancelar"
               >

--- a/src/app/components/auth/communication/newsletter/newsletter.component.ts
+++ b/src/app/components/auth/communication/newsletter/newsletter.component.ts
@@ -66,7 +66,6 @@ export class NewsletterComponent implements OnInit {
     this.loading = true;
 
     if(fileList.length > 0){
-      console.log("isMatriz:", this.checked);
       this.newsletterService.createNewsletterWithOneFile(fileList[0], this.checked)
         .subscribe({
           next: (msg: string) => {

--- a/src/app/infrastructure/services/newsletter/newsletter.service.ts
+++ b/src/app/infrastructure/services/newsletter/newsletter.service.ts
@@ -8,15 +8,6 @@ import { environment } from '../../../../environments/environment';
 export class NewsletterService {
   constructor(private http: HttpClient){}
 
-  createNewsletters(files: File[], isMatriz: boolean = false){
-    const formData = new FormData();
-    files.forEach(f => formData.append('files', f));
-
-    formData.append('isMatriz', String(isMatriz));
-
-    return this.http.post(`${environment.apiUrl}/newsletter/upload`, formData, {responseType: 'text'});
-  }
-
   createNewsletterWithOneFile(file: File, isMatriz: boolean = false){
     const formData = new FormData();
     formData.append('file', file);


### PR DESCRIPTION
O `createNewsletters` apontava para `POST api/newsletter/upload`, que deixou de
existir. Ninguém o chamava — a tela já usava o de arquivo único e o
`p-fileUpload` já estava com `[multiple]="false"` —, então nada quebrava; era um
método pronto para dar 404 no dia em que alguém o usasse.

Junto: um console.log de depuração esquecido no upload, e o rótulo do botão, que
prometia "Selecionar Arquivos" numa tela que aceita um.
