### PR TITLE
fix(estoque): ordena movimentacao por quando foi registrada

### DIFF
--- a/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
+++ b/src/app/components/auth/stock/inventory-hub/inventory-hub.component.ts
@@ -117,8 +117,15 @@ export class InventoryHubComponent implements OnInit {
     const broken = new Set(this.brokenCodes());
 
     return this.products().filter(product => !broken.has(product.systemCode)).map(product => {
+      // Ordem por `createdAt`, aqui e nos outros dois pontos desta tela.
+      //
+      // Não é cosmético: o delta de cada linha é `quantity` menos a `quantity`
+      // da anterior. `movementDate` é `date` no banco, sem hora, então dois
+      // lançamentos do mesmo dia empatavam — e na ordem trocada uma entrada
+      // aparecia como saída. O dia exibido continua vindo de `movementDate`,
+      // que é quando a movimentação aconteceu.
       const history = [...(histories.get(product.systemCode) ?? [])]
-        .sort((a, b) => a.movementDate.localeCompare(b.movementDate));
+        .sort((a, b) => (a.createdAt ?? a.movementDate).localeCompare(b.createdAt ?? b.movementDate));
 
       let entered = 0;
       let left = 0;
@@ -215,7 +222,7 @@ export class InventoryHubComponent implements OnInit {
     const byDay = new Map<string, { in: number; out: number }>();
 
     for (const history of histories.values()) {
-      const sorted = [...history].sort((a, b) => a.movementDate.localeCompare(b.movementDate));
+      const sorted = [...history].sort((a, b) => (a.createdAt ?? a.movementDate).localeCompare(b.createdAt ?? b.movementDate));
 
       sorted.forEach((movement, index) => {
         const day = movement.movementDate.slice(0, 10);
@@ -262,7 +269,7 @@ export class InventoryHubComponent implements OnInit {
     const items: FeedItem[] = [];
 
     for (const [systemCode, history] of this.histories()) {
-      const sorted = [...history].sort((a, b) => a.movementDate.localeCompare(b.movementDate));
+      const sorted = [...history].sort((a, b) => (a.createdAt ?? a.movementDate).localeCompare(b.createdAt ?? b.movementDate));
 
       sorted.forEach((movement, index) => {
         items.push({

--- a/src/app/components/auth/stock/movements/movements.component.spec.ts
+++ b/src/app/components/auth/stock/movements/movements.component.spec.ts
@@ -97,6 +97,37 @@ describe('MovementsComponent · conciliação', () => {
   };
 
   /**
+   * **O teste do bug de 2026-08-26.**
+   *
+   * Ele tinha 2 máquinas em estoque, marcou uma como entregue e o estoque foi
+   * para 0. `movementDate` é `date` no banco, sem hora: dois lançamentos do
+   * mesmo dia empatam, e o "último" da lista saía por acaso.
+   *
+   * Os itens chegam fora de ordem de propósito. Ordenando por `movementDate`,
+   * este teste devolveria 9 — o último da lista como ela chegou.
+   */
+  it('estoque atual é o último REGISTRADO, não o último datado', () => {
+    const mesmoDia = '2026-09-10T00:00:00';
+    component.movements.set([
+      { systemCode: 'MAQ-001', quantity: 7, movementDate: mesmoDia, createdAt: '2026-09-10T08:00:02Z' },
+      { systemCode: 'MAQ-001', quantity: 5, movementDate: mesmoDia, createdAt: '2026-09-10T08:00:03Z' },
+      { systemCode: 'MAQ-001', quantity: 9, movementDate: mesmoDia, createdAt: '2026-09-10T08:00:01Z' },
+    ]);
+
+    expect(component.currentStock()).toBe(5);
+  });
+
+  /** Movimentação antiga, de cliente que não manda o campo, não pode quebrar. */
+  it('sem createdAt, cai na data e não estoura', () => {
+    component.movements.set([
+      { systemCode: 'MAQ-001', quantity: 3, movementDate: '2026-09-09T00:00:00' },
+      { systemCode: 'MAQ-001', quantity: 4, movementDate: '2026-09-10T00:00:00' },
+    ]);
+
+    expect(component.currentStock()).toBe(4);
+  });
+
+  /**
    * **A garantia de que nada mudou para quem não é máquina.**
    *
    * O lançamento de estoque comum é operação diária, e a conciliação não pode

--- a/src/app/components/auth/stock/movements/movements.component.ts
+++ b/src/app/components/auth/stock/movements/movements.component.ts
@@ -71,8 +71,11 @@ export class MovementsComponent implements OnInit {
 
   /**
    * Estoque atual é a quantidade do ÚLTIMO movimento — a base guarda o valor
-   * absoluto resultante, não a diferença. O desktop confia na ordem que a API
-   * devolve; aqui ordenamos por data, que é o mesmo resultado sem depender disso.
+   * absoluto resultante, não a diferença.
+   *
+   * "Último" é o último **registrado**, não o último datado: `movementDate` é
+   * `date` no banco e não tem hora, então dois lançamentos do mesmo dia
+   * empatavam e o último da lista saía por acaso.
    */
   readonly currentStock = computed(() => {
     const list = this.sortedMovements();
@@ -84,8 +87,14 @@ export class MovementsComponent implements OnInit {
     return list.length ? list[list.length - 1].movementDate : null;
   });
 
+  /**
+   * A API já devolve ordenado por `createdAt`. Reordenar aqui é cinto de
+   * segurança para o dia em que alguém mexer lá — e o `??` cobre movimentação
+   * antiga vinda de cliente que não manda o campo.
+   */
   readonly sortedMovements = computed(() =>
-    [...this.movements()].sort((a, b) => a.movementDate.localeCompare(b.movementDate)));
+    [...this.movements()].sort((a, b) =>
+      (a.createdAt ?? a.movementDate).localeCompare(b.createdAt ?? b.movementDate)));
 
   /** Histórico mostrado: mais recente primeiro, com filtro opcional de período. */
   readonly historyRows = computed(() => {

--- a/src/app/components/auth/stock/programacao/programacao.component.ts
+++ b/src/app/components/auth/stock/programacao/programacao.component.ts
@@ -414,7 +414,11 @@ export class ProgramacaoComponent implements OnInit {
 
     this.inventoryService.getInventoryMovementsByProduct(machine.systemCode).subscribe({
       next: (list) => {
-        const sorted = [...(list ?? [])].sort((a, b) => a.movementDate.localeCompare(b.movementDate));
+        // Por `createdAt`, não por `movementDate`: a segunda não tem hora, e
+        // dois lançamentos do mesmo dia empatam. Era o que fazia o diálogo
+        // mostrar um estoque de partida errado.
+        const sorted = [...(list ?? [])].sort((a, b) =>
+          (a.createdAt ?? a.movementDate).localeCompare(b.createdAt ?? b.movementDate));
         this.currentStock.set(sorted.length ? sorted[sorted.length - 1].quantity : 0);
         this.loadingStock.set(false);
       },

--- a/src/app/domain/models/products.model.ts
+++ b/src/app/domain/models/products.model.ts
@@ -41,9 +41,21 @@ export interface InventoryProductResponse{
  * nulo e a API respondia 404 "código do sistema está nulo ou vazio".
  */
 export interface InventoryMovement{
+  /** Quando a movimentação aconteceu. É o que a tela **mostra**. */
   movementDate: string;
   quantity: number;
   systemCode: string;
+
+  /**
+   * Quando foi registrada. É por ela que a lista se **ordena**.
+   *
+   * `movementDate` é `date` no banco, sem hora: dois lançamentos do mesmo dia
+   * empatam, e ordenar por ela deixava o estoque atual por conta do acaso —
+   * uma entrega de uma máquina levou o estoque de 2 para 0.
+   *
+   * Opcional porque só a leitura devolve: no POST quem manda é o servidor.
+   */
+  createdAt?: string;
 }
 
 export interface ProductWebSiteCreateDTO{


### PR DESCRIPTION
Contraparte do fix da API. `movementDate` e `date` no banco, sem hora:
dois lancamentos do mesmo dia empatam, e a tela lia o ultimo da lista como
estoque atual -- que com empate saia por acaso.

Cinco pontos tinham a mesma falha, com consequencias diferentes:

- tela de movimentacao: o estoque atual e a previa do lancamento
- dialogo de conciliacao da programacao: o estoque de partida
- hub do estoque, tres vezes: ali o delta de cada linha e `quantity` menos
  a `quantity` da anterior, entao na ordem trocada uma ENTRADA aparecia
  como saida no grafico e no feed

O dia exibido continua vindo de `movementDate`, que e quando a
movimentacao aconteceu. So a ORDEM mudou de campo.

O `?? movementDate` cobre movimentacao antiga, de cliente que nao manda o
campo novo.

- InventoryMovement ganha createdAt
- 2 testes: o cenario dele, e o fallback sem createdAt
