### PR TITLE
feat(programacao): confirma o estoque ao mexer no status

### DIFF
--- a/src/app/components/auth/stock/programacao/programacao-import.component.ts
+++ b/src/app/components/auth/stock/programacao/programacao-import.component.ts
@@ -195,6 +195,12 @@ export class ProgramacaoImportComponent {
         previsaoEntrega: previsao,
         consultor: row.consultor,
         tecnico: row.tecnico,
+
+        // Explícito, e nunca `true`: a planilha traz o histórico da programação,
+        // não máquinas chegando agora. Ligar isto faria uma importação de 200
+        // linhas lançar 200 entradas e estourar o estoque de todas as máquinas
+        // de uma vez.
+        adjustStock: false,
       };
 
       await new Promise<void>(resolve => {

--- a/src/app/components/auth/stock/programacao/programacao.component.html
+++ b/src/app/components/auth/stock/programacao/programacao.component.html
@@ -325,3 +325,56 @@
     <pk-button pkType="cancel" pkSize="sm" pkLabel="Fechar" (clicked)="historicoAberto.set(false)" />
   </div>
 </pk-dialog>
+
+<!--
+  Confirmação de estoque.
+
+  Aparece só quando a transição cruza a fronteira do galpão. "Mudei um status" e
+  "mexi no estoque" não parecem a mesma ação para quem edita a grade — o número
+  antes e depois é o que liga as duas coisas na cabeça de quem clica.
+-->
+<pk-dialog
+  [header]="stockDelta() < 0 ? 'Marcar como Entregue?' : 'Devolver ao estoque?'"
+  [visible]="stockDialogOpen()"
+  width="460px"
+  (visibleChange)="cancelStockChange()">
+
+  <div pkDialogContent class="estoque">
+    @if (loadingStock()) {
+      <p class="estoque__nota"><i class="pi pi-spin pi-spinner"></i> Conferindo o estoque…</p>
+    } @else {
+      <p class="estoque__lead">
+        O estoque de <strong>{{ stockMachineName() }}</strong>
+        {{ stockDelta() < 0 ? 'cai' : 'sobe' }} de
+      </p>
+
+      <p class="estoque__conta">
+        <span class="estoque__de">{{ currentStock() }}</span>
+        <i class="pi pi-arrow-right"></i>
+        <strong class="estoque__para" [class.estoque__para--bad]="stockWouldGoNegative()">
+          {{ newStock() }}
+        </strong>
+      </p>
+
+      @if (stockWouldGoNegative()) {
+        <p class="estoque__aviso">
+          <i class="pi pi-exclamation-triangle"></i>
+          O estoque em movimentações já está em {{ currentStock() }}, então ele
+          não tem essa máquina para dar baixa. A programação e o estoque estão
+          divergentes desde antes desta edição — dá para salvar o status agora e
+          acertar o estoque pela tela de movimentação.
+        </p>
+      }
+    }
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" pkSize="sm" pkLabel="Cancelar" (clicked)="cancelStockChange()" />
+    <pk-button
+      pkType="save"
+      pkSize="sm"
+      [pkLabel]="stockWouldGoNegative() ? 'Salvar sem mexer no estoque' : 'Confirmar'"
+      [pkDisabled]="loadingStock()"
+      (clicked)="confirmStockChange()" />
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/stock/programacao/programacao.component.scss
+++ b/src/app/components/auth/stock/programacao/programacao.component.scss
@@ -243,3 +243,60 @@
   color: var(--app-text-muted);
   font-size: var(--text-ui-sm);
 }
+
+// ─── Confirmação de estoque ─────────────────────────────────────────────────
+.estoque {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.estoque__lead {
+  margin: 0;
+  font-size: var(--text-ui);
+}
+
+// O número é a informação. Grande porque é o que a pessoa precisa conferir.
+.estoque__conta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  margin: 0;
+  padding: 12px 0;
+  font-size: 1.6rem;
+
+  i { font-size: 1rem; color: var(--app-text-muted); }
+}
+
+.estoque__de { color: var(--app-text-muted); }
+
+.estoque__para {
+  color: var(--app-primary);
+
+  &--bad { color: var(--app-danger); }
+}
+
+.estoque__nota {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  color: var(--app-text-muted);
+  font-size: var(--text-ui-sm);
+}
+
+.estoque__aviso {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--app-danger-soft, rgba(220, 38, 38, .08));
+  color: var(--app-danger);
+  font-size: var(--text-ui-sm);
+  line-height: 1.45;
+
+  i { margin-top: 2px; }
+}

