### PR TITLE
feat(programação): o histórico de adiamentos fica visível na linha

### DIFF
--- a/src/app/components/auth/stock/programacao/programacao.component.html
+++ b/src/app/components/auth/stock/programacao/programacao.component.html
@@ -195,6 +195,11 @@
                       [disabled]="!canSaveDraft(row)" pTooltip="Salvar linha" tooltipPosition="left"
                       (click)="saveDraft(row)"></button>
             }
+            @if (!isDraft(row)) {
+              <button pButton type="button" icon="pi pi-history" class="row-btn"
+                      pTooltip="Histórico de adiamentos" tooltipPosition="left"
+                      (click)="abrirHistorico(row)"></button>
+            }
             <button pButton type="button" icon="pi pi-trash" class="row-btn row-btn--danger"
                     [pTooltip]="isDraft(row) ? 'Descartar' : 'Excluir'" tooltipPosition="left"
                     (click)="deleteRow(row)"></button>
@@ -268,5 +273,55 @@
       pkLabel="Salvar alteração"
       [pkDisabled]="!motivoValido()"
       (clicked)="confirmarMotivo()" />
+  </div>
+</pk-dialog>
+
+<!--
+  Histórico de adiamentos.
+
+  Carregado no clique, não junto da grade: seria um GET por linha numa tela de
+  centenas, para uma informação que se consulta raramente.
+-->
+<pk-dialog
+  [header]="'Adiamentos · ' + historicoDe()"
+  [visible]="historicoAberto()"
+  width="560px"
+  (visibleChange)="historicoAberto.set(false)">
+
+  <div pkDialogContent class="pk-form-section">
+    @if (historicoCarregando()) {
+      <p class="hist-vazio"><i class="pi pi-spin pi-spinner"></i> Carregando…</p>
+    } @else if (historico().length > 0) {
+      <!--
+        Do mais recente para o mais antigo. Quem abre quer saber a justificativa
+        da última mudança; o resto é contexto.
+      -->
+      <div class="hist">
+        @for (item of historico(); track item.id) {
+          <div class="hist__item">
+            <div class="hist__datas">
+              <span class="hist__de">{{ item.previsaoAnterior | date: 'dd/MM/yyyy' }}</span>
+              <i class="pi pi-arrow-right"></i>
+              <span class="hist__para">
+                {{ item.previsaoNova ? (item.previsaoNova | date: 'dd/MM/yyyy') : 'sem previsão' }}
+              </span>
+            </div>
+            <p class="hist__motivo">{{ item.motivo }}</p>
+            <span class="hist__quem">
+              {{ item.changedBy || 'Autor não registrado' }} · {{ item.changedAt | date: 'dd/MM/yyyy HH:mm' }}
+            </span>
+          </div>
+        }
+      </div>
+    } @else {
+      <p class="hist-vazio">
+        <i class="pi pi-check-circle"></i>
+        Esta programação nunca foi adiada.
+      </p>
+    }
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" pkSize="sm" pkLabel="Fechar" (clicked)="historicoAberto.set(false)" />
   </div>
 </pk-dialog>

--- a/src/app/components/auth/stock/programacao/programacao.component.scss
+++ b/src/app/components/auth/stock/programacao/programacao.component.scss
@@ -183,3 +183,63 @@
 }
 
 .audit__none { color: var(--app-text-subtle); }