--- a/src/app/components/auth/stock/programacao/programacao.component.spec.ts
+++ b/src/app/components/auth/stock/programacao/programacao.component.spec.ts
@@ -1,0 +1,207 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { of } from 'rxjs';
+
+import { ProgramacaoComponent } from './programacao.component';
+import { RegisterService } from '../../../../infrastructure/services/prostock/register.service';
+import { MachineService } from '../../../../infrastructure/services/prostock/machine.service';
+import { InventoryProductService } from '../../../../infrastructure/services/company/inventory/inventory-product.service';
+import { MachineRegisterStore } from '../../../../infrastructure/state/machine-register.store';
+import { MachineStore } from '../../../../infrastructure/state/machine.store';
+import { MachineRegister, UpdateMachineRegister } from '../../../../domain/models/prostock/register.model';
+import { Machine, MachineStatus } from '../../../../domain/models/prostock/machine.model';
+
+/**
+ * A programação mexendo no estoque (Parte 4).
+ *
+ * O que estes testes protegem é **quando a tela não pergunta**. Perguntar
+ * demais numa grade que se edita o dia todo é o jeito mais rápido de ensinar
+ * alguém a clicar em "Confirmar" sem ler — e aí a confirmação deixa de valer
+ * para as vezes em que ela importa.
+ */
+describe('ProgramacaoComponent · estoque', () => {
+  let component: ProgramacaoComponent;
+  let fixture: ComponentFixture<ProgramacaoComponent>;
+
+  let registerService: jasmine.SpyObj<RegisterService>;
+  let inventoryService: jasmine.SpyObj<InventoryProductService>;
+  let registerStore: MachineRegisterStore;
+  let machineStore: MachineStore;
+
+  const MACHINE_ID = 'm0000000-0000-0000-0000-000000000001';
+  const REGISTER_ID = 'r0000000-0000-0000-0000-000000000001';
+
+  const machine: Machine = {
+    id: MACHINE_ID,
+    systemCode: 'MAQ-001',
+    name: 'Lavadora',
+    brand: 'Marca',
+    machineType: null,
+    machineStatus: null,
+    minimum_stock: 1,
+    active: true,
+  };
+
+  const register = (status: MachineStatus): MachineRegister => ({
+    id: REGISTER_ID,
+    machineId: MACHINE_ID,
+    nomeCliente: 'Cliente',
+    tag: 1,
+    regiao: 'Sul',
+    solicitante: 'Solicitante',
+    status,
+    Observacao: '',
+    previsaoEntrega: null,
+    consultor: 'Consultor',
+    tecnico: 'Técnico',
+  });
+
+  /** A linha da grade é o registro mais a data já convertida. */
+  const rowWith = (stored: MachineRegister, status: MachineStatus) =>
+    ({ ...stored, status, previsao: null }) as never;
+
+  const stockIs = (quantity: number) => {
+    inventoryService.getInventoryMovementsByProduct.and.returnValue(of([
+      { systemCode: 'MAQ-001', quantity, movementDate: '2026-08-01T10:00:00' },
+    ]));
+  };
+
+  /** O `update` que a tela acabou de disparar. */
+  const lastPayload = (): UpdateMachineRegister =>
+    registerService.update.calls.mostRecent().args[1];
+
+  beforeEach(async () => {
+    registerService = jasmine.createSpyObj<RegisterService>('RegisterService', [
+      'getAll', 'getByMachine', 'create', 'update', 'delete', 'scheduleChanges',
+    ]);
+    registerService.getAll.and.returnValue(of([]));
+    registerService.create.and.returnValue(of('ok'));
+    registerService.update.and.returnValue(of('ok'));
+
+    const machineService = jasmine.createSpyObj<MachineService>('MachineService', ['getAll', 'reconcile']);
+    machineService.getAll.and.returnValue(of([]));
+
+    inventoryService = jasmine.createSpyObj<InventoryProductService>(
+      'InventoryProductService', ['getInventoryProducts', 'getInventoryMovementsByProduct']);
+    inventoryService.getInventoryProducts.and.returnValue(of([]));
+    stockIs(5);
+
+    await TestBed.configureTestingModule({
+      imports: [ProgramacaoComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: RegisterService, useValue: registerService },
+        { provide: MachineService, useValue: machineService },
+        { provide: InventoryProductService, useValue: inventoryService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgramacaoComponent);
+    component = fixture.componentInstance;
+
+    // Stores reais, populados direto: `upsert` é o mesmo caminho que a tela usa
+    // depois de gravar, então o estado fica idêntico ao de uso real sem HTTP.
+    registerStore = TestBed.inject(MachineRegisterStore);
+    machineStore = TestBed.inject(MachineStore);
+    machineStore.upsert(machine);
+  });
+
+  /**
+   * **O teste que impede o atrito.**
+   *
+   * Reservar não é entregar: a máquina continua no galpão. Um diálogo aqui
+   * apareceria dezenas de vezes por dia sem nada a dizer.
+   */
+  it('mudar entre status de estoque não pergunta nada e grava direto', () => {
+    registerStore.upsert(register(MachineStatus.DISPONIVEL));
+
+    component.onCellEdited(rowWith(register(MachineStatus.DISPONIVEL), MachineStatus.RESERVADA));
+
+    expect(component.stockDialogOpen()).toBeFalse();
+    expect(registerService.update).toHaveBeenCalled();
+    expect(lastPayload().adjustStock).toBeUndefined();
+  });
+
+  it('marcar ENTREGUE pergunta antes e não grava ainda', () => {
+    registerStore.upsert(register(MachineStatus.DISPONIVEL));
+
+    component.onCellEdited(rowWith(register(MachineStatus.DISPONIVEL), MachineStatus.ENTREGUE));
+
+    expect(component.stockDialogOpen()).toBeTrue();
+    expect(component.stockDelta()).toBe(-1);
+    expect(component.currentStock()).toBe(5);
+    expect(component.newStock()).toBe(4);
+    expect(registerService.update).not.toHaveBeenCalled();
+  });
+
+  it('confirmar grava com adjustStock ligado', () => {
+    registerStore.upsert(register(MachineStatus.DISPONIVEL));
+    component.onCellEdited(rowWith(register(MachineStatus.DISPONIVEL), MachineStatus.ENTREGUE));
+
+    component.confirmStockChange();
+
+    expect(lastPayload().adjustStock).toBeTrue();
+    expect(lastPayload().status).toBe(MachineStatus.ENTREGUE);
+    expect(component.stockDialogOpen()).toBeFalse();
+  });
+
+  /** O caso que ele reportou: voltar de ENTREGUE tem que devolver ao estoque. */
+  it('voltar de ENTREGUE soma 1', () => {
+    registerStore.upsert(register(MachineStatus.ENTREGUE));
+
+    component.onCellEdited(rowWith(register(MachineStatus.ENTREGUE), MachineStatus.DISPONIVEL));
+
+    expect(component.stockDelta()).toBe(1);
+    expect(component.newStock()).toBe(6);
+  });
+
+  /**
+   * AGUARDANDO_AQUISICAO é máquina que ainda não chegou — nunca entrou no
+   * estoque, então entregá-la não pode baixar nada. É a metade da regra que
+   * some quando alguém lê só "só ENTREGUE".
+   */
+  it('entregar o que nunca esteve em estoque não pergunta nada', () => {
+    registerStore.upsert(register(MachineStatus.AGUARDANDO_AQUISICAO));
+
+    component.onCellEdited(
+      rowWith(register(MachineStatus.AGUARDANDO_AQUISICAO), MachineStatus.ENTREGUE));
+
+    expect(component.stockDialogOpen()).toBeFalse();
+    expect(registerService.update).toHaveBeenCalled();
+  });
+
+  /**
+   * **Divergência que já existia não pode travar o trabalho.**
+   *
+   * Se o estoque em movimentações está zerado e a programação diz que há
+   * máquina, a API recusaria a baixa. Em vez de deixar a pessoa sem saída, o
+   * botão troca de função e grava só o status.
+   */
+  it('estoque insuficiente troca o botão e grava sem mexer no estoque', () => {
+    stockIs(0);
+    registerStore.upsert(register(MachineStatus.DISPONIVEL));
+
+    component.onCellEdited(rowWith(register(MachineStatus.DISPONIVEL), MachineStatus.ENTREGUE));
+
+    expect(component.stockWouldGoNegative()).toBeTrue();
+
+    component.confirmStockChange();
+
+    expect(lastPayload().adjustStock).toBeFalse();
+    expect(lastPayload().status).toBe(MachineStatus.ENTREGUE);
+  });
+
+  /**
+   * Desistir não pode deixar o status novo na tela: a pessoa sairia achando
+   * que salvou. O `refresh` traz de volta o que está no banco.
+   */
+  it('cancelar não grava nada', () => {
+    registerStore.upsert(register(MachineStatus.DISPONIVEL));
+    component.onCellEdited(rowWith(register(MachineStatus.DISPONIVEL), MachineStatus.ENTREGUE));
+
+    component.cancelStockChange();
+
+    expect(component.stockDialogOpen()).toBeFalse();
+    expect(registerService.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/auth/stock/programacao/programacao.component.ts
+++ b/src/app/components/auth/stock/programacao/programacao.component.ts
@@ -18,7 +18,9 @@ import {
   MACHINE_STATUS_LABEL,
   MACHINE_STATUS_SEVERITY,
   MachineStatus,
+  IN_STOCK_STATUSES,
   machineStatusOptions,
+  stockDeltaFor,
 } from '../../../../domain/models/prostock/machine.model';
 import {
   CreateMachineRegister,
@@ -29,6 +31,7 @@ import {
 import { MachineRegisterStore } from '../../../../infrastructure/state/machine-register.store';
 import { MachineStore } from '../../../../infrastructure/state/machine.store';
 import { RegisterService } from '../../../../infrastructure/services/prostock/register.service';
+import { InventoryProductService } from '../../../../infrastructure/services/company/inventory/inventory-product.service';
 import { formatStampBr, parseDateOnly } from '../../../../domain/utils/date-only';
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
@@ -75,6 +78,7 @@ export class ProgramacaoComponent implements OnInit {
   private readonly store = inject(MachineRegisterStore);
   private readonly machineStore = inject(MachineStore);
   private readonly registerService = inject(RegisterService);
+  private readonly inventoryService = inject(InventoryProductService);
   private readonly messageService = inject(MessageService);
   private readonly confirmationService = inject(ConfirmationService);
 
@@ -106,6 +110,36 @@ export class ProgramacaoComponent implements OnInit {
   private pendente: { row: Row; payload: UpdateMachineRegister } | null = null;
 
   readonly motivoValido = computed(() => this.motivoTexto().trim().length > 0);
+
+  // ─── Confirmação de estoque ──────────────────────────────────────────────
+  //
+  // Uma linha de programação é uma máquina física. Sair do estoque para
+  // ENTREGUE tira uma do galpão; voltar devolve. A tela mostra o número antes
+  // de gravar, porque "mudei um status" e "mexi no estoque" não parecem a
+  // mesma ação para quem está editando a grade.
+
+  readonly stockDialogOpen = signal(false);
+  readonly loadingStock = signal(false);
+  readonly currentStock = signal(0);
+  readonly stockDelta = signal(0);
+  readonly stockMachineName = signal('');
+
+  /** O que fica esperando a confirmação do estoque. */
+  private pendingStock:
+    | { row: Row; payload: UpdateMachineRegister }
+    | { draft: Row; payload: CreateMachineRegister }
+    | null = null;
+
+  readonly newStock = computed(() => this.currentStock() + this.stockDelta());
+
+  /**
+   * O estoque em movimentações não bate com a programação.
+   *
+   * Acontece de verdade: são duas contagens do mesmo fato, e qualquer caminho
+   * antigo pode tê-las separado. Travar aqui deixaria a pessoa sem saída, então
+   * o botão muda de função em vez de sumir.
+   */
+  readonly stockWouldGoNegative = computed(() => this.newStock() < 0);
 
   // ─── Histórico de adiamentos ─────────────────────────────────────────────
   //
@@ -309,6 +343,21 @@ export class ProgramacaoComponent implements OnInit {
       tecnico: row.tecnico ?? '',
     };
 
+    // Linha nova nascendo em estoque é uma máquina entrando no galpão.
+    const delta = stockDeltaFor(null, row.status);
+    if (delta !== 0) {
+      this.pendingStock = { draft: row, payload };
+      this.mark('saving', row.id, false);
+      this.openStockDialog(row.machineId, delta);
+      return;
+    }
+
+    this.createRow(row, payload);
+  }
+
+  private createRow(row: Row, payload: CreateMachineRegister): void {
+    this.mark('saving', row.id, true);
+
     this.store.create(payload).subscribe({
       next: () => {
         this.mark('saving', row.id, false);
@@ -320,6 +369,94 @@ export class ProgramacaoComponent implements OnInit {
         this.showError(err);
       },
     });
+  }
+
+  // ─── A checagem do estoque ───────────────────────────────────────────────
+
+  /**
+   * Pergunta antes de gravar, mas **só quando a transição cruza a fronteira**.
+   *
+   * DISPONIVEL → RESERVADA não pergunta nada: a máquina continua no galpão, e
+   * um diálogo aí seria atrito puro numa grade que se edita o dia todo.
+   */
+  private checkStockBeforeUpdate(row: Row, payload: UpdateMachineRegister): void {
+    const stored = this.store.items().find(item => item.id === row.id);
+    const delta = stored ? stockDeltaFor(stored.status, payload.status) : 0;
+
+    if (delta === 0) {
+      this.gravar(row, payload);
+      return;
+    }
+
+    this.pendingStock = { row, payload };
+    this.openStockDialog(row.machineId, delta);
+  }
+
+  /**
+   * O estoque atual vem do último movimento, como na tela de movimentação.
+   *
+   * Carregado no clique e não junto da grade: seria um GET por linha numa tela
+   * de centenas, para um número que só interessa nesse instante.
+   */
+  private openStockDialog(machineId: string, delta: number): void {
+    const machine = this.machineStore.items().find(item => item.id === machineId);
+
+    this.stockDelta.set(delta);
+    this.stockMachineName.set(machine?.name ?? 'esta máquina');
+    this.currentStock.set(0);
+    this.loadingStock.set(true);
+    this.stockDialogOpen.set(true);
+
+    if (!machine) {
+      this.loadingStock.set(false);
+      return;
+    }
+
+    this.inventoryService.getInventoryMovementsByProduct(machine.systemCode).subscribe({
+      next: (list) => {
+        const sorted = [...(list ?? [])].sort((a, b) => a.movementDate.localeCompare(b.movementDate));
+        this.currentStock.set(sorted.length ? sorted[sorted.length - 1].quantity : 0);
+        this.loadingStock.set(false);
+      },
+      // 404 é máquina sem movimento nenhum: estoque zero, não erro.
+      error: () => this.loadingStock.set(false),
+    });
+  }
+
+  /**
+   * Confirma e grava, com o `adjustStock` ligado.
+   *
+   * Quando o estoque ficaria negativo o botão vira "salvar sem mexer no
+   * estoque" e manda `false`: a divergência já existia antes desta edição, e
+   * travar a pessoa aqui não conserta nada — só impede o trabalho dela.
+   */
+  confirmStockChange(): void {
+    if (!this.pendingStock || this.loadingStock()) return;
+
+    const adjustStock = !this.stockWouldGoNegative();
+    const pending = this.pendingStock;
+    this.pendingStock = null;
+    this.stockDialogOpen.set(false);
+
+    if ('draft' in pending) {
+      this.createRow(pending.draft, { ...pending.payload, adjustStock });
+    } else {
+      this.gravar(pending.row, { ...pending.payload, adjustStock });
+    }
+  }
+
+  /**
+   * Desistir desfaz a edição.
+   *
+   * Mesmo motivo do `cancelarMotivo`: deixar o status novo na tela sem gravar é
+   * pior que o erro, porque a pessoa sai achando que salvou.
+   */
+  cancelStockChange(): void {
+    const pending = this.pendingStock;
+    this.pendingStock = null;
+    this.stockDialogOpen.set(false);
+
+    if (pending && !('draft' in pending)) this.store.refresh();
   }
 
   // ─── Edição em célula ─────────────────────────────────────────────────────
@@ -362,7 +499,7 @@ export class ProgramacaoComponent implements OnInit {
       return;
     }
 
-    this.gravar(row, payload);
+    this.checkStockBeforeUpdate(row, payload);
   }
 
   /** Confirma o motivo e solta o PUT que estava esperando. */
@@ -373,7 +510,10 @@ export class ProgramacaoComponent implements OnInit {
     this.pendente = null;
     this.motivoAberto.set(false);
 
-    this.gravar(row, { ...payload, motivoAlteracaoPrevisao: this.motivoTexto().trim() });
+    // Os dois diálogos podem cair na mesma edição — mudar a data E o status de
+    // uma vez. Em fila, nunca ao mesmo tempo: um por cima do outro esconderia
+    // metade da pergunta.
+    this.checkStockBeforeUpdate(row, { ...payload, motivoAlteracaoPrevisao: this.motivoTexto().trim() });
   }
 
   /**
@@ -440,10 +580,19 @@ export class ProgramacaoComponent implements OnInit {
 
     const quem = row.nomeCliente?.trim() || 'sem cliente';
 
+    // Apagar não baixa o estoque de propósito: apagar é "essa linha nunca
+    // deveria ter existido". Se a máquina está no galpão, o certo é mudar o
+    // status. Mas quem clica precisa saber disso antes, não depois.
+    const contaNoEstoque = IN_STOCK_STATUSES.includes(row.status)
+      ? '<br><br>Esta máquina conta no estoque. Apagar a linha <strong>não</strong> '
+        + 'baixa o estoque — para isso, mude o status para Entregue.'
+      : '';
+
     this.confirmationService.confirm({
       header: 'Excluir programação',
       message: `Excluir a programação de <strong>${quem}</strong>? `
-        + 'O histórico de adiamentos dessa linha vai junto, e não há como recuperar.',
+        + 'O histórico de adiamentos dessa linha vai junto, e não há como recuperar.'
+        + contaNoEstoque,
       icon: 'pi pi-exclamation-triangle',
       acceptLabel: 'Excluir',
       rejectLabel: 'Cancelar',

--- a/src/app/domain/models/prostock/machine.model.ts
+++ b/src/app/domain/models/prostock/machine.model.ts
@@ -119,3 +119,30 @@ export interface ReconcileRequest {
   /** Quantas programações nascem DISPONIVEL. Só quando `delta` é positivo. */
   registersToCreate: number;
 }
+
+/**
+ * Quanto o estoque anda quando o status de uma programação muda.
+ *
+ * Espelha `MachineReconciliationService.stockDeltaFor`. Existe aqui para a tela
+ * saber **se precisa perguntar** alguma coisa antes de gravar — quem decide de
+ * verdade continua sendo o servidor, que recalcula e recusa.
+ *
+ * A regra é "só ENTREGUE", com uma segunda metade que não é óbvia: o ajuste só
+ * vale quando o outro lado da transição está em estoque. AGUARDANDO_AQUISICAO
+ * é máquina que ainda não chegou, e entregá-la não pode baixar nada.
+ *
+ * `before` nulo é linha nova: nascer em estoque é entrada.
+ */
+export function stockDeltaFor(
+  before: MachineStatus | null,
+  after: MachineStatus,
+): number {
+  const inStock = (status: MachineStatus) => IN_STOCK_STATUSES.includes(status);
+
+  if (before === null) return inStock(after) ? 1 : 0;
+
+  if (inStock(before) && after === MachineStatus.ENTREGUE) return -1;
+  if (before === MachineStatus.ENTREGUE && inStock(after)) return 1;
+
+  return 0;
+}

--- a/src/app/domain/models/prostock/register.model.ts
+++ b/src/app/domain/models/prostock/register.model.ts
@@ -48,6 +48,14 @@ export interface CreateMachineRegister {
   previsaoEntrega: string | null;
   consultor: string;
   tecnico: string;
+
+  /**
+   * Pedido explícito para lançar a movimentação de estoque junto.
+   *
+   * Omitido, a API cai em `false` — o campo é primitivo do outro lado. É o que
+   * mantém a importação de planilha e o desktop inertes: eles nunca mandam.
+   */
+  adjustStock?: boolean;
 }
 
 /** O update não leva `machineId`: a máquina do registro não muda. */
@@ -59,6 +67,9 @@ export type UpdateMachineRegister = Omit<CreateMachineRegister, 'machineId'> & {
    * é adiamento e não precisa de nada.
    */
   motivoAlteracaoPrevisao?: string | null;
+
+  /** Ver `CreateMachineRegister.adjustStock`. */
+  adjustStock?: boolean;
 };
 
 /** Uma alteração de previsão já registrada — espelha `ScheduleChangeDTO`. */


### PR DESCRIPTION
Fecha o ciclo do lado da grade. O que a tela faz e mostrar o numero antes
de gravar: "mudei um status" e "mexi no estoque" nao parecem a mesma acao
para quem edita a grade o dia todo.

So pergunta quando a transicao cruza a fronteira do galpao. DISPONIVEL ->
RESERVADA nao pergunta nada -- um dialogo ai apareceria dezenas de vezes
por dia sem ter o que dizer, e confirmacao que aparece a toa ensina a
clicar sem ler.

Os dois dialogos entram em fila quando a mesma edicao muda a data E o
status. Um por cima do outro esconderia metade da pergunta.

Quando o estoque em movimentacoes nao tem a maquina para dar baixa, o
botao troca de funcao em vez de sumir: a divergencia ja existia antes
dessa edicao, e travar a pessoa nao conserta nada.

A importacao manda adjustStock: false explicito, com comentario dizendo
por que. Apagar linha nao mexe no estoque, mas a confirmacao passa a
avisar.

- stockDeltaFor espelhando a regra da API
- dialogo de confirmacao em programacao.component
- 7 testes novos