+
+// ─── Histórico de adiamentos ────────────────────────────────────────────────
+
+.hist {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+// Cada adiamento é um bloco. A barra à esquerda liga visualmente os itens numa
+// linha do tempo — sem ela, três blocos parecem três coisas soltas.
+.hist__item {
+  padding: 10px 14px;
+  border-left: 2px solid var(--app-warning);
+  background: var(--app-surface-2);
+  border-radius: 0 var(--radius-control) var(--radius-control) 0;
+}
+
+.hist__datas {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-ui-sm);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+
+  i { font-size: .7rem; color: var(--app-text-subtle); }
+}
+
+// A data que saiu fica riscada: o "de → para" já diz a direção, e o risco
+// deixa claro qual das duas não vale mais.
+.hist__de {
+  color: var(--app-text-subtle);
+  text-decoration: line-through;
+}
+
+.hist__para { color: var(--app-text); }
+
+.hist__motivo {
+  margin: 6px 0 4px;
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+  color: var(--app-text);
+}
+
+.hist__quem {
+  font-size: var(--text-ui-sm);
+  color: var(--app-text-subtle);
+}
+
+.hist-vazio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 28px 12px;
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-ui-sm);
+}

--- a/src/app/components/auth/stock/programacao/programacao.component.ts
+++ b/src/app/components/auth/stock/programacao/programacao.component.ts
@@ -23,6 +23,7 @@ import {
 import {
   CreateMachineRegister,
   MachineRegister,
+  ScheduleChange,
   UpdateMachineRegister,
 } from '../../../../domain/models/prostock/register.model';
 import { MachineRegisterStore } from '../../../../infrastructure/state/machine-register.store';
@@ -105,6 +106,38 @@ export class ProgramacaoComponent implements OnInit {
   private pendente: { row: Row; payload: UpdateMachineRegister } | null = null;
 
   readonly motivoValido = computed(() => this.motivoTexto().trim().length > 0);
+
+  // ─── Histórico de adiamentos ─────────────────────────────────────────────
+  //
+  // Carregado sob demanda, um GET por vez que alguém abre. A alternativa seria
+  // trazer a contagem junto da grade, e aí seria um GET por linha numa tela que
+  // costuma ter centenas — caro para uma informação que se consulta raramente.
+
+  readonly historicoAberto = signal(false);
+  readonly historicoCarregando = signal(false);
+  readonly historico = signal<ScheduleChange[]>([]);
+  readonly historicoDe = signal<string>('');
+
+  abrirHistorico(row: Row): void {
+    if (this.isDraft(row)) return;
+
+    this.historicoDe.set(row.nomeCliente?.trim() || 'programação sem cliente');
+    this.historico.set([]);
+    this.historicoCarregando.set(true);
+    this.historicoAberto.set(true);
+
+    this.registerService.scheduleChanges(row.id).subscribe({
+      next: (lista) => {
+        this.historico.set(lista ?? []);
+        this.historicoCarregando.set(false);
+      },
+      error: (err: HttpErrorResponse) => {
+        this.historicoCarregando.set(false);
+        this.historicoAberto.set(false);
+        this.showError(err);
+      },
+    });
+  }
 
   readonly hasFilters = computed(() =>
     this.statusFilter().length > 0 || !!this.machineFilter() || this.onlyLate());


### PR DESCRIPTION
A V82 já guardava os adiamentos e o endpoint já respondia, mas nada na tela
lia. Fecha a Parte 2: agora dá para perguntar "por que essa máquina atrasou?" e
ter a resposta.

**Carregado no clique, não junto da grade.** Trazer a contagem em cada linha
seria um GET por linha numa tela que costuma ter centenas — caro demais para
uma informação que se consulta raramente. O botão aparece em toda linha salva e
o diálogo busca sob demanda.

Do mais recente para o mais antigo: quem abre quer a justificativa da última
mudança, e o resto é contexto.

Cada adiamento mostra **de → para**, com a data que saiu riscada. A seta já dá
a direção, e o risco deixa claro qual das duas não vale mais. Previsão apagada
aparece como "sem previsão" em vez de espaço vazio — é o caso mais grave e não
pode se parecer com dado faltando.

Rascunho não tem o botão: linha que nunca foi gravada não tem o que contar.

Autor sem registro mostra "Autor não registrado". Os adiamentos anteriores à
V82 não existem, mas registros importados podem ter `changed_by` nulo se o
contexto de auditoria não estiver ativo — melhor dizer isso que exibir vazio.
