### PR TITLE
feature/permissoes por tela

### DIFF
--- a/src/app/app.routes.spec.ts
+++ b/src/app/app.routes.spec.ts
@@ -1,0 +1,70 @@
+import { Route } from '@angular/router';
+
+import { routes } from './app.routes';
+
+/**
+ * O contrato entre as rotas e o catálogo de permissões.
+ *
+ * Uma rota autenticada sem `data.screen` **passa pelo guard sem ser checada** —
+ * fica aberta para qualquer pessoa logada, e nada denuncia: o build passa, a
+ * tela abre, e só um teste como este percebe.
+ *
+ * É o contrário do defeito que a sincronização cobre. Lá o risco é a tela sumir
+ * para todo mundo; aqui é ela ficar visível para todo mundo.
+ *
+ * Importar as rotas é barato: `loadComponent` é uma função preguiçosa e não
+ * executa no import — o que chega aqui é o array, não os 55 componentes.
+ */
+describe('app.routes · o catálogo de telas', () => {
+
+  /**
+   * Não participam do controle, e a razão de cada uma:
+   *
+   * - `unauthorized` é a própria tela de acesso negado. Trancá-la deixaria a
+   *   pessoa barrada sem nem o aviso de que foi barrada.
+   * - `home` e `notificacoes` são o mínimo que todo logado precisa.
+   * - `cliente/*` é o portal, que tem sessão e escopo próprios.
+   */
+  const FORA_DO_CONTROLE = ['home', 'unauthorized', 'notificacoes'];
+
+  /** Anda pela árvore inteira: as rotas do ERP moram sob o layout autenticado. */
+  const todas = (lista: Route[], prefixo = ''): { path: string; data?: Record<string, unknown> }[] =>
+    lista.flatMap(rota => {
+      const path = [prefixo, rota.path].filter(Boolean).join('/');
+      const filhas = rota.children ? todas(rota.children, path) : [];
+      return rota.loadComponent
+        ? [{ path, data: rota.data as Record<string, unknown> | undefined }, ...filhas]
+        : filhas;
+    });
+
+  const controladas = todas(routes)
+    .filter(r => !r.path.startsWith('cliente') && !FORA_DO_CONTROLE.includes(r.path));
+
+  it('encontrou as rotas autenticadas', () => {
+    // Se este número despencar, a travessia parou de funcionar — e os outros
+    // testes passariam vazios, sem afirmar nada.
+    expect(controladas.length).toBeGreaterThan(40);
+  });
+
+  /** **O teste que importa.** Sem `data.screen`, o guard deixa passar sem checar. */
+  it('toda rota autenticada declara data.screen', () => {
+    const semScreen = controladas.filter(r => !r.data?.['screen']).map(r => r.path);
+
+    expect(semScreen).toEqual([]);
+  });
+
+  /**
+   * O código da tela **é** a rota.
+   *
+   * Divergir é o pior dos dois mundos: a rota existe, o catálogo tem outra
+   * coisa, e a pessoa vê "acesso negado" numa tela que ela pode acessar — com a
+   * configuração dizendo que pode.
+   */
+  it('o screen declarado é igual ao path da rota', () => {
+    const divergentes = controladas
+      .filter(r => r.data?.['screen'] !== r.path)
+      .map(r => ({ path: r.path, screen: r.data?.['screen'] }));
+
+    expect(divergentes).toEqual([]);
+  });
+});

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -128,6 +128,8 @@ export const routes: Routes = [
       // ── Configurações ────────────────────────────────────────────────────
       { path: 'settings/products/website', loadComponent: () => import('./components/auth/company/products/website/website.component').then(m => m.WebsiteComponent), data: { screen: 'settings/products/website', roles: ['ADMIN', 'DESIGN'] } },
       { path: 'settings/admin', loadComponent: () => import('./components/auth/admin-center/admin-center.component').then(m => m.AdminCenterComponent), data: { screen: 'settings/admin', roles: ['ADMIN'] } },
+      { path: 'settings/permissions/templates', loadComponent: () => import('./components/auth/settings/permissions/templates/permission-templates.component').then(m => m.PermissionTemplatesComponent), data: { screen: 'settings/permissions/templates', roles: ['ADMIN'] } },
+      { path: 'settings/permissions/users', loadComponent: () => import('./components/auth/settings/permissions/users/permission-users.component').then(m => m.PermissionUsersComponent), data: { screen: 'settings/permissions/users', roles: ['ADMIN'] } },
       { path: 'faq/manager', loadComponent: () => import('./components/auth/faq-manager/faq-manager.component').then(m => m.FaqManagerComponent), data: { screen: 'faq/manager', roles: ['ADMIN'] } },
       { path: 'profile-manager', loadComponent: () => import('./components/auth/profile/profile-manager/profile-manager.component').then(m => m.ProfileManagerComponent), data: { screen: 'profile-manager', roles: ['ADMIN'] } },
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -61,93 +61,93 @@ export const routes: Routes = [
       { path: 'unauthorized', loadComponent: () => import('./components/auth/access-denied/access-denied.component').then(m => m.AccessDeniedComponent) },
 
       // ── RH (gestão) ──────────────────────────────────────────────────────
-      { path: 'rh/hub', loadComponent: () => import('./components/auth/rh/rh-hub/rh-hub.component').then(m => m.RhHubComponent), data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/hub', loadComponent: () => import('./components/auth/rh/rh-hub/rh-hub.component').then(m => m.RhHubComponent), data: { screen: 'rh/hub', roles: ['ADMIN', 'RH'] } },
       // Menu de ferramentas + conteúdo ao lado. A rota era o separador direto;
       // ele virou uma das ferramentas de dentro. Papéis declarados: esta era a
       // única tela do RH sem `roles`, e ela publica holerite.
-      { path: 'rh/holerit', loadComponent: () => import('./components/auth/documents/holerite-hub/holerite-hub.component').then(m => m.HoleriteHubComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/holerit/extractor', loadComponent: () => import('./components/auth/documents/holerit-extractor/holerit-extractor.component').then(m => m.HoleritExtractorComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/employees', loadComponent: () => import('./components/auth/partners/employes/employes.component').then(m => m.EmployesComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/organizational-structure', loadComponent: () => import('./components/auth/rh/org-structure/org-structure.component').then(m => m.OrgStructureComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/career-structure', loadComponent: () => import('./components/auth/rh/career-structure/career-structure.component').then(m => m.CareerStructureComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/vacation-requests', loadComponent: () => import('./components/auth/rh/vacation-requests-manager/vacation-requests-manager.component').then(m => m.VacationRequestsManagerComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/reimbursements', loadComponent: () => import('./components/auth/rh/reimbursements-manager/reimbursements-manager.component').then(m => m.ReimbursementsManagerComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/calendar', loadComponent: () => import('./components/auth/rh/hr-calendar/hr-calendar.component').then(m => m.HrCalendarComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/team-overview', loadComponent: () => import('./components/auth/rh/team-overview/team-overview.component').then(m => m.TeamOverviewComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/calculators', loadComponent: () => import('./components/auth/rh/hr-calculators/hr-calculators.component').then(m => m.HrCalculatorsComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/equipment-assignments', loadComponent: () => import('./components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component').then(m => m.HrEquipmentAssignmentsComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/notifications', loadComponent: () => import('./components/auth/rh/hr-notifications/hr-notifications.component').then(m => m.HrNotificationsComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/announcements', loadComponent: () => import('./components/auth/rh/hr-announcements-manager/hr-announcements-manager.component').then(m => m.HrAnnouncementsManagerComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/medical-certificates', loadComponent: () => import('./components/auth/rh/medical-certificates-manager/medical-certificates-manager.component').then(m => m.MedicalCertificatesManagerComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/painel-de-vagas', loadComponent: () => import('./components/auth/rh/painel-de-vagas/painel-de-vagas.component').then(m => m.PainelDeVagasComponent), data: { roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/candidaturas', loadComponent: () => import('./components/auth/rh/candidaturas/candidaturas.component').then(m => m.CandidaturasComponent), data: { roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/holerit', loadComponent: () => import('./components/auth/documents/holerite-hub/holerite-hub.component').then(m => m.HoleriteHubComponent), data: { screen: 'rh/holerit', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/holerit/extractor', loadComponent: () => import('./components/auth/documents/holerit-extractor/holerit-extractor.component').then(m => m.HoleritExtractorComponent), data: { screen: 'rh/holerit/extractor', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/employees', loadComponent: () => import('./components/auth/partners/employes/employes.component').then(m => m.EmployesComponent), data: { screen: 'rh/employees', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/organizational-structure', loadComponent: () => import('./components/auth/rh/org-structure/org-structure.component').then(m => m.OrgStructureComponent), data: { screen: 'rh/organizational-structure', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/career-structure', loadComponent: () => import('./components/auth/rh/career-structure/career-structure.component').then(m => m.CareerStructureComponent), data: { screen: 'rh/career-structure', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/vacation-requests', loadComponent: () => import('./components/auth/rh/vacation-requests-manager/vacation-requests-manager.component').then(m => m.VacationRequestsManagerComponent), data: { screen: 'rh/vacation-requests', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/reimbursements', loadComponent: () => import('./components/auth/rh/reimbursements-manager/reimbursements-manager.component').then(m => m.ReimbursementsManagerComponent), data: { screen: 'rh/reimbursements', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/calendar', loadComponent: () => import('./components/auth/rh/hr-calendar/hr-calendar.component').then(m => m.HrCalendarComponent), data: { screen: 'rh/calendar', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/team-overview', loadComponent: () => import('./components/auth/rh/team-overview/team-overview.component').then(m => m.TeamOverviewComponent), data: { screen: 'rh/team-overview', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/calculators', loadComponent: () => import('./components/auth/rh/hr-calculators/hr-calculators.component').then(m => m.HrCalculatorsComponent), data: { screen: 'rh/calculators', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/equipment-assignments', loadComponent: () => import('./components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component').then(m => m.HrEquipmentAssignmentsComponent), data: { screen: 'rh/equipment-assignments', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/notifications', loadComponent: () => import('./components/auth/rh/hr-notifications/hr-notifications.component').then(m => m.HrNotificationsComponent), data: { screen: 'rh/notifications', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/announcements', loadComponent: () => import('./components/auth/rh/hr-announcements-manager/hr-announcements-manager.component').then(m => m.HrAnnouncementsManagerComponent), data: { screen: 'rh/announcements', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/medical-certificates', loadComponent: () => import('./components/auth/rh/medical-certificates-manager/medical-certificates-manager.component').then(m => m.MedicalCertificatesManagerComponent), data: { screen: 'rh/medical-certificates', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/painel-de-vagas', loadComponent: () => import('./components/auth/rh/painel-de-vagas/painel-de-vagas.component').then(m => m.PainelDeVagasComponent), data: { screen: 'rh/painel-de-vagas', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/candidaturas', loadComponent: () => import('./components/auth/rh/candidaturas/candidaturas.component').then(m => m.CandidaturasComponent), data: { screen: 'rh/candidaturas', roles: ['ADMIN', 'RH'] } },
 
       // ── Estoque (ProStock) ───────────────────────────────────────────────
       // Mesmas funções do desktop JavaFX, que continua no ar consumindo a
       // mesma API — nenhum contrato pode mudar aqui.
-      { path: 'stock/hub', loadComponent: () => import('./components/auth/stock/hub/machine-hub.component').then(m => m.MachineHubComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/programacao', loadComponent: () => import('./components/auth/stock/programacao/programacao.component').then(m => m.ProgramacaoComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/inventory-hub', loadComponent: () => import('./components/auth/stock/inventory-hub/inventory-hub.component').then(m => m.InventoryHubComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO'] } },
+      { path: 'stock/hub', loadComponent: () => import('./components/auth/stock/hub/machine-hub.component').then(m => m.MachineHubComponent), data: { screen: 'stock/hub', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
+      { path: 'stock/programacao', loadComponent: () => import('./components/auth/stock/programacao/programacao.component').then(m => m.ProgramacaoComponent), data: { screen: 'stock/programacao', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
+      { path: 'stock/inventory-hub', loadComponent: () => import('./components/auth/stock/inventory-hub/inventory-hub.component').then(m => m.InventoryHubComponent), data: { screen: 'stock/inventory-hub', roles: ['ADMIN', 'ALMOXARIFADO'] } },
       // CONTRATOS entra aqui porque a tela de máquinas, que ele acessava, virou
       // esta. Sem isso, dobrar máquina dentro de produto tiraria o acesso dele.
-      { path: 'stock/products', loadComponent: () => import('./components/auth/stock/products/products.component').then(m => m.ProductsComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/movements', loadComponent: () => import('./components/auth/stock/movements/movements.component').then(m => m.MovementsComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO'] } },
+      { path: 'stock/products', loadComponent: () => import('./components/auth/stock/products/products.component').then(m => m.ProductsComponent), data: { screen: 'stock/products', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
+      { path: 'stock/movements', loadComponent: () => import('./components/auth/stock/movements/movements.component').then(m => m.MovementsComponent), data: { screen: 'stock/movements', roles: ['ADMIN', 'ALMOXARIFADO'] } },
       // Máquina virou produto marcado: o cadastro é o de produtos. O redirect
       // fica porque a rota antiga está em link salvo e no menu de quem já usava.
       { path: 'stock/machines', redirectTo: 'stock/products', pathMatch: 'full' },
-      { path: 'stock/alerts', loadComponent: () => import('./components/auth/stock/alerts/machine-alerts.component').then(m => m.MachineAlertsComponent), data: { roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
+      { path: 'stock/alerts', loadComponent: () => import('./components/auth/stock/alerts/machine-alerts.component').then(m => m.MachineAlertsComponent), data: { screen: 'stock/alerts', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
 
       // ── Ferramentas ──────────────────────────────────────────────────────
       // Cada ferramenta é uma rota própria para abrir na sua aba, como as
       // demais telas da área de trabalho.
-      { path: 'tools/pdf', loadComponent: () => import('./components/auth/tools/pdf/pdf-hub/pdf-hub.component').then(m => m.PdfHubComponent) },
-      { path: 'tools/pdf/unlock', loadComponent: () => import('./components/auth/tools/pdf/pdf-unlock/pdf-unlock.component').then(m => m.PdfUnlockComponent) },
-      { path: 'tools/pdf/nfse-rename', loadComponent: () => import('./components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component').then(m => m.PdfNfseRenameComponent) },
-      { path: 'tools/certificados', loadComponent: () => import('./components/auth/tools/certificates/certificate-batch/certificate-batch.component').then(m => m.CertificateBatchComponent), data: { roles: ['ADMIN'] } },
+      { path: 'tools/pdf', loadComponent: () => import('./components/auth/tools/pdf/pdf-hub/pdf-hub.component').then(m => m.PdfHubComponent), data: { screen: 'tools/pdf' } },
+      { path: 'tools/pdf/unlock', loadComponent: () => import('./components/auth/tools/pdf/pdf-unlock/pdf-unlock.component').then(m => m.PdfUnlockComponent), data: { screen: 'tools/pdf/unlock' } },
+      { path: 'tools/pdf/nfse-rename', loadComponent: () => import('./components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component').then(m => m.PdfNfseRenameComponent), data: { screen: 'tools/pdf/nfse-rename' } },
+      { path: 'tools/certificados', loadComponent: () => import('./components/auth/tools/certificates/certificate-batch/certificate-batch.component').then(m => m.CertificateBatchComponent), data: { screen: 'tools/certificados', roles: ['ADMIN'] } },
 
       // ── Empresa ──────────────────────────────────────────────────────────
-      { path: 'company/nfe-collector', loadComponent: () => import('./components/auth/documents/nfe-data-collector/nfe-data-collector.component').then(m => m.NfeDataCollectorComponent), data: { roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },
-      { path: 'company/excel', loadComponent: () => import('./components/auth/documents/excel-credentials/excel-credentials.component').then(m => m.ExcelCredentialsComponent) },
+      { path: 'company/nfe-collector', loadComponent: () => import('./components/auth/documents/nfe-data-collector/nfe-data-collector.component').then(m => m.NfeDataCollectorComponent), data: { screen: 'company/nfe-collector', roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },
+      { path: 'company/excel', loadComponent: () => import('./components/auth/documents/excel-credentials/excel-credentials.component').then(m => m.ExcelCredentialsComponent), data: { screen: 'company/excel' } },
       // As telas de estoque moram em `stock/*`. Estas duas rotas ficaram para
       // trás porque já estavam publicadas (e quebradas) — redirecionam.
       { path: 'company/products', redirectTo: 'stock/products', pathMatch: 'full' },
       { path: 'company/inventory', redirectTo: 'stock/movements', pathMatch: 'full' },
-      { path: 'company/customers', loadComponent: () => import('./components/auth/partners/customer/customer.component').then(m => m.CustomerComponent), data: { roles: ['ADMIN', 'RH', 'MARKETING'] } },
-      { path: 'company/fuel-hub', loadComponent: () => import('./components/auth/company/vehicle/fuel-hub/fuel-hub.component').then(m => m.FuelHubComponent), data: { roles: ['ADMIN', 'COMPRADOR'] } },
-      { path: 'company/fuel-supply', loadComponent: () => import('./components/auth/company/vehicle/fuel-supply/fuel-supply.component').then(m => m.FuelSupplyComponent), data: { roles: ['ADMIN', 'COMPRADOR'] } },
-      { path: 'company/guide', loadComponent: () => import('./components/auth/guide/guide.component').then(m => m.GuideComponent), data: { roles: ['ADMIN', 'CONTRATOS'] } },
-      { path: 'company/equipments', loadComponent: () => import('./components/auth/company/equipments/equipments.component').then(m => m.EquipmentsComponent), data: { roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] } },
+      { path: 'company/customers', loadComponent: () => import('./components/auth/partners/customer/customer.component').then(m => m.CustomerComponent), data: { screen: 'company/customers', roles: ['ADMIN', 'RH', 'MARKETING'] } },
+      { path: 'company/fuel-hub', loadComponent: () => import('./components/auth/company/vehicle/fuel-hub/fuel-hub.component').then(m => m.FuelHubComponent), data: { screen: 'company/fuel-hub', roles: ['ADMIN', 'COMPRADOR'] } },
+      { path: 'company/fuel-supply', loadComponent: () => import('./components/auth/company/vehicle/fuel-supply/fuel-supply.component').then(m => m.FuelSupplyComponent), data: { screen: 'company/fuel-supply', roles: ['ADMIN', 'COMPRADOR'] } },
+      { path: 'company/guide', loadComponent: () => import('./components/auth/guide/guide.component').then(m => m.GuideComponent), data: { screen: 'company/guide', roles: ['ADMIN', 'CONTRATOS'] } },
+      { path: 'company/equipments', loadComponent: () => import('./components/auth/company/equipments/equipments.component').then(m => m.EquipmentsComponent), data: { screen: 'company/equipments', roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] } },
 
       // ── Comunicação ──────────────────────────────────────────────────────
-      { path: 'communication/newsletter', loadComponent: () => import('./components/auth/communication/newsletter/newsletter.component').then(m => m.NewsletterComponent), data: { roles: ['ADMIN', 'MARKETING'] } },
-      { path: 'communication/email', loadComponent: () => import('./components/auth/communication/email/email.component').then(m => m.EmailComponent), data: { roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] } },
-      { path: 'communication/secrets', loadComponent: () => import('./components/auth/communication/secrets/secrets.component').then(m => m.SecretsComponent), data: { roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] } },
-      { path: 'communication/email-signature', loadComponent: () => import('./components/auth/documents/email-signature/email-signature.component').then(m => m.EmailSignatureComponent), data: { roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] } },
-      { path: 'communication/contact', loadComponent: () => import('./components/auth/support/contacts/contacts.component').then(m => m.ContactsComponent), data: { roles: ['ADMIN', 'SUPPORT'] } },
+      { path: 'communication/newsletter', loadComponent: () => import('./components/auth/communication/newsletter/newsletter.component').then(m => m.NewsletterComponent), data: { screen: 'communication/newsletter', roles: ['ADMIN', 'MARKETING'] } },
+      { path: 'communication/email', loadComponent: () => import('./components/auth/communication/email/email.component').then(m => m.EmailComponent), data: { screen: 'communication/email', roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] } },
+      { path: 'communication/secrets', loadComponent: () => import('./components/auth/communication/secrets/secrets.component').then(m => m.SecretsComponent), data: { screen: 'communication/secrets', roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] } },
+      { path: 'communication/email-signature', loadComponent: () => import('./components/auth/documents/email-signature/email-signature.component').then(m => m.EmailSignatureComponent), data: { screen: 'communication/email-signature', roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] } },
+      { path: 'communication/contact', loadComponent: () => import('./components/auth/support/contacts/contacts.component').then(m => m.ContactsComponent), data: { screen: 'communication/contact', roles: ['ADMIN', 'SUPPORT'] } },
 
       // ── Configurações ────────────────────────────────────────────────────
-      { path: 'settings/products/website', loadComponent: () => import('./components/auth/company/products/website/website.component').then(m => m.WebsiteComponent), data: { roles: ['ADMIN', 'DESIGN'] } },
-      { path: 'settings/admin', loadComponent: () => import('./components/auth/admin-center/admin-center.component').then(m => m.AdminCenterComponent), data: { roles: ['ADMIN'] } },
-      { path: 'faq/manager', loadComponent: () => import('./components/auth/faq-manager/faq-manager.component').then(m => m.FaqManagerComponent), data: { roles: ['ADMIN'] } },
-      { path: 'profile-manager', loadComponent: () => import('./components/auth/profile/profile-manager/profile-manager.component').then(m => m.ProfileManagerComponent), data: { roles: ['ADMIN'] } },
+      { path: 'settings/products/website', loadComponent: () => import('./components/auth/company/products/website/website.component').then(m => m.WebsiteComponent), data: { screen: 'settings/products/website', roles: ['ADMIN', 'DESIGN'] } },
+      { path: 'settings/admin', loadComponent: () => import('./components/auth/admin-center/admin-center.component').then(m => m.AdminCenterComponent), data: { screen: 'settings/admin', roles: ['ADMIN'] } },
+      { path: 'faq/manager', loadComponent: () => import('./components/auth/faq-manager/faq-manager.component').then(m => m.FaqManagerComponent), data: { screen: 'faq/manager', roles: ['ADMIN'] } },
+      { path: 'profile-manager', loadComponent: () => import('./components/auth/profile/profile-manager/profile-manager.component').then(m => m.ProfileManagerComponent), data: { screen: 'profile-manager', roles: ['ADMIN'] } },
 
       // ── Financeiro ───────────────────────────────────────────────────────
-      { path: 'finance/rent-receipt-generator', loadComponent: () => import('./components/auth/finance/rent-receipt-generator/rent-receipt-generator.component').then(m => m.RentReceiptGeneratorComponent), data: { roles: ['ADMIN', 'FINANCEIRO'] } },
+      { path: 'finance/rent-receipt-generator', loadComponent: () => import('./components/auth/finance/rent-receipt-generator/rent-receipt-generator.component').then(m => m.RentReceiptGeneratorComponent), data: { screen: 'finance/rent-receipt-generator', roles: ['ADMIN', 'FINANCEIRO'] } },
 
       // ── Documentos (área pessoal) ────────────────────────────────────────
-      { path: 'documentos', loadComponent: () => import('./components/auth/documentos/documentos.component').then(m => m.DocumentosComponent) },
-      { path: 'documentos/galeria', loadComponent: () => import('./components/auth/gallery/gallery.component').then(m => m.GalleryComponent) },
-      { path: 'documentos/logos', loadComponent: () => import('./components/public/branding/branding.component').then(m => m.BrandingComponent) },
-      { path: 'documentos/holerites', loadComponent: () => import('./components/auth/holerites/holerites.component').then(m => m.HoleritesComponent) },
-      { path: 'documentos/rh', loadComponent: () => import('./components/auth/hr-hub/hr-hub.component').then(m => m.HrHubComponent) },
-      { path: 'documentos/rh/documents', loadComponent: () => import('./components/auth/hr-documents/hr-documents.component').then(m => m.HrDocumentsComponent) },
-      { path: 'documentos/rh/medical-certificates', loadComponent: () => import('./components/auth/hr-medical-certificates/hr-medical-certificates.component').then(m => m.HrMedicalCertificatesComponent) },
-      { path: 'documentos/rh/reimbursements', loadComponent: () => import('./components/auth/hr-reimbursements/hr-reimbursements.component').then(m => m.HrReimbursementsComponent) },
-      { path: 'documentos/rh/vacation-requests', loadComponent: () => import('./components/auth/hr-vacation-requests/hr-vacation-requests.component').then(m => m.HrVacationRequestsComponent) },
-      { path: 'documentos/rh/announcements', loadComponent: () => import('./components/auth/hr-announcements/hr-announcements.component').then(m => m.HrAnnouncementsComponent) },
+      { path: 'documentos', loadComponent: () => import('./components/auth/documentos/documentos.component').then(m => m.DocumentosComponent), data: { screen: 'documentos' } },
+      { path: 'documentos/galeria', loadComponent: () => import('./components/auth/gallery/gallery.component').then(m => m.GalleryComponent), data: { screen: 'documentos/galeria' } },
+      { path: 'documentos/logos', loadComponent: () => import('./components/public/branding/branding.component').then(m => m.BrandingComponent), data: { screen: 'documentos/logos' } },
+      { path: 'documentos/holerites', loadComponent: () => import('./components/auth/holerites/holerites.component').then(m => m.HoleritesComponent), data: { screen: 'documentos/holerites' } },
+      { path: 'documentos/rh', loadComponent: () => import('./components/auth/hr-hub/hr-hub.component').then(m => m.HrHubComponent), data: { screen: 'documentos/rh' } },
+      { path: 'documentos/rh/documents', loadComponent: () => import('./components/auth/hr-documents/hr-documents.component').then(m => m.HrDocumentsComponent), data: { screen: 'documentos/rh/documents' } },
+      { path: 'documentos/rh/medical-certificates', loadComponent: () => import('./components/auth/hr-medical-certificates/hr-medical-certificates.component').then(m => m.HrMedicalCertificatesComponent), data: { screen: 'documentos/rh/medical-certificates' } },
+      { path: 'documentos/rh/reimbursements', loadComponent: () => import('./components/auth/hr-reimbursements/hr-reimbursements.component').then(m => m.HrReimbursementsComponent), data: { screen: 'documentos/rh/reimbursements' } },
+      { path: 'documentos/rh/vacation-requests', loadComponent: () => import('./components/auth/hr-vacation-requests/hr-vacation-requests.component').then(m => m.HrVacationRequestsComponent), data: { screen: 'documentos/rh/vacation-requests' } },
+      { path: 'documentos/rh/announcements', loadComponent: () => import('./components/auth/hr-announcements/hr-announcements.component').then(m => m.HrAnnouncementsComponent), data: { screen: 'documentos/rh/announcements' } },
 
       { path: 'notificacoes', loadComponent: () => import('./components/auth/notificacoes/notificacoes.component').then(m => m.NotificacoesComponent) },
-      { path: 'perfil', loadComponent: () => import('./components/auth/perfil/perfil.component').then(m => m.PerfilComponent) },
+      { path: 'perfil', loadComponent: () => import('./components/auth/perfil/perfil.component').then(m => m.PerfilComponent), data: { screen: 'perfil' } },
     ],
   },
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -61,41 +61,40 @@ export const routes: Routes = [
       { path: 'unauthorized', loadComponent: () => import('./components/auth/access-denied/access-denied.component').then(m => m.AccessDeniedComponent) },
 
       // ── RH (gestão) ──────────────────────────────────────────────────────
-      { path: 'rh/hub', loadComponent: () => import('./components/auth/rh/rh-hub/rh-hub.component').then(m => m.RhHubComponent), data: { screen: 'rh/hub', roles: ['ADMIN', 'RH'] } },
+      { path: 'rh/hub', loadComponent: () => import('./components/auth/rh/rh-hub/rh-hub.component').then(m => m.RhHubComponent), data: { screen: 'rh/hub' } },
       // Menu de ferramentas + conteúdo ao lado. A rota era o separador direto;
-      // ele virou uma das ferramentas de dentro. Papéis declarados: esta era a
-      // única tela do RH sem `roles`, e ela publica holerite.
-      { path: 'rh/holerit', loadComponent: () => import('./components/auth/documents/holerite-hub/holerite-hub.component').then(m => m.HoleriteHubComponent), data: { screen: 'rh/holerit', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/holerit/extractor', loadComponent: () => import('./components/auth/documents/holerit-extractor/holerit-extractor.component').then(m => m.HoleritExtractorComponent), data: { screen: 'rh/holerit/extractor', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/employees', loadComponent: () => import('./components/auth/partners/employes/employes.component').then(m => m.EmployesComponent), data: { screen: 'rh/employees', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/organizational-structure', loadComponent: () => import('./components/auth/rh/org-structure/org-structure.component').then(m => m.OrgStructureComponent), data: { screen: 'rh/organizational-structure', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/career-structure', loadComponent: () => import('./components/auth/rh/career-structure/career-structure.component').then(m => m.CareerStructureComponent), data: { screen: 'rh/career-structure', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/vacation-requests', loadComponent: () => import('./components/auth/rh/vacation-requests-manager/vacation-requests-manager.component').then(m => m.VacationRequestsManagerComponent), data: { screen: 'rh/vacation-requests', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/reimbursements', loadComponent: () => import('./components/auth/rh/reimbursements-manager/reimbursements-manager.component').then(m => m.ReimbursementsManagerComponent), data: { screen: 'rh/reimbursements', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/calendar', loadComponent: () => import('./components/auth/rh/hr-calendar/hr-calendar.component').then(m => m.HrCalendarComponent), data: { screen: 'rh/calendar', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/team-overview', loadComponent: () => import('./components/auth/rh/team-overview/team-overview.component').then(m => m.TeamOverviewComponent), data: { screen: 'rh/team-overview', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/calculators', loadComponent: () => import('./components/auth/rh/hr-calculators/hr-calculators.component').then(m => m.HrCalculatorsComponent), data: { screen: 'rh/calculators', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/equipment-assignments', loadComponent: () => import('./components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component').then(m => m.HrEquipmentAssignmentsComponent), data: { screen: 'rh/equipment-assignments', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/notifications', loadComponent: () => import('./components/auth/rh/hr-notifications/hr-notifications.component').then(m => m.HrNotificationsComponent), data: { screen: 'rh/notifications', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/announcements', loadComponent: () => import('./components/auth/rh/hr-announcements-manager/hr-announcements-manager.component').then(m => m.HrAnnouncementsManagerComponent), data: { screen: 'rh/announcements', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/medical-certificates', loadComponent: () => import('./components/auth/rh/medical-certificates-manager/medical-certificates-manager.component').then(m => m.MedicalCertificatesManagerComponent), data: { screen: 'rh/medical-certificates', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/painel-de-vagas', loadComponent: () => import('./components/auth/rh/painel-de-vagas/painel-de-vagas.component').then(m => m.PainelDeVagasComponent), data: { screen: 'rh/painel-de-vagas', roles: ['ADMIN', 'RH'] } },
-      { path: 'rh/candidaturas', loadComponent: () => import('./components/auth/rh/candidaturas/candidaturas.component').then(m => m.CandidaturasComponent), data: { screen: 'rh/candidaturas', roles: ['ADMIN', 'RH'] } },
+      // ele virou uma das ferramentas de dentro.
+      { path: 'rh/holerit', loadComponent: () => import('./components/auth/documents/holerite-hub/holerite-hub.component').then(m => m.HoleriteHubComponent), data: { screen: 'rh/holerit' } },
+      { path: 'rh/holerit/extractor', loadComponent: () => import('./components/auth/documents/holerit-extractor/holerit-extractor.component').then(m => m.HoleritExtractorComponent), data: { screen: 'rh/holerit/extractor' } },
+      { path: 'rh/employees', loadComponent: () => import('./components/auth/partners/employes/employes.component').then(m => m.EmployesComponent), data: { screen: 'rh/employees' } },
+      { path: 'rh/organizational-structure', loadComponent: () => import('./components/auth/rh/org-structure/org-structure.component').then(m => m.OrgStructureComponent), data: { screen: 'rh/organizational-structure' } },
+      { path: 'rh/career-structure', loadComponent: () => import('./components/auth/rh/career-structure/career-structure.component').then(m => m.CareerStructureComponent), data: { screen: 'rh/career-structure' } },
+      { path: 'rh/vacation-requests', loadComponent: () => import('./components/auth/rh/vacation-requests-manager/vacation-requests-manager.component').then(m => m.VacationRequestsManagerComponent), data: { screen: 'rh/vacation-requests' } },
+      { path: 'rh/reimbursements', loadComponent: () => import('./components/auth/rh/reimbursements-manager/reimbursements-manager.component').then(m => m.ReimbursementsManagerComponent), data: { screen: 'rh/reimbursements' } },
+      { path: 'rh/calendar', loadComponent: () => import('./components/auth/rh/hr-calendar/hr-calendar.component').then(m => m.HrCalendarComponent), data: { screen: 'rh/calendar' } },
+      { path: 'rh/team-overview', loadComponent: () => import('./components/auth/rh/team-overview/team-overview.component').then(m => m.TeamOverviewComponent), data: { screen: 'rh/team-overview' } },
+      { path: 'rh/calculators', loadComponent: () => import('./components/auth/rh/hr-calculators/hr-calculators.component').then(m => m.HrCalculatorsComponent), data: { screen: 'rh/calculators' } },
+      { path: 'rh/equipment-assignments', loadComponent: () => import('./components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component').then(m => m.HrEquipmentAssignmentsComponent), data: { screen: 'rh/equipment-assignments' } },
+      { path: 'rh/notifications', loadComponent: () => import('./components/auth/rh/hr-notifications/hr-notifications.component').then(m => m.HrNotificationsComponent), data: { screen: 'rh/notifications' } },
+      { path: 'rh/announcements', loadComponent: () => import('./components/auth/rh/hr-announcements-manager/hr-announcements-manager.component').then(m => m.HrAnnouncementsManagerComponent), data: { screen: 'rh/announcements' } },
+      { path: 'rh/medical-certificates', loadComponent: () => import('./components/auth/rh/medical-certificates-manager/medical-certificates-manager.component').then(m => m.MedicalCertificatesManagerComponent), data: { screen: 'rh/medical-certificates' } },
+      { path: 'rh/painel-de-vagas', loadComponent: () => import('./components/auth/rh/painel-de-vagas/painel-de-vagas.component').then(m => m.PainelDeVagasComponent), data: { screen: 'rh/painel-de-vagas' } },
+      { path: 'rh/candidaturas', loadComponent: () => import('./components/auth/rh/candidaturas/candidaturas.component').then(m => m.CandidaturasComponent), data: { screen: 'rh/candidaturas' } },
 
       // ── Estoque (ProStock) ───────────────────────────────────────────────
       // Mesmas funções do desktop JavaFX, que continua no ar consumindo a
       // mesma API — nenhum contrato pode mudar aqui.
-      { path: 'stock/hub', loadComponent: () => import('./components/auth/stock/hub/machine-hub.component').then(m => m.MachineHubComponent), data: { screen: 'stock/hub', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/programacao', loadComponent: () => import('./components/auth/stock/programacao/programacao.component').then(m => m.ProgramacaoComponent), data: { screen: 'stock/programacao', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/inventory-hub', loadComponent: () => import('./components/auth/stock/inventory-hub/inventory-hub.component').then(m => m.InventoryHubComponent), data: { screen: 'stock/inventory-hub', roles: ['ADMIN', 'ALMOXARIFADO'] } },
+      { path: 'stock/hub', loadComponent: () => import('./components/auth/stock/hub/machine-hub.component').then(m => m.MachineHubComponent), data: { screen: 'stock/hub' } },
+      { path: 'stock/programacao', loadComponent: () => import('./components/auth/stock/programacao/programacao.component').then(m => m.ProgramacaoComponent), data: { screen: 'stock/programacao' } },
+      { path: 'stock/inventory-hub', loadComponent: () => import('./components/auth/stock/inventory-hub/inventory-hub.component').then(m => m.InventoryHubComponent), data: { screen: 'stock/inventory-hub' } },
       // CONTRATOS entra aqui porque a tela de máquinas, que ele acessava, virou
       // esta. Sem isso, dobrar máquina dentro de produto tiraria o acesso dele.
-      { path: 'stock/products', loadComponent: () => import('./components/auth/stock/products/products.component').then(m => m.ProductsComponent), data: { screen: 'stock/products', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
-      { path: 'stock/movements', loadComponent: () => import('./components/auth/stock/movements/movements.component').then(m => m.MovementsComponent), data: { screen: 'stock/movements', roles: ['ADMIN', 'ALMOXARIFADO'] } },
+      { path: 'stock/products', loadComponent: () => import('./components/auth/stock/products/products.component').then(m => m.ProductsComponent), data: { screen: 'stock/products' } },
+      { path: 'stock/movements', loadComponent: () => import('./components/auth/stock/movements/movements.component').then(m => m.MovementsComponent), data: { screen: 'stock/movements' } },
       // Máquina virou produto marcado: o cadastro é o de produtos. O redirect
       // fica porque a rota antiga está em link salvo e no menu de quem já usava.
       { path: 'stock/machines', redirectTo: 'stock/products', pathMatch: 'full' },
-      { path: 'stock/alerts', loadComponent: () => import('./components/auth/stock/alerts/machine-alerts.component').then(m => m.MachineAlertsComponent), data: { screen: 'stock/alerts', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] } },
+      { path: 'stock/alerts', loadComponent: () => import('./components/auth/stock/alerts/machine-alerts.component').then(m => m.MachineAlertsComponent), data: { screen: 'stock/alerts' } },
 
       // ── Ferramentas ──────────────────────────────────────────────────────
       // Cada ferramenta é uma rota própria para abrir na sua aba, como as
@@ -103,38 +102,38 @@ export const routes: Routes = [
       { path: 'tools/pdf', loadComponent: () => import('./components/auth/tools/pdf/pdf-hub/pdf-hub.component').then(m => m.PdfHubComponent), data: { screen: 'tools/pdf' } },
       { path: 'tools/pdf/unlock', loadComponent: () => import('./components/auth/tools/pdf/pdf-unlock/pdf-unlock.component').then(m => m.PdfUnlockComponent), data: { screen: 'tools/pdf/unlock' } },
       { path: 'tools/pdf/nfse-rename', loadComponent: () => import('./components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component').then(m => m.PdfNfseRenameComponent), data: { screen: 'tools/pdf/nfse-rename' } },
-      { path: 'tools/certificados', loadComponent: () => import('./components/auth/tools/certificates/certificate-batch/certificate-batch.component').then(m => m.CertificateBatchComponent), data: { screen: 'tools/certificados', roles: ['ADMIN'] } },
+      { path: 'tools/certificados', loadComponent: () => import('./components/auth/tools/certificates/certificate-batch/certificate-batch.component').then(m => m.CertificateBatchComponent), data: { screen: 'tools/certificados' } },
 
       // ── Empresa ──────────────────────────────────────────────────────────
-      { path: 'company/nfe-collector', loadComponent: () => import('./components/auth/documents/nfe-data-collector/nfe-data-collector.component').then(m => m.NfeDataCollectorComponent), data: { screen: 'company/nfe-collector', roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] } },
+      { path: 'company/nfe-collector', loadComponent: () => import('./components/auth/documents/nfe-data-collector/nfe-data-collector.component').then(m => m.NfeDataCollectorComponent), data: { screen: 'company/nfe-collector' } },
       { path: 'company/excel', loadComponent: () => import('./components/auth/documents/excel-credentials/excel-credentials.component').then(m => m.ExcelCredentialsComponent), data: { screen: 'company/excel' } },
       // As telas de estoque moram em `stock/*`. Estas duas rotas ficaram para
       // trás porque já estavam publicadas (e quebradas) — redirecionam.
       { path: 'company/products', redirectTo: 'stock/products', pathMatch: 'full' },
       { path: 'company/inventory', redirectTo: 'stock/movements', pathMatch: 'full' },
-      { path: 'company/customers', loadComponent: () => import('./components/auth/partners/customer/customer.component').then(m => m.CustomerComponent), data: { screen: 'company/customers', roles: ['ADMIN', 'RH', 'MARKETING'] } },
-      { path: 'company/fuel-hub', loadComponent: () => import('./components/auth/company/vehicle/fuel-hub/fuel-hub.component').then(m => m.FuelHubComponent), data: { screen: 'company/fuel-hub', roles: ['ADMIN', 'COMPRADOR'] } },
-      { path: 'company/fuel-supply', loadComponent: () => import('./components/auth/company/vehicle/fuel-supply/fuel-supply.component').then(m => m.FuelSupplyComponent), data: { screen: 'company/fuel-supply', roles: ['ADMIN', 'COMPRADOR'] } },
-      { path: 'company/guide', loadComponent: () => import('./components/auth/guide/guide.component').then(m => m.GuideComponent), data: { screen: 'company/guide', roles: ['ADMIN', 'CONTRATOS'] } },
-      { path: 'company/equipments', loadComponent: () => import('./components/auth/company/equipments/equipments.component').then(m => m.EquipmentsComponent), data: { screen: 'company/equipments', roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] } },
+      { path: 'company/customers', loadComponent: () => import('./components/auth/partners/customer/customer.component').then(m => m.CustomerComponent), data: { screen: 'company/customers' } },
+      { path: 'company/fuel-hub', loadComponent: () => import('./components/auth/company/vehicle/fuel-hub/fuel-hub.component').then(m => m.FuelHubComponent), data: { screen: 'company/fuel-hub' } },
+      { path: 'company/fuel-supply', loadComponent: () => import('./components/auth/company/vehicle/fuel-supply/fuel-supply.component').then(m => m.FuelSupplyComponent), data: { screen: 'company/fuel-supply' } },
+      { path: 'company/guide', loadComponent: () => import('./components/auth/guide/guide.component').then(m => m.GuideComponent), data: { screen: 'company/guide' } },
+      { path: 'company/equipments', loadComponent: () => import('./components/auth/company/equipments/equipments.component').then(m => m.EquipmentsComponent), data: { screen: 'company/equipments' } },
 
       // ── Comunicação ──────────────────────────────────────────────────────
-      { path: 'communication/newsletter', loadComponent: () => import('./components/auth/communication/newsletter/newsletter.component').then(m => m.NewsletterComponent), data: { screen: 'communication/newsletter', roles: ['ADMIN', 'MARKETING'] } },
-      { path: 'communication/email', loadComponent: () => import('./components/auth/communication/email/email.component').then(m => m.EmailComponent), data: { screen: 'communication/email', roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] } },
-      { path: 'communication/secrets', loadComponent: () => import('./components/auth/communication/secrets/secrets.component').then(m => m.SecretsComponent), data: { screen: 'communication/secrets', roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] } },
-      { path: 'communication/email-signature', loadComponent: () => import('./components/auth/documents/email-signature/email-signature.component').then(m => m.EmailSignatureComponent), data: { screen: 'communication/email-signature', roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] } },
-      { path: 'communication/contact', loadComponent: () => import('./components/auth/support/contacts/contacts.component').then(m => m.ContactsComponent), data: { screen: 'communication/contact', roles: ['ADMIN', 'SUPPORT'] } },
+      { path: 'communication/newsletter', loadComponent: () => import('./components/auth/communication/newsletter/newsletter.component').then(m => m.NewsletterComponent), data: { screen: 'communication/newsletter' } },
+      { path: 'communication/email', loadComponent: () => import('./components/auth/communication/email/email.component').then(m => m.EmailComponent), data: { screen: 'communication/email' } },
+      { path: 'communication/secrets', loadComponent: () => import('./components/auth/communication/secrets/secrets.component').then(m => m.SecretsComponent), data: { screen: 'communication/secrets' } },
+      { path: 'communication/email-signature', loadComponent: () => import('./components/auth/documents/email-signature/email-signature.component').then(m => m.EmailSignatureComponent), data: { screen: 'communication/email-signature' } },
+      { path: 'communication/contact', loadComponent: () => import('./components/auth/support/contacts/contacts.component').then(m => m.ContactsComponent), data: { screen: 'communication/contact' } },
 
       // ── Configurações ────────────────────────────────────────────────────
-      { path: 'settings/products/website', loadComponent: () => import('./components/auth/company/products/website/website.component').then(m => m.WebsiteComponent), data: { screen: 'settings/products/website', roles: ['ADMIN', 'DESIGN'] } },
-      { path: 'settings/admin', loadComponent: () => import('./components/auth/admin-center/admin-center.component').then(m => m.AdminCenterComponent), data: { screen: 'settings/admin', roles: ['ADMIN'] } },
-      { path: 'settings/permissions/templates', loadComponent: () => import('./components/auth/settings/permissions/templates/permission-templates.component').then(m => m.PermissionTemplatesComponent), data: { screen: 'settings/permissions/templates', roles: ['ADMIN'] } },
-      { path: 'settings/permissions/users', loadComponent: () => import('./components/auth/settings/permissions/users/permission-users.component').then(m => m.PermissionUsersComponent), data: { screen: 'settings/permissions/users', roles: ['ADMIN'] } },
-      { path: 'faq/manager', loadComponent: () => import('./components/auth/faq-manager/faq-manager.component').then(m => m.FaqManagerComponent), data: { screen: 'faq/manager', roles: ['ADMIN'] } },
-      { path: 'profile-manager', loadComponent: () => import('./components/auth/profile/profile-manager/profile-manager.component').then(m => m.ProfileManagerComponent), data: { screen: 'profile-manager', roles: ['ADMIN'] } },
+      { path: 'settings/products/website', loadComponent: () => import('./components/auth/company/products/website/website.component').then(m => m.WebsiteComponent), data: { screen: 'settings/products/website' } },
+      { path: 'settings/admin', loadComponent: () => import('./components/auth/admin-center/admin-center.component').then(m => m.AdminCenterComponent), data: { screen: 'settings/admin' } },
+      { path: 'settings/permissions/templates', loadComponent: () => import('./components/auth/settings/permissions/templates/permission-templates.component').then(m => m.PermissionTemplatesComponent), data: { screen: 'settings/permissions/templates' } },
+      { path: 'settings/permissions/users', loadComponent: () => import('./components/auth/settings/permissions/users/permission-users.component').then(m => m.PermissionUsersComponent), data: { screen: 'settings/permissions/users' } },
+      { path: 'faq/manager', loadComponent: () => import('./components/auth/faq-manager/faq-manager.component').then(m => m.FaqManagerComponent), data: { screen: 'faq/manager' } },
+      { path: 'profile-manager', loadComponent: () => import('./components/auth/profile/profile-manager/profile-manager.component').then(m => m.ProfileManagerComponent), data: { screen: 'profile-manager' } },
 
       // ── Financeiro ───────────────────────────────────────────────────────
-      { path: 'finance/rent-receipt-generator', loadComponent: () => import('./components/auth/finance/rent-receipt-generator/rent-receipt-generator.component').then(m => m.RentReceiptGeneratorComponent), data: { screen: 'finance/rent-receipt-generator', roles: ['ADMIN', 'FINANCEIRO'] } },
+      { path: 'finance/rent-receipt-generator', loadComponent: () => import('./components/auth/finance/rent-receipt-generator/rent-receipt-generator.component').then(m => m.RentReceiptGeneratorComponent), data: { screen: 'finance/rent-receipt-generator' } },
 
       // ── Documentos (área pessoal) ────────────────────────────────────────
       { path: 'documentos', loadComponent: () => import('./components/auth/documentos/documentos.component').then(m => m.DocumentosComponent), data: { screen: 'documentos' } },

--- a/src/app/components/auth/admin-center/admin-center.component.html
+++ b/src/app/components/auth/admin-center/admin-center.component.html
@@ -55,6 +55,12 @@
             Sem vínculo
           </span>
         </td>
+        <!--
+          Setor, e não acesso. Desde a V86 estes valores não decidem mais nada:
+          o menu e a API leem `user_permissions`. Ficam como histórico de onde a
+          pessoa veio, e o rótulo diz isso para ninguém mexer achando que muda
+          alguma coisa.
+        -->
         <td>
           <span class="ac-tag" *ngFor="let role of user.roles" [attr.data-role]="role">
             {{ getRoleLabel(role) }}
@@ -69,7 +75,9 @@
         <td style="text-align: center">
           <div class="ac-actions">
             <pk-button pkType="edit" pkSize="sm" [pkIconOnly]="true"
-                       pkTooltip="Editar permissões" (clicked)="selectUserToEdit(user)"/>
+                       pkIcon="pi pi-lock"
+                       pkTooltip="Permissões desta pessoa"
+                       (clicked)="openPermissions(user)"/>
             <pk-button *ngIf="!user.roles.includes('DEVELOPER')"
                        [pkType]="user.active ? 'delete' : 'save'" pkSize="sm" [pkIconOnly]="true"
                        [pkIcon]="user.active ? 'pi pi-lock' : 'pi pi-lock-open'"
@@ -115,9 +123,11 @@
                        placeholder="Repita a senha"/>
         </ng-container>
 
-        <pk-multiselect formControlName="roles" label="Permissões" [pkRequired]="true"
-                        [options]="availableRoles" optionLabel="label" optionValue="value"
-                        placeholder="Selecione as permissões"/>
+        <p class="ac-form-hint">
+          O acesso não é dado aqui. O usuário nasce sem tela nenhuma e recebe o
+          modelo <b>Base</b> no primeiro acesso; o resto se configura em
+          <b>Configurações › Permissões por usuário</b>.
+        </p>
       </div>
 
       <button type="submit" hidden></button>

--- a/src/app/components/auth/admin-center/admin-center.component.ts
+++ b/src/app/components/auth/admin-center/admin-center.component.ts
@@ -1,7 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { AuthService } from './../../../infrastructure/services/auth.service';
-import { Component, OnInit, signal } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { TabDirtyCheck } from '../../../infrastructure/routing/tab-dirty-check';
 import { ToastModule } from 'primeng/toast';
 import { MessageService } from 'primeng/api';
@@ -40,6 +41,8 @@ export class AdminCenterComponent implements OnInit, TabDirtyCheck {
   isTabDirty(): boolean {
     return this.mode() === 'form' && this.registerForm.dirty;
   }
+
+  private readonly router = inject(Router);
 
   loading = false;
   registerForm!: FormGroup;
@@ -92,7 +95,6 @@ export class AdminCenterComponent implements OnInit, TabDirtyCheck {
       email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required, Validators.minLength(8)]],
       confirmPassword: ['', [Validators.required]],
-      roles: [[], [Validators.required]]
     }, { validators: this.passwordMatchValidator });
   }
 
@@ -106,25 +108,17 @@ export class AdminCenterComponent implements OnInit, TabDirtyCheck {
     this.mode.set('form');
   }
 
-  /** Abre o modal já preenchido para editar as permissões de um usuário. */
-  selectUserToEdit(user: UserResponseDTO): void {
-    this.editingUser = user;
-    this.buildRegisterForm();
-
-    // Na edição só as permissões mudam: login travado; e-mail e senha não se aplicam
-    ['email', 'password', 'confirmPassword'].forEach(name => {
-      const control = this.registerForm.get(name);
-      control?.clearValidators();
-      control?.updateValueAndValidity();
-    });
-    this.registerForm.get('login')?.disable();
-
-    this.registerForm.patchValue({
-      login: user.login,
-      roles: [...user.roles]
-    });
-
-    this.mode.set('form');
+  /**
+   * Leva para as permissões desta pessoa.
+   *
+   * Antes isto abria um formulário cujo único campo editável era o multiselect
+   * de papéis — e desde a V86 mexer nele **não muda o menu de ninguém**. Quem
+   * decide acesso agora é a tela de Permissões por usuário, e o caminho mais
+   * curto até ela é este botão.
+   */
+  openPermissions(user: UserResponseDTO): void {
+    this.router.navigate(['settings/permissions/users'],
+      { queryParams: { login: user.login } });
   }
 
   /** Fecha o modal e restaura o formulário ao estado inicial. */
@@ -153,30 +147,7 @@ export class AdminCenterComponent implements OnInit, TabDirtyCheck {
       return;
     }
 
-    if (this.editingUser) {
-      this.updateRoles();
-    } else {
-      this.registerNewUser();
-    }
-  }
-
-  private updateRoles(): void {
-    this.isSubmitting = true;
-    const roles: string[] = this.registerForm.get('roles')?.value;
-
-    const editingLogin = this.editingUser!.login;
-    this.authService.updateUserRoles(editingLogin, roles).subscribe({
-      next: () => {
-        this.editingUser!.roles = [...roles]; // atualiza linha na tabela sem recarregar
-        this.messageService.add({ severity: 'success', summary: 'Sucesso', detail: `Permissões de "${editingLogin}" atualizadas!` });
-        this.isSubmitting = false;
-        this.closeDialog();
-      },
-      error: (err) => {
-        this.isSubmitting = false;
-        this.messageService.add({ severity: 'error', summary: 'Erro', detail: 'Falha ao atualizar permissões.' });
-      }
-    });
+    this.registerNewUser();
   }
 
   private registerNewUser(): void {
@@ -186,7 +157,9 @@ export class AdminCenterComponent implements OnInit, TabDirtyCheck {
       login: formValue.login,
       email: formValue.email,
       password: formValue.password,
-      roles: formValue.roles
+      // Tipo de conta, e nada mais: quem dá acesso é a tela de Permissões, e o
+      // primeiro acesso já carimba o modelo Base.
+      roles: ['USER']
     };
 
     this.authService.registerUser(registerData).subscribe({

--- a/src/app/components/auth/documentos/documentos.component.html
+++ b/src/app/components/auth/documentos/documentos.component.html
@@ -5,15 +5,8 @@
     subtitle="Acesse os arquivos e materiais da empresa" />
 
   <div class="docs-grid">
-    @for (cat of categorias; track cat.titulo) {
-      <button type="button"
-              class="doc-card"
-              [class.doc-card--disabled]="cat.emDesenvolvimento"
-              (click)="abrir(cat)">
-
-        @if (cat.emDesenvolvimento) {
-          <span class="doc-card__badge">Em breve</span>
-        }
+    @for (cat of categorias(); track cat.rota) {
+      <button type="button" class="doc-card" (click)="abrir(cat)">
 
         <span class="doc-card__icon" [style.--accent]="cat.accent">
           <i [class]="cat.icon"></i>
@@ -24,10 +17,17 @@
           <span class="doc-card__desc">{{ cat.descricao }}</span>
         </span>
 
-        @if (!cat.emDesenvolvimento) {
-          <i class="pi pi-chevron-right doc-card__arrow"></i>
-        }
+        <i class="pi pi-chevron-right doc-card__arrow"></i>
       </button>
+    } @empty {
+      <!--
+        Só acontece se a pessoa não puder abrir nenhuma das telas — e aí a
+        página vazia sem explicação pareceria defeito.
+      -->
+      <p class="docs-empty">
+        Você ainda não tem acesso a nenhuma pasta de documentos. Fale com quem
+        cuida das permissões.
+      </p>
     }
   </div>
 </section>

--- a/src/app/components/auth/documentos/documentos.component.scss
+++ b/src/app/components/auth/documentos/documentos.component.scss
@@ -81,7 +81,7 @@
 
   // ── Hover (active cards only) ──
 
-  &:hover:not(.doc-card--disabled) {
+  &:hover {
     transform: translateY(-3px);
     border-color: color-mix(in srgb, var(--accent) 35%, transparent);
     box-shadow: var(--app-shadow-sm);
@@ -93,36 +93,11 @@
     }
   }
 
-  &:active:not(.doc-card--disabled) {
+  &:active {
     transform: scale(0.98);
     transition-duration: 0.06s;
   }
 
-  // ── Disabled ──
-
-  &--disabled {
-    cursor: default;
-    opacity: 0.5;
-    border-style: dashed;
-
-    .doc-card__arrow { display: none; }
-  }
-
-  // ── Badge ──
-
-  &__badge {
-    position: absolute;
-    top: 10px;
-    right: 12px;
-    background: var(--app-text-muted);
-    color: #fff;
-    font-size: 0.65rem;
-    font-weight: 700;
-    padding: 2px 8px;
-    border-radius: 20px;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
 }
 
 // ── Tablet ───────────────────────────────────────────────────────────────────
@@ -162,14 +137,7 @@
       overflow: hidden;
     }
 
-    &__badge {
-      top: 8px;
-      right: 8px;
-      font-size: 0.6rem;
-      padding: 2px 6px;
-    }
-
-    &:hover:not(.doc-card--disabled) {
+    &:hover {
       transform: none;
     }
   }
@@ -179,4 +147,20 @@
   .docs-grid {
     grid-template-columns: 1fr;
   }
+}
+
+// ── Sem acesso a nada ────────────────────────────────────────────────────────
+//
+// A grade filtra por permissão, então esta mensagem é o único conteúdo que
+// sobra para quem não abre nenhuma pasta. Sem ela, a página apareceria vazia e
+// pareceria defeito.
+.docs-empty {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 28px 20px;
+  text-align: center;
+  color: var(--app-text-muted);
+  font-size: 0.9rem;
+  border: 1px dashed var(--app-border-strong);
+  border-radius: var(--radius-surface);
 }

--- a/src/app/components/auth/documentos/documentos.component.spec.ts
+++ b/src/app/components/auth/documentos/documentos.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { Router } from '@angular/router';
+
+import { DocumentosComponent } from './documentos.component';
+import { PermissionStore } from '../../../infrastructure/state/permission.store';
+
+/**
+ * O hub de Documentos, depois que o "Em breve" saiu.
+ *
+ * Três cards ficavam meses anunciando telas que não existiam. O que substituiu
+ * a promessa foi o controle de acesso: o card aparece quando a pessoa consegue
+ * abrir a tela, e some quando não consegue.
+ *
+ * O que estes testes protegem é a **ausência**, que é o modo de falha desta
+ * tela: card a mais leva a pessoa para o acesso negado; card a menos esconde
+ * uma pasta que ela poderia usar. Nenhum dos dois dá erro.
+ */
+describe('DocumentosComponent', () => {
+  let fixture: ComponentFixture<DocumentosComponent>;
+  let component: DocumentosComponent;
+
+  /** As telas que a pessoa enxerga neste teste. */
+  let abertas: string[];
+
+  beforeEach(async () => {
+    abertas = [];
+
+    await TestBed.configureTestingModule({
+      imports: [DocumentosComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: Router, useValue: jasmine.createSpyObj<Router>('Router', ['navigate']) },
+        {
+          provide: PermissionStore,
+          useValue: { canOpen: (tela: string) => abertas.includes(tela) },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  const montar = () => {
+    fixture = TestBed.createComponent(DocumentosComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  const titulos = () => component.categorias().map(c => c.titulo);
+
+  it('mostra só as pastas que a pessoa consegue abrir', () => {
+    abertas = ['documentos/galeria', 'documentos/holerites'];
+    montar();
+
+    expect(titulos()).toEqual(['Galeria', 'Holerites']);
+  });
+
+  /**
+   * **O "Pessoal" tinha tela desde sempre.**
+   *
+   * `documentos/rh` é o Portal do funcionário, e o card ficou meses marcado
+   * como "em breve" apontando para lugar nenhum.
+   */
+  it('o card Pessoal leva ao Portal do funcionário', () => {
+    abertas = ['documentos/rh'];
+    montar();
+
+    expect(component.categorias()[0].rota).toBe('documentos/rh');
+  });
+
+  /**
+   * Qualquer uma das sete abre a tela — não só `CONSULTAR`.
+   *
+   * É o técnico que lança um reembolso sem poder ver os dos outros: ele precisa
+   * do card mesmo sem permissão de consulta.
+   */
+  it('basta ter qualquer permissão na tela para ver o card', () => {
+    abertas = ['documentos/logos'];
+    montar();
+
+    expect(titulos()).toContain('Logos');
+  });
+
+  /**
+   * **A página vazia precisa dizer alguma coisa.**
+   *
+   * Sem esta mensagem, quem não tem acesso a nada abre o hub e vê um retângulo
+   * em branco — que parece defeito, e vira chamado.
+   */
+  it('sem acesso a nada, explica em vez de ficar em branco', () => {
+    montar();
+
+    expect(titulos()).toEqual([]);
+    expect(fixture.nativeElement.textContent).toContain('ainda não tem acesso');
+  });
+
+  /** E o "Em breve" não existe mais em lugar nenhum da tela. */
+  it('nenhum card fica marcado como Em breve', () => {
+    abertas = ['documentos/galeria', 'documentos/logos', 'documentos/holerites',
+               'documentos/rh', 'tools/pdf'];
+    montar();
+
+    expect(fixture.nativeElement.textContent).not.toContain('Em breve');
+    expect(titulos().length).toBe(5);
+  });
+});

--- a/src/app/components/auth/documentos/documentos.component.ts
+++ b/src/app/components/auth/documentos/documentos.component.ts
@@ -1,17 +1,33 @@
-import { Component } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { PageHeaderComponent } from '../shared/page-header/page-header.component';
+import { PermissionStore } from '../../../infrastructure/state/permission.store';
 
 interface CategoriaDoc {
   titulo: string;
   descricao: string;
   icon: string;
   accent: string;
-  rota?: string;
-  emDesenvolvimento?: boolean;
+  /** A rota, que é também o código da tela no catálogo de permissões. */
+  rota: string;
 }
 
+/**
+ * O hub de Documentos.
+ *
+ * Antes ele tinha três cards em "Em breve" — Pessoal, Propostas e Checklist —
+ * que existiam há meses e não abriam nada. Um card que não clica ensina a
+ * ignorar cards, e depois de um tempo ninguém tenta os que funcionam.
+ *
+ * O "Pessoal" tinha tela desde sempre (`documentos/rh`, o Portal do
+ * funcionário) e só não estava ligado. Os outros dois saíram: sem tela e sem
+ * data, "em breve" é uma promessa que o hub não pode cumprir.
+ *
+ * O que ficou no lugar da promessa é o **controle de acesso**: cada card só
+ * aparece para quem consegue abrir a tela dele. Antes, quem não tinha acesso à
+ * Galeria via o card, clicava e batia na tela de acesso negado.
+ */
 @Component({
   selector: 'app-documentos',
   standalone: true,
@@ -20,22 +36,29 @@ interface CategoriaDoc {
   styleUrl: './documentos.component.scss',
 })
 export class DocumentosComponent {
-  categorias: CategoriaDoc[] = [
-    { titulo: 'Galeria',       descricao: 'Fotos, logos e catálogos da empresa',    icon: 'pi pi-images',     accent: '#7c5cbf', rota: '/documentos/galeria' },
-    { titulo: 'Logos',         descricao: 'Identidade visual e arquivos da marca',   icon: 'pi pi-palette',    accent: '#e07b4c', rota: '/documentos/logos' },
-    { titulo: 'Holerites',     descricao: 'Seus demonstrativos de pagamento',        icon: 'pi pi-receipt',    accent: '#d92d20', rota: '/documentos/holerites' },
-    { titulo: 'Ferramentas',   descricao: 'Desbloquear PDF, renomear NFS-e e outras ferramentas de arquivo', icon: 'pi pi-wrench', accent: 'var(--app-action)', rota: '/tools/pdf' },
-    { titulo: 'Pessoal',       descricao: 'Documentos de RH e pessoais',             icon: 'pi pi-id-card',    accent: '#232e61', emDesenvolvimento: true },
-    { titulo: 'Propostas',     descricao: 'Modelos e propostas comerciais',          icon: 'pi pi-file-edit',  accent: '#3e9e8e', emDesenvolvimento: true },
-    { titulo: 'Checklist',     descricao: 'Formulários e checklists',              icon: 'pi pi-list',       accent: '#f5a623', emDesenvolvimento: true }
+
+  private readonly router = inject(Router);
+  private readonly permissions = inject(PermissionStore);
+
+  private readonly todas: CategoriaDoc[] = [
+    { titulo: 'Galeria',     descricao: 'Fotos, logos e catálogos da empresa',      icon: 'pi pi-images',    accent: '#7c5cbf', rota: 'documentos/galeria' },
+    { titulo: 'Logos',       descricao: 'Identidade visual e arquivos da marca',    icon: 'pi pi-palette',   accent: '#e07b4c', rota: 'documentos/logos' },
+    { titulo: 'Holerites',   descricao: 'Seus demonstrativos de pagamento',         icon: 'pi pi-receipt',   accent: '#d92d20', rota: 'documentos/holerites' },
+    { titulo: 'Pessoal',     descricao: 'Suas férias, reembolsos, atestados e documentos', icon: 'pi pi-id-card', accent: '#232e61', rota: 'documentos/rh' },
+    { titulo: 'Ferramentas', descricao: 'Desbloquear PDF, renomear NFS-e e outras ferramentas de arquivo', icon: 'pi pi-wrench', accent: 'var(--app-action)', rota: 'tools/pdf' },
   ];
 
-  constructor(private router: Router) {}
+  /**
+   * Só o que a pessoa consegue abrir.
+   *
+   * Usa `canOpen`, e não `can(…, 'CONSULTAR')`: qualquer uma das sete
+   * permissões abre a tela — é o técnico que lança um reembolso sem poder ver
+   * os dos outros.
+   */
+  readonly categorias = computed(() =>
+    this.todas.filter(cat => this.permissions.canOpen(cat.rota)));
 
   abrir(cat: CategoriaDoc): void {
-    if (cat.emDesenvolvimento) return;
-    if (cat.rota) {
-      this.router.navigate([cat.rota]);
-    }
+    this.router.navigate([cat.rota]);
   }
 }

--- a/src/app/components/auth/perfil/perfil.component.html
+++ b/src/app/components/auth/perfil/perfil.component.html
@@ -259,6 +259,32 @@
       </section>
     }
   </div>
+} @else {
+
+  <!--
+    O ramo que faltava.
+
+    Antes eram só `loading` e `data`: no erro a tela ficava em branco, com um
+    toast que some em três segundos. Quem chegasse depois disso via uma página
+    vazia sem explicação — e o caso mais comum tem saída conhecida.
+  -->
+  <div class="perfil-wrapper">
+    <div class="empty-state">
+      <div class="empty-state__icon">
+        <i [class]="notLinked ? 'pi pi-link' : 'pi pi-exclamation-triangle'"></i>
+      </div>
+
+      <h2>{{ notLinked ? 'Sua conta ainda não está vinculada' : 'Não deu para abrir seu perfil' }}</h2>
+
+      <!-- A frase vem da API: é lá que está escrito o que fazer e para quem pedir. -->
+      <p>{{ errorMessage }}</p>
+
+      @if (!notLinked) {
+        <button pButton label="Tentar de novo" icon="pi pi-refresh"
+                class="p-button-sm" (click)="load()"></button>
+      }
+    </div>
+  </div>
 }
 
 <!-- QR Code Dialog -->

--- a/src/app/components/auth/perfil/perfil.component.html
+++ b/src/app/components/auth/perfil/perfil.component.html
@@ -29,7 +29,14 @@
       </div>
     </section>
 
-    <!-- SEÇÃO 2 — Cartão Digital (só VENDEDOR) -->
+    <!--
+      SEÇÃO 2 — Cartão Digital.
+
+      `canCreate` vem da API, e desde a V88 ela responde `perfil:INCLUIR` em
+      vez da role VENDEDOR — dá para liberar pela tela de permissões, sem
+      mexer em código. Continua vindo do servidor de propósito: o front
+      esconder e a API aceitar seria pior que os dois recusarem.
+    -->
     @if (canCreate) {
       <section class="vcard-section">
 

--- a/src/app/components/auth/perfil/perfil.component.scss
+++ b/src/app/components/auth/perfil/perfil.component.scss
@@ -516,3 +516,52 @@
     .inline-input { min-width: 100%; }
   }
 }
+
+// ─── Quando o perfil não abre ───────────────────────────────────────────────
+//
+// A tela tinha só dois estados — carregando e carregado — e o erro caía no
+// vazio entre eles. Este bloco é o terceiro, e existe para o caso mais comum:
+// a conta de acesso que ninguém vinculou ao cadastro de funcionário.
+//
+// Sem botão de "tentar de novo" nesse caso, de propósito: repetir a requisição
+// não vincula nada, e oferecer um botão que não resolve é pior que não oferecer.
+.empty-state {
+  max-width: 46ch;
+  margin: 48px auto;
+  padding: 28px 24px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-surface);
+}
+
+.empty-state__icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--app-action-soft);
+  color: var(--app-action);
+  font-size: 22px;
+}
+
+.empty-state h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -.01em;
+  color: var(--app-text);
+}
+
+.empty-state p {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--app-text-muted);
+}

--- a/src/app/components/auth/perfil/perfil.component.spec.ts
+++ b/src/app/components/auth/perfil/perfil.component.spec.ts
@@ -1,0 +1,163 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+
+import { PerfilComponent } from './perfil.component';
+import { VcardService } from '../../../infrastructure/services/profile/vcard/vcard.service';
+import { AuthService } from '../../../infrastructure/services/auth.service';
+import { MyProfileResponseDto } from '../../../domain/models/profile.model';
+
+/**
+ * A tela de perfil quando ela **não** abre.
+ *
+ * O caminho feliz não é o que quebra aqui. O que quebrava era o erro: a tela
+ * tinha `@if (loading)` e `@else if (data)` e mais nada, então uma falha
+ * deixava a página **em branco** com um toast que some em três segundos. Quem
+ * chegasse depois disso via uma página vazia e nenhuma explicação.
+ *
+ * E o erro mais comum tem saída conhecida — a conta de acesso que ninguém
+ * vinculou ao cadastro de funcionário. Dizer isso na tela é a diferença entre
+ * a pessoa procurar o RH e a pessoa achar que o sistema quebrou.
+ */
+describe('PerfilComponent · quando não abre', () => {
+  let fixture: ComponentFixture<PerfilComponent>;
+  let component: PerfilComponent;
+  let vcard: jasmine.SpyObj<VcardService>;
+  /** MessageService de verdade: o `p-toast` do template assina o observable dele. */
+  let toast: MessageService;
+
+  const RECADO_DA_API =
+    'Sua conta de acesso ainda não está vinculada ao seu cadastro de funcionário. '
+    + 'Peça ao RH para vincular o seu login ao seu cadastro.';
+
+  const erro = (status: number, message?: string) =>
+    throwError(() => ({ status, error: message ? { message } : null }));
+
+  beforeEach(async () => {
+    vcard = jasmine.createSpyObj<VcardService>('VcardService', [
+      'getMyProfile', 'createMyProfile', 'updateMyProfile',
+      'downloadVCard', 'uploadMyProfileImage',
+    ]);
+    toast = new MessageService();
+    spyOn(toast, 'add');
+
+    await TestBed.configureTestingModule({
+      imports: [PerfilComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        { provide: VcardService, useValue: vcard },
+        { provide: AuthService, useValue: {} },
+        { provide: MessageService, useValue: toast },
+      ],
+    })
+      // O componente declara `providers: [MessageService]`, e provider de
+      // componente ganha do provider do TestBed. Sem trocar aqui, o espião
+      // nunca é o que a tela usa — e o teste do toast passaria a afirmar nada.
+      .overrideComponent(PerfilComponent, {
+        set: { providers: [{ provide: MessageService, useValue: toast }] },
+      })
+      .compileComponents();
+  });
+
+  const montar = () => {
+    fixture = TestBed.createComponent(PerfilComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  const texto = () => fixture.nativeElement.textContent as string;
+
+  // ─── Conta sem vínculo ────────────────────────────────────────────────────
+
+  /**
+   * **O teste que dá nome ao arquivo.**
+   *
+   * A frase vem da API, e não está duplicada no front: é lá que se sabe o que
+   * houve e para quem pedir. Se o front escrevesse a própria, as duas
+   * divergiriam no dia em que alguém melhorasse uma delas.
+   */
+  it('sem funcionário vinculado, a mensagem da API aparece NA TELA', () => {
+    vcard.getMyProfile.and.returnValue(erro(404, RECADO_DA_API));
+
+    montar();
+
+    expect(component.notLinked).toBeTrue();
+    expect(texto()).toContain('Sua conta ainda não está vinculada');
+    expect(texto()).toContain('Peça ao RH');
+  });
+
+  /**
+   * **Sem toast neste caso, de propósito.**
+   *
+   * Um aviso que some em três segundos é o contrário do que alguém travado
+   * precisa. A mensagem fica na tela até a pessoa resolver.
+   */
+  it('a conta sem vínculo não vira toast', () => {
+    vcard.getMyProfile.and.returnValue(erro(404, RECADO_DA_API));
+
+    montar();
+
+    expect(toast.add).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Repetir a requisição não vincula nada. Oferecer um botão que não resolve é
+   * pior que não oferecer: gasta o tempo da pessoa e ensina que o botão mente.
+   */
+  it('não oferece "tentar de novo" para quem não tem vínculo', () => {
+    vcard.getMyProfile.and.returnValue(erro(404, RECADO_DA_API));
+
+    montar();
+
+    expect(texto()).not.toContain('Tentar de novo');
+  });
+
+  // ─── Qualquer outra falha ─────────────────────────────────────────────────
+
+  /**
+   * Um 500 é outra história: pode ter sido a rede, e tentar de novo resolve.
+   * Aí o botão aparece — e o toast também, porque não há saída a explicar.
+   */
+  it('falha genérica mostra o botão de tentar de novo, e avisa', () => {
+    vcard.getMyProfile.and.returnValue(erro(500));
+
+    montar();
+
+    expect(component.notLinked).toBeFalse();
+    expect(texto()).toContain('Tentar de novo');
+    expect(toast.add).toHaveBeenCalled();
+  });
+
+  /** Sem mensagem da API, uma frase própria — nunca a tela vazia de antes. */
+  it('sem mensagem da API, ainda diz alguma coisa', () => {
+    vcard.getMyProfile.and.returnValue(erro(500));
+
+    montar();
+
+    expect(component.errorMessage).toBeTruthy();
+    expect(texto()).toContain('Não deu para abrir seu perfil');
+  });
+
+  // ─── O caminho feliz continua de pé ───────────────────────────────────────
+
+  it('com vínculo, a tela abre normalmente', () => {
+    const resposta: MyProfileResponseDto = {
+      profile: null,
+      employeeName: 'Ricardo Souza',
+      employeeEmail: 'ricardo@proautokimium.com.br',
+      employeeCargo: null,
+      employeeEmpresa: 'Proauto Kimium',
+      canCreateProfile: true,
+    } as MyProfileResponseDto;
+    vcard.getMyProfile.and.returnValue(of(resposta));
+
+    montar();
+
+    expect(component.notLinked).toBeFalse();
+    expect(texto()).toContain('Ricardo Souza');
+  });
+});

--- a/src/app/components/auth/perfil/perfil.component.ts
+++ b/src/app/components/auth/perfil/perfil.component.ts
@@ -50,6 +50,18 @@ export class PerfilComponent implements OnInit {
 
   data: MyProfileResponseDto | null = null;
   loading = true;
+
+  /**
+   * O que a API respondeu quando não deu para carregar.
+   *
+   * A tela tinha `@if (loading) @else if (data)` e mais nada: no erro ela
+   * ficava **em branco**, com um toast vermelho que some sozinho. Quem chegava
+   * depois de três segundos via uma página vazia sem explicação nenhuma.
+   */
+  errorMessage: string | null = null;
+
+  /** A conta não está ligada a um funcionário — o caso que tem saída conhecida. */
+  notLinked = false;
   saving = false;
   editing = false;
 
@@ -104,6 +116,9 @@ export class PerfilComponent implements OnInit {
 
   load(): void {
     this.loading = true;
+    this.errorMessage = null;
+    this.notLinked = false;
+
     this.vcardService.getMyProfile().subscribe({
       next: (res) => {
         this.data = res;
@@ -112,9 +127,21 @@ export class PerfilComponent implements OnInit {
           this.patchForm(res.profile);
         }
       },
-      error: () => {
+      error: (erro) => {
         this.loading = false;
-        this.toast.add({ severity: 'error', summary: 'Erro', detail: 'Não foi possível carregar seu perfil.' });
+
+        // O 404 daqui não é "não existe": é a conta sem vínculo com um
+        // funcionário. A API manda a frase com a saída — quem pedir e para
+        // quem — e a tela mostra isso em vez de um "erro" genérico.
+        this.notLinked = erro?.status === 404;
+        this.errorMessage = erro?.error?.message
+          ?? 'Não foi possível carregar seu perfil. Tente novamente em instantes.';
+
+        // Sem toast no caso conhecido: a mensagem fica NA TELA, e um toast que
+        // some em três segundos é o contrário do que alguém travado precisa.
+        if (!this.notLinked) {
+          this.toast.add({ severity: 'error', summary: 'Erro', detail: this.errorMessage ?? undefined });
+        }
       },
     });
   }

--- a/src/app/components/auth/perfil/perfil.component.ts
+++ b/src/app/components/auth/perfil/perfil.component.ts
@@ -82,6 +82,13 @@ export class PerfilComponent implements OnInit {
     return !!this.data?.profile;
   }
 
+  /**
+   * Pode criar o cartão digital?
+   *
+   * Quem decide é a API, por `perfil:INCLUIR`. A tela de perfil em si é de
+   * todo mundo — o que se controla aqui é a seção de dentro, e é o primeiro
+   * lugar do sistema onde "abrir a tela" e "fazer algo nela" se separam.
+   */
   get canCreate(): boolean {
     return !!this.data?.canCreateProfile;
   }

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.html
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.html
@@ -218,14 +218,20 @@
 
         <div class="form-field form-field--full">
           <label class="balance-toggle">
-            <input type="checkbox" [(ngModel)]="setBalance" [ngModelOptions]="{standalone: true}">
+            <input type="checkbox" [ngModel]="setBalance"
+                   (ngModelChange)="onSetBalanceChange($event)"
+                   [ngModelOptions]="{standalone: true}">
             Definir saldo de férias deste funcionário
           </label>
         </div>
 
         @if (setBalance) {
           <div class="form-field form-field--full">
-            <label>Saldo de férias (dias)</label>
+            <label>Saldo de férias (dias) <span class="required">*</span></label>
+            <!--
+              O valor digitado é o saldo DEPOIS deste lançamento, e não uma
+              entrada para descontar. Zero vale: é a pessoa ficando zerada.
+            -->
             <p-inputNumber
               formControlName="vacationBalanceDays"
               [min]="0"

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.scss
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.scss
@@ -42,17 +42,21 @@
   align-items: center;
   justify-content: center;
 
-  &--approve:hover {
-    background: var(--app-success);
-    border-color: var(--app-success);
-    color: #fff;
-  }
+}
 
-  &--reject:hover {
-    background: var(--app-danger);
-    border-color: var(--app-danger);
-    color: #fff;
-  }
+// O `&` daqui não podia estar dentro de `.action-btn.p-button`: ele concatena
+// no ÚLTIMO seletor, então `&--approve` compilava para `.action-btn.p-button--approve`
+// — uma classe que não existe. O hover verde e o vermelho nunca apareceram.
+.action-btn--approve.p-button:hover {
+  background: var(--app-success);
+  border-color: var(--app-success);
+  color: #fff;
+}
+
+.action-btn--reject.p-button:hover {
+  background: var(--app-danger);
+  border-color: var(--app-danger);
+  color: #fff;
 }
 
 .vr-badge {

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.spec.ts
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.spec.ts
@@ -1,0 +1,137 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { VacationRequestsManagerComponent } from './vacation-requests-manager.component';
+import { VacationRequestService } from '../../../../infrastructure/services/hr/vacation-request.service';
+import { EmployeeStore } from '../../../../infrastructure/state/employee.store';
+import { VacationRequest } from '../../../../domain/models/hr/vacation-request.model';
+
+/**
+ * A coluna de ações das férias.
+ *
+ * Ela abriu vazia em produção: nem os botões de aprovar e recusar, nem o traço
+ * que deveria aparecer no lugar deles. Uma coluna vazia não dá erro em canto
+ * nenhum — a tela carrega, a tabela mostra os dados, e só a ação some.
+ */
+describe('VacationRequestsManagerComponent · coluna de ações', () => {
+  let fixture: ComponentFixture<VacationRequestsManagerComponent>;
+  let service: jasmine.SpyObj<VacationRequestService>;
+
+  const pedido = (status: VacationRequest['status']): VacationRequest => ({
+    id: 'v-1',
+    employeeId: 'e-1',
+    startDate: '2026-09-01',
+    endDate: '2026-09-10',
+    daysRequested: 10,
+    status,
+    requestedAt: '2026-08-01T10:00:00Z',
+    replacementEmployeeId: null,
+    reviewedById: null,
+    reviewedAt: null,
+    reviewNotes: null,
+  });
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj<VacationRequestService>('VacationRequestService', [
+      'getAll', 'getAlerts', 'approve', 'reject', 'registerByRh',
+    ]);
+    service.getAlerts.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [VacationRequestsManagerComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        { provide: VacationRequestService, useValue: service },
+        { provide: EmployeeStore, useValue: { items: () => [], load: () => of([]), ensureLoaded: () => of([]), nameOf: () => 'Funcionário' } },
+      ],
+    }).compileComponents();
+  });
+
+  const montarCom = (...pedidos: VacationRequest[]) => {
+    service.getAll.and.returnValue(of(pedidos));
+    fixture = TestBed.createComponent(VacationRequestsManagerComponent);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  };
+
+  const componente = () => fixture.componentInstance;
+
+  /**
+   * **O teste que reproduz o defeito.**
+   *
+   * Uma solicitação pendente tem que oferecer aprovar e recusar. Sem os dois
+   * botões, a tela vira só leitura e o RH não consegue trabalhar por ela.
+   */
+  it('solicitação pendente mostra aprovar e recusar', () => {
+    const tela = montarCom(pedido('PENDING'));
+
+    expect(tela.querySelector('.action-btn--approve'))
+      .withContext('o botão de aprovar')
+      .not.toBeNull();
+    expect(tela.querySelector('.action-btn--reject'))
+      .withContext('o botão de recusar')
+      .not.toBeNull();
+  });
+
+  /** E o ícone precisa estar lá dentro: botão vazio não se distingue de bug. */
+  it('os botões têm ícone', () => {
+    const tela = montarCom(pedido('PENDING'));
+
+    expect(tela.querySelector('.action-btn--approve .pi')).not.toBeNull();
+  });
+
+  /** Já decidida não oferece ação — mas mostra o traço, e não o vazio. */
+  it('solicitação já aprovada mostra o traço no lugar dos botões', () => {
+    const tela = montarCom(pedido('APPROVED'));
+
+    expect(tela.querySelector('.action-btn')).toBeNull();
+    expect(tela.textContent).toContain('—');
+  });
+
+  // ─── O saldo no lançamento do RH ──────────────────────────────────────────
+
+  /**
+   * **Marcar a caixa e deixar o campo vazio faria o oposto do que ela promete.**
+   *
+   * `null` é o sinal de "não informado", e a API desconta os dias em vez de
+   * gravar o valor. Sem a exigência, o RH marca "definir saldo", esquece de
+   * digitar, e o saldo cai — sem erro nenhum na tela.
+   */
+  it('marcar "definir saldo" torna o campo obrigatório', () => {
+    montarCom();
+    componente().onSetBalanceChange(true);
+
+    const campo = componente().registerForm.get('vacationBalanceDays')!;
+    expect(campo.hasError('required')).toBeTrue();
+  });
+
+  /**
+   * **Zero é um saldo, e não vazio.**
+   *
+   * É o RH lançando as últimas férias e dizendo que a pessoa fica zerada. Se o
+   * campo recusasse zero, esse caso não teria como ser expresso.
+   */
+  it('zero é um valor válido de saldo', () => {
+    montarCom();
+    componente().onSetBalanceChange(true);
+
+    const campo = componente().registerForm.get('vacationBalanceDays')!;
+    campo.setValue(0);
+
+    expect(campo.valid).toBeTrue();
+  });
+
+  /** Desmarcar limpa o campo: sobra escondida vira saldo gravado sem querer. */
+  it('desmarcar limpa o valor', () => {
+    montarCom();
+    componente().onSetBalanceChange(true);
+    componente().registerForm.get('vacationBalanceDays')!.setValue(7);
+
+    componente().onSetBalanceChange(false);
+
+    expect(componente().registerForm.get('vacationBalanceDays')!.value).toBeNull();
+  });
+});

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
@@ -72,6 +72,29 @@ export class VacationRequestsManagerComponent implements OnInit, TabDirtyCheck {
   readonly employeeOptions = this.employeeStore.activeOptions;
   setBalance = false;
 
+  /**
+   * Liga e desliga o campo de saldo — e a exigência junto.
+   *
+   * Marcar a caixa e deixar o campo vazio manda `null`, e `null` é o sinal de
+   * "não informado": a API desconta os dias em vez de gravar o valor. Ou seja,
+   * a caixa faria o **oposto** do que promete, sem erro nenhum na tela.
+   *
+   * Zero é um valor legítimo aqui: é o RH lançando as últimas férias e dizendo
+   * que a pessoa fica zerada.
+   */
+  onSetBalanceChange(ligado: boolean): void {
+    this.setBalance = ligado;
+    const campo = this.registerForm.get('vacationBalanceDays');
+
+    if (ligado) {
+      campo?.addValidators(Validators.required);
+    } else {
+      campo?.clearValidators();
+      campo?.setValue(null);
+    }
+    campo?.updateValueAndValidity();
+  }
+
   constructor(
     private vacationRequestService: VacationRequestService,
     private msgService: MessageService,
@@ -195,7 +218,7 @@ export class VacationRequestsManagerComponent implements OnInit, TabDirtyCheck {
 
   openRegisterDialog(): void {
     this.registerForm.reset();
-    this.setBalance = false;
+    this.onSetBalanceChange(false);
     this.mode.set('form');
   }
 

--- a/src/app/components/auth/settings/permissions/_permission-shell.scss
+++ b/src/app/components/auth/settings/permissions/_permission-shell.scss
@@ -120,7 +120,65 @@
   p { margin: 0; font-size: 12px; color: var(--app-text-muted); }
 }
 
-.pshell__subject-id { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.pshell__subject-id { display: flex; flex-direction: column; gap: 6px; min-width: 0; flex: 1; }
+
+// ─── Os modelos aplicados ───────────────────────────────────────────────────
+//
+// Fichas com um × em cada, e não texto corrido. A versão anterior dizia
+// "carimbado com A, B" — informava o que tinha acontecido e não oferecia saída
+// nenhuma, e foi de onde veio a pergunta "como eu removo um carimbo?".
+.pshell__applied {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.pshell__applied-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--app-text-subtle);
+}
+
+.pshell__applied-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px 3px 10px;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--app-surface);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-text);
+
+  button {
+    cursor: pointer;
+    border: 0;
+    background: transparent;
+    color: var(--app-text-subtle);
+    font: inherit;
+    font-size: 14px;
+    line-height: 1;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover { background: var(--app-danger-soft); color: var(--app-danger); }
+    &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+  }
+}
+
+.pshell__applied-none {
+  margin: 0;
+  font-size: 12px;
+  color: var(--app-text-subtle);
+}
 .pshell__subject-acts { display: flex; gap: 8px; flex-wrap: wrap; }
 
 // O aviso que impede o "reaplicar" cego. Âmbar avisa; não é erro.

--- a/src/app/components/auth/settings/permissions/_permission-shell.scss
+++ b/src/app/components/auth/settings/permissions/_permission-shell.scss
@@ -51,26 +51,6 @@
   }
 }
 
-.pshell__field {
-  height: var(--field-h);
-  width: 100%;
-  padding: 0 10px;
-  border: 1px solid var(--app-border-strong);
-  border-radius: var(--radius-control);
-  background: var(--app-surface);
-  color: var(--app-text);
-  font: inherit;
-  font-size: 13px;
-
-  &::placeholder { color: var(--app-text-subtle); }
-
-  &:focus {
-    outline: none;
-    border-color: var(--app-action);
-    box-shadow: var(--app-focus-ring);
-  }
-}
-
 .pshell__list {
   overflow-y: auto;
   padding: 8px;
@@ -217,17 +197,10 @@
 }
 
 // ─── Diálogos ───────────────────────────────────────────────────────────────
+// Empilhador, e nada mais: o padding e os traços vêm da `pk-form-section` do
+// tema, e o rodapé da `pk-dialog-footer`. Recriar isso aqui foi o erro que
+// deixou os diálogos sem respiro.
 .pform { display: flex; flex-direction: column; gap: 14px; }
-
-.pform__row { display: flex; flex-direction: column; gap: 5px; }
-
-.pform__label {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  color: var(--app-text-muted);
-}
 
 .pform__opts { display: flex; gap: 6px; flex-wrap: wrap; }
 
@@ -279,4 +252,3 @@
   span.pform__warn { color: var(--app-warning); font-weight: 600; }
 }
 
-.pform__foot { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }

--- a/src/app/components/auth/settings/permissions/_permission-shell.scss
+++ b/src/app/components/auth/settings/permissions/_permission-shell.scss
@@ -1,0 +1,282 @@
+// A moldura das duas telas de configuração de permissão.
+//
+// Elas têm o mesmo esqueleto — lista à esquerda, sujeito e grade à direita — e
+// só mudam no que a lista contém. Repetir isso em dois arquivos garantiria que
+// eles divergissem sozinhos, que foi exatamente o que aconteceu com o
+// calendário antes de ele virar componente.
+
+.pshell {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 0;
+  height: 100%;
+  background: var(--app-bg);
+}
+
+@media (max-width: 900px) {
+  .pshell { grid-template-columns: 1fr; }
+  .pshell__rail { border-right: 0; border-bottom: 1px solid var(--app-border); }
+  .pshell__list { max-height: 220px; }
+}
+
+// ─── Lista lateral ──────────────────────────────────────────────────────────
+.pshell__rail {
+  background: var(--app-surface);
+  border-right: 1px solid var(--app-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.pshell__rail-head {
+  padding: 14px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.pshell__rail-title {
+  font-weight: 700;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  span {
+    font-weight: 500;
+    font-size: 11px;
+    color: var(--app-text-subtle);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.pshell__field {
+  height: var(--field-h);
+  width: 100%;
+  padding: 0 10px;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-control);
+  background: var(--app-surface);
+  color: var(--app-text);
+  font: inherit;
+  font-size: 13px;
+
+  &::placeholder { color: var(--app-text-subtle); }
+
+  &:focus {
+    outline: none;
+    border-color: var(--app-action);
+    box-shadow: var(--app-focus-ring);
+  }
+}
+
+.pshell__list {
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.pshell__item {
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  font: inherit;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: var(--radius-control);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-left: 3px solid transparent;
+
+  &:hover { background: var(--app-surface-2); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+
+  &[aria-current='true'] {
+    background: var(--app-action-soft);
+    border-left-color: var(--app-action);
+  }
+
+  b { font-weight: 600; font-size: 13px; }
+
+  span {
+    font-size: 11px;
+    color: var(--app-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  &--off b { color: var(--app-text-subtle); text-decoration: line-through; }
+}
+
+.pshell__rail-foot { padding: 10px; border-top: 1px solid var(--app-border); }
+
+// ─── Painel ─────────────────────────────────────────────────────────────────
+.pshell__main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+.pshell__subject {
+  padding: 14px 18px;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  flex-wrap: wrap;
+
+  h2 {
+    margin: 0 0 3px;
+    font-size: 19px;
+    font-weight: 700;
+    letter-spacing: -.02em;
+  }
+
+  p { margin: 0; font-size: 12px; color: var(--app-text-muted); }
+}
+
+.pshell__subject-id { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.pshell__subject-acts { display: flex; gap: 8px; flex-wrap: wrap; }
+
+// O aviso que impede o "reaplicar" cego. Âmbar avisa; não é erro.
+.pshell__note {
+  margin: 0 18px 12px;
+  padding: 10px 14px;
+  background: var(--app-warning-soft);
+  border: 1px solid var(--app-warning);
+  border-radius: var(--radius-surface);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+  color: var(--app-warning);
+
+  b { font-weight: 700; }
+  code { font-family: var(--font-mono, 'Courier New', monospace); font-size: 11.5px; }
+  .pshell__note-act { margin-left: auto; }
+}
+
+// ─── Barra de gravação ──────────────────────────────────────────────────────
+//
+// Fica cinza até algo mudar. Gravação automática em 385 células é o desenho que
+// apaga acesso por engano — e o erro só aparece dias depois, na pessoa errada.
+.pshell__save {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 12px 18px;
+  background: var(--app-surface);
+  border-top: 1px solid var(--app-border-strong);
+
+  &[data-dirty='false'] .pshell__save-acts { opacity: .45; pointer-events: none; }
+}
+
+.pshell__save-msg {
+  font-size: 13px;
+  color: var(--app-text-muted);
+
+  b { color: var(--app-text); font-variant-numeric: tabular-nums; }
+}
+
+.pshell__save-acts { display: flex; gap: 8px; margin-left: auto; }
+
+.pshell__legend {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+  color: var(--app-text-muted);
+  align-items: center;
+
+  i { display: inline-flex; align-items: center; gap: 6px; font-style: normal; }
+
+  .sw {
+    width: 13px;
+    height: 13px;
+    border-radius: 4px;
+    border: 1.5px solid var(--app-border-strong);
+    display: inline-block;
+  }
+
+  .sw--on { background: var(--app-success); border-color: var(--app-success); }
+
+  .sw--diverges {
+    background: var(--app-warning);
+    border-color: var(--app-warning);
+    border-radius: 50%;
+    width: 9px;
+    height: 9px;
+  }
+}
+
+// ─── Diálogos ───────────────────────────────────────────────────────────────
+.pform { display: flex; flex-direction: column; gap: 14px; }
+
+.pform__row { display: flex; flex-direction: column; gap: 5px; }
+
+.pform__label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--app-text-muted);
+}
+
+.pform__opts { display: flex; gap: 6px; flex-wrap: wrap; }
+
+.pform__chip {
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+  border-radius: var(--radius-pill);
+  padding: 5px 12px;
+
+  &[aria-pressed='true'] {
+    background: var(--app-action);
+    border-color: var(--app-action);
+    color: var(--app-on-action);
+    font-weight: 600;
+  }
+
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+}
+
+.pform__mode {
+  display: flex;
+  gap: 11px;
+  padding: 11px 13px;
+  cursor: pointer;
+  border: 1.5px solid var(--app-border);
+  border-radius: var(--radius-surface);
+  background: var(--app-surface);
+  text-align: left;
+  font: inherit;
+  width: 100%;
+
+  &[aria-pressed='true'] { border-color: var(--app-action); background: var(--app-action-soft); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+
+  b { display: block; font-size: 13px; font-weight: 600; color: var(--app-text); }
+
+  span {
+    display: block;
+    font-size: 12px;
+    color: var(--app-text-muted);
+    line-height: 1.5;
+  }
+
+  // A consequência que apaga trabalho fica escrita, e em âmbar.
+  span.pform__warn { color: var(--app-warning); font-weight: 600; }
+}
+
+.pform__foot { display: flex; gap: 8px; justify-content: flex-end; margin-top: 4px; }

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.html
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.html
@@ -2,12 +2,12 @@
 
   <!-- Filtro e ações em massa. O alcance de tudo aqui é o que está visível. -->
   <div class="pgrid__bar">
-    <input type="search"
-           class="pgrid__search"
-           placeholder="Filtrar tela…"
-           aria-label="Filtrar tela"
-           [value]="filter()"
-           (input)="setFilter($any($event.target).value)" />
+    <pk-input class="pgrid__search"
+              placeholder="Filtrar tela…"
+              icon="pi pi-search"
+              [ngModel]="filter()"
+              (ngModelChange)="setFilter($event)"
+              [ngModelOptions]="{ standalone: true }" />
 
     <div class="pgrid__chips" role="group" aria-label="Filtrar por módulo">
       <button type="button" class="pgrid__chip"

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.html
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.html
@@ -1,0 +1,121 @@
+<div class="pgrid">
+
+  <!-- Filtro e ações em massa. O alcance de tudo aqui é o que está visível. -->
+  <div class="pgrid__bar">
+    <input type="search"
+           class="pgrid__search"
+           placeholder="Filtrar tela…"
+           aria-label="Filtrar tela"
+           [value]="filter()"
+           (input)="setFilter($any($event.target).value)" />
+
+    <div class="pgrid__chips" role="group" aria-label="Filtrar por módulo">
+      <button type="button" class="pgrid__chip"
+              [attr.aria-pressed]="module() === 'todos'"
+              (click)="setModule('todos')">Todos</button>
+
+      @for (m of modules(); track m) {
+        <button type="button" class="pgrid__chip"
+                [attr.aria-pressed]="module() === m"
+                (click)="setModule(m)">{{ m }}</button>
+      }
+    </div>
+
+    <span class="pgrid__spacer"></span>
+
+    @if (!disabled()) {
+      <button type="button" class="pgrid__mini" (click)="toggleAll(true)">Liberar tudo</button>
+      <button type="button" class="pgrid__mini" (click)="toggleAll(false)">Bloquear tudo</button>
+    }
+  </div>
+
+  <div class="pgrid__scroll">
+    <table class="pgrid__table">
+      <thead>
+        <tr>
+          <th class="pgrid__th-screen">Tela</th>
+
+          @for (p of permissions; track p) {
+            <th class="pgrid__th-perm">
+              <button type="button"
+                      [disabled]="disabled()"
+                      [title]="'Ligar ou desligar ' + p + ' nas telas visíveis'"
+                      (click)="toggleColumn(p)">{{ labels[p] }}</button>
+            </th>
+          }
+
+          <th class="pgrid__th-row">Linha</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        @for (block of blocks(); track block.kind === 'module' ? 'm:' + block.module : block.screen.code) {
+
+          @if (block.kind === 'module') {
+            <tr class="pgrid__module" [attr.data-open]="block.open">
+              <td [attr.colspan]="permissions.length + 2">
+                <div class="pgrid__module-inner">
+                  <button type="button" class="pgrid__module-toggle"
+                          (click)="collapse(block.module)">
+                    <span class="pgrid__caret" aria-hidden="true">▼</span>{{ block.module }}
+                  </button>
+
+                  <span class="pgrid__module-score">{{ block.allowed }}/{{ block.total }}</span>
+
+                  @if (!disabled()) {
+                    <span class="pgrid__module-acts">
+                      <button type="button" class="pgrid__mini pgrid__mini--ghost"
+                              (click)="toggleModule(block.module, true)">tudo</button>
+                      <button type="button" class="pgrid__mini pgrid__mini--ghost"
+                              (click)="toggleModule(block.module, false)">nada</button>
+                    </span>
+                  }
+                </div>
+              </td>
+            </tr>
+          } @else {
+            <tr class="pgrid__row">
+              <td class="pgrid__cell-screen">
+                <span class="pgrid__label">{{ block.screen.label }}</span>
+                <span class="pgrid__code">{{ block.screen.code }}</span>
+              </td>
+
+              @for (cell of block.cells; track cell.key) {
+                <td class="pgrid__cell">
+                  <button type="button"
+                          class="pgrid__box"
+                          role="checkbox"
+                          [attr.aria-checked]="cell.on"
+                          [attr.data-diverges]="cell.diverges ? true : null"
+                          [disabled]="disabled()"
+                          [attr.aria-label]="block.screen.label + ' — ' + cell.permission"
+                          (click)="toggleCell(cell.key)"></button>
+                </td>
+              }
+
+              <td class="pgrid__cell">
+                @if (!disabled()) {
+                  @if (block.full) {
+                    <button type="button" class="pgrid__mini pgrid__mini--ghost"
+                            (click)="toggleRow(block.screen, false)">limpar</button>
+                  } @else {
+                    <button type="button" class="pgrid__mini pgrid__mini--ghost"
+                            (click)="toggleRow(block.screen, true)">tudo</button>
+                  }
+                }
+              </td>
+            </tr>
+          }
+        }
+
+        @if (!blocks().length) {
+          <tr>
+            <td [attr.colspan]="permissions.length + 2" class="pgrid__empty">
+              Nenhuma tela com esse filtro.
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
@@ -1,0 +1,297 @@
+// A grade de permissões.
+//
+// Densidade de ERP: linha de 38px, cabeçalho de 34px, texto de 13px — os mesmos
+// tokens do resto do sistema. Uma grade "arejada" aqui viraria rolagem infinita
+// em 55 linhas.
+
+.pgrid {
+  display: flex;
+  flex-direction: column;
+  background: var(--app-surface);
+  border-top: 1px solid var(--app-border);
+  border-bottom: 1px solid var(--app-border);
+  min-width: 0;
+}
+
+// ─── Barra de filtro ────────────────────────────────────────────────────────
+.pgrid__bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.pgrid__search {
+  height: var(--field-h);
+  width: 200px;
+  padding: 0 10px;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-control);
+  background: var(--app-surface);
+  color: var(--app-text);
+  font: inherit;
+  font-size: 13px;
+
+  &::placeholder { color: var(--app-text-subtle); }
+
+  &:focus {
+    outline: none;
+    border-color: var(--app-action);
+    box-shadow: var(--app-focus-ring);
+  }
+}
+
+.pgrid__chips { display: flex; gap: 5px; flex-wrap: wrap; }
+
+.pgrid__chip {
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  border: 1px solid var(--app-border-strong);
+  background: var(--app-surface);
+  color: var(--app-text-muted);
+  border-radius: var(--radius-pill);
+  padding: 4px 11px;
+
+  &[aria-pressed='true'] {
+    background: var(--app-action);
+    border-color: var(--app-action);
+    color: var(--app-on-action);
+    font-weight: 600;
+  }
+
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+}
+
+.pgrid__spacer { flex: 1; }
+
+.pgrid__mini {
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  height: var(--btn-h-sm);
+  padding: 0 10px;
+  border: 1px solid var(--app-border-strong);
+  border-radius: var(--radius-control);
+  background: var(--app-surface);
+  color: var(--app-text);
+
+  &:hover { background: var(--app-surface-2); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+
+  &--ghost {
+    border-color: transparent;
+    background: transparent;
+    color: var(--app-text-muted);
+
+    &:hover { background: var(--app-surface-3); }
+  }
+}
+
+// ─── A tabela ───────────────────────────────────────────────────────────────
+.pgrid__scroll {
+  overflow: auto;
+  max-height: 62vh;
+  min-height: 240px;
+}
+
+.pgrid__table {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  min-width: 760px;
+}
+
+// O cabeçalho gruda: com 55 linhas, rolar até o meio sem ele significa contar
+// colunas para saber qual é o Excluir.
+thead th {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: var(--app-surface-3);
+  border-bottom: 1px solid var(--app-border-strong);
+  height: var(--row-head-h);
+  padding: 0 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--app-text-muted);
+  white-space: nowrap;
+}
+
+.pgrid__th-screen {
+  text-align: left;
+  padding-left: 16px;
+  left: 0;
+  z-index: 4;
+  min-width: 240px;
+}
+
+.pgrid__th-perm {
+  width: 62px;
+
+  button {
+    cursor: pointer;
+    border: 0;
+    background: transparent;
+    font: inherit;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: inherit;
+    padding: 6px 2px;
+    border-radius: 5px;
+    width: 100%;
+
+    &:hover:not(:disabled) { background: var(--app-action-soft); color: var(--app-action); }
+    &:disabled { cursor: default; }
+    &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+  }
+}
+
+.pgrid__th-row { width: 92px; }
+
+// ─── Faixa de módulo ────────────────────────────────────────────────────────
+.pgrid__module > td {
+  position: sticky;
+  top: var(--row-head-h);
+  z-index: 2;
+  background: var(--app-surface-3);
+  border-top: 1px solid var(--app-border);
+  border-bottom: 1px solid var(--app-border);
+  padding: 0 16px;
+  height: 32px;
+}
+
+.pgrid__module-inner { display: flex; align-items: center; gap: 10px; }
+
+.pgrid__module-toggle {
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  color: var(--app-action);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0;
+
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+}
+
+.pgrid__caret {
+  font-size: 9px;
+  display: inline-block;
+  transition: transform .15s ease;
+}
+
+.pgrid__module[data-open='false'] .pgrid__caret { transform: rotate(-90deg); }
+
+.pgrid__module-score {
+  font-size: 11px;
+  color: var(--app-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.pgrid__module-acts { margin-left: auto; display: flex; gap: 4px; }
+
+// ─── Linhas ─────────────────────────────────────────────────────────────────
+tbody td {
+  height: var(--row-h);
+  border-bottom: 1px solid var(--app-border);
+  padding: 0 6px;
+  text-align: center;
+}
+
+.pgrid__row:hover td { background: var(--app-surface-2); }
+
+.pgrid__cell-screen {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--app-surface);
+  padding-left: 16px;
+  text-align: left;
+  border-right: 1px solid var(--app-border);
+}
+
+.pgrid__row:hover .pgrid__cell-screen { background: var(--app-surface-2); }
+
+.pgrid__label { font-size: 13px; font-weight: 500; display: block; }
+.pgrid__code {
+  font-family: var(--font-mono, 'Courier New', monospace);
+  font-size: 10px;
+  color: var(--app-text-subtle);
+}
+
+.pgrid__empty {
+  padding: 28px 16px;
+  color: var(--app-text-muted);
+  font-size: 13px;
+}
+
+// ─── A célula ───────────────────────────────────────────────────────────────
+//
+// Botão e não `<input type="checkbox">`: são 385 por tela, e o checkbox nativo
+// não aceita o ponto de divergência no canto sem um elemento extra por célula.
+.pgrid__box {
+  cursor: pointer;
+  padding: 0;
+  margin: 0 auto;
+  display: block;
+  width: 19px;
+  height: 19px;
+  border-radius: 5px;
+  border: 1.5px solid var(--app-border-strong);
+  background: var(--app-surface);
+  position: relative;
+  transition: background .1s ease, border-color .1s ease;
+
+  &:hover:not(:disabled) { border-color: var(--app-action); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+  &:disabled { cursor: default; opacity: .75; }
+
+  &[aria-checked='true'] {
+    background: var(--app-success);
+    border-color: var(--app-success);
+
+    &::after {
+      content: '';
+      position: absolute;
+      left: 5px;
+      top: 2px;
+      width: 5px;
+      height: 9px;
+      border: solid var(--app-on-action);
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg);
+    }
+  }
+
+  // Difere dos carimbos aplicados. É o que impede o "reaplicar" cego: sem esta
+  // marca, devolver uma permissão que alguém tirou de propósito é invisível.
+  &[data-diverges]::before {
+    content: '';
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--app-warning);
+    border: 1.5px solid var(--app-surface);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pgrid__caret, .pgrid__box { transition: none; }
+}

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
@@ -23,25 +23,7 @@
   border-bottom: 1px solid var(--app-border);
 }
 
-.pgrid__search {
-  height: var(--field-h);
-  width: 200px;
-  padding: 0 10px;
-  border: 1px solid var(--app-border-strong);
-  border-radius: var(--radius-control);
-  background: var(--app-surface);
-  color: var(--app-text);
-  font: inherit;
-  font-size: 13px;
-
-  &::placeholder { color: var(--app-text-subtle); }
-
-  &:focus {
-    outline: none;
-    border-color: var(--app-action);
-    box-shadow: var(--app-focus-ring);
-  }
-}
+.pgrid__search { width: 200px; }
 
 .pgrid__chips { display: flex; gap: 5px; flex-wrap: wrap; }
 

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.scss
@@ -259,7 +259,7 @@ tbody td {
     }
   }
 
-  // Difere dos carimbos aplicados. É o que impede o "reaplicar" cego: sem esta
+  // Difere dos modelos aplicados. É o que impede o "reaplicar" cego: sem esta
   // marca, devolver uma permissão que alguém tirou de propósito é invisível.
   &[data-diverges]::before {
     content: '';

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.spec.ts
@@ -173,12 +173,12 @@ describe('PermissionGridComponent', () => {
   /**
    * A marca que impede o reaplicar cego.
    *
-   * Ela aparece nos dois sentidos: a permissão que o carimbo deu e alguém
-   * tirou, e a que ninguém carimbou e alguém ligou à mão.
+   * Ela aparece nos dois sentidos: a permissão que o modelo deu e alguém
+   * tirou, e a que nenhum modelo dava e alguém ligou à mão.
    */
-  it('marca as células que diferem dos carimbos, nos dois sentidos', () => {
+  it('marca as células que diferem dos modelos aplicados, nos dois sentidos', () => {
     fixture.componentRef.setInput('saved', { 'stock/movements': ['ALTERAR'] });
-    fixture.componentRef.setInput('stamped', { 'stock/movements': ['EXCLUIR'] });
+    fixture.componentRef.setInput('applied', { 'stock/movements': ['EXCLUIR'] });
     fixture.detectChanges();
 
     const linha = component.blocks().find(
@@ -186,20 +186,20 @@ describe('PermissionGridComponent', () => {
     const cells = linha?.kind === 'screen' ? linha.cells : [];
 
     expect(cells.find(c => c.permission === 'ALTERAR')?.diverges)
-      .withContext('ligada à mão, o carimbo não dava').toBeTrue();
+      .withContext('ligada à mão, nenhum modelo dava').toBeTrue();
     expect(cells.find(c => c.permission === 'EXCLUIR')?.diverges)
-      .withContext('o carimbo dava, alguém tirou').toBeTrue();
+      .withContext('o modelo dava, alguém tirou').toBeTrue();
     expect(cells.find(c => c.permission === 'CONSULTAR')?.diverges)
-      .withContext('nem carimbo nem ajuste').toBeFalse();
+      .withContext('nem modelo nem ajuste').toBeFalse();
   });
 
   /**
-   * Sem carimbo nenhum não há divergência — é a tela de modelos, onde o
+   * Sem modelo aplicado não há divergência — é a tela de modelos, onde o
    * conceito não existe. Marcar tudo lá seria ruído em 385 células.
    */
-  it('sem carimbo, nenhuma célula diverge', () => {
+  it('sem modelo aplicado, nenhuma célula diverge', () => {
     fixture.componentRef.setInput('saved', { 'stock/movements': ['ALTERAR'] });
-    fixture.componentRef.setInput('stamped', {});
+    fixture.componentRef.setInput('applied', {});
     fixture.detectChanges();
 
     const linha = component.blocks().find(

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.spec.ts
@@ -1,0 +1,233 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+import { PermissionGridComponent } from './permission-grid.component';
+import { ScreenRow } from '../../../../../domain/models/permission-admin.model';
+
+/**
+ * A grade de 385 células.
+ *
+ * O que se protege aqui é o **alcance**. Uma ação em massa que mexe em mais do
+ * que a pessoa está vendo não dá erro nenhum: ela grava, responde 200, e o
+ * estrago aparece dias depois em quem perdeu uma tela sem saber por quê.
+ */
+describe('PermissionGridComponent', () => {
+  let fixture: ComponentFixture<PermissionGridComponent>;
+  let component: PermissionGridComponent;
+
+  const TELAS: ScreenRow[] = [
+    { code: 'stock/movements', label: 'Movimentações', module: 'Estoque', sortOrder: 10 },
+    { code: 'stock/products', label: 'Produtos', module: 'Estoque', sortOrder: 20 },
+    { code: 'rh/hub', label: 'Painel RH', module: 'Recursos Humanos', sortOrder: 30 },
+  ];
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PermissionGridComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PermissionGridComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('screens', TELAS);
+    fixture.componentRef.setInput('saved', {});
+    fixture.detectChanges();
+  });
+
+  /** Quantas células estão ligadas numa tela, no estado de edição. */
+  const ligadasEm = (tela: string) => component.current()[tela]?.length ?? 0;
+
+  // ─── O alcance ────────────────────────────────────────────────────────────
+
+  /**
+   * **O teste que impede a armadilha.**
+   *
+   * "Liberar tudo" com um filtro ativo tem que respeitar o filtro. Se ele
+   * ignorasse, alguém que filtrou "Estoque" para arrumar seis células liberaria
+   * as 385 sem perceber — e a barra de gravação diria só um número grande.
+   */
+  it('liberar tudo respeita o filtro de módulo', () => {
+    component.setModule('Estoque');
+    component.toggleAll(true);
+
+    expect(ligadasEm('stock/movements')).toBe(7);
+    expect(ligadasEm('stock/products')).toBe(7);
+    expect(ligadasEm('rh/hub')).withContext('fora do filtro, intocada').toBe(0);
+  });
+
+  it('a busca por texto também limita o alcance', () => {
+    component.setFilter('produtos');
+    component.toggleAll(true);
+
+    expect(ligadasEm('stock/products')).toBe(7);
+    expect(ligadasEm('stock/movements')).toBe(0);
+  });
+
+  /**
+   * A coluna é um interruptor: se tudo já está ligado, o clique desliga. Sem
+   * isso, o cabeçalho só ligaria — e desligar uma permissão inteira voltaria a
+   * ser 55 cliques.
+   */
+  it('clicar na coluna liga e o segundo clique desliga', () => {
+    component.toggleColumn('EXCLUIR');
+    expect(component.current()['stock/movements']).toContain('EXCLUIR');
+
+    component.toggleColumn('EXCLUIR');
+    expect(component.current()['stock/movements'] ?? []).not.toContain('EXCLUIR');
+  });
+
+  it('o módulo liga só as telas dele', () => {
+    component.toggleModule('Estoque', true);
+
+    expect(ligadasEm('stock/movements')).toBe(7);
+    expect(ligadasEm('rh/hub')).toBe(0);
+  });
+
+  // ─── O formato que vai para a API ─────────────────────────────────────────
+
+  /**
+   * `current()` devolve só o ligado — **ausente é negado**.
+   *
+   * É o que torna o `PUT` idempotente. Se ele mandasse as negadas também, o
+   * corpo teria 385 entradas e a diferença entre "negado" e "não mandado"
+   * voltaria a existir.
+   */
+  it('current() devolve só o que está ligado', () => {
+    component.toggleCell('rh/hub:CONSULTAR');
+
+    expect(component.current()).toEqual({ 'rh/hub': ['CONSULTAR'] });
+  });
+
+  /**
+   * O código da tela tem barras, e a permissão vem depois do ÚLTIMO
+   * dois-pontos. Partir no primeiro devolveria `stock` como nome de tela.
+   */
+  it('desmonta a chave pelo último dois-pontos', () => {
+    component.toggleCell('stock/movements:ALTERAR');
+
+    expect(Object.keys(component.current())).toEqual(['stock/movements']);
+  });
+
+  // ─── A contagem e o descarte ──────────────────────────────────────────────
+
+  it('conta tanto o que ligou quanto o que desligou', () => {
+    fixture.componentRef.setInput('saved', { 'rh/hub': ['CONSULTAR'] });
+    fixture.detectChanges();
+
+    component.toggleCell('rh/hub:CONSULTAR');      // desligou uma
+    component.toggleCell('stock/products:INCLUIR'); // ligou outra
+
+    expect(component.changed()).toBe(2);
+  });
+
+  it('descartar volta ao gravado', () => {
+    fixture.componentRef.setInput('saved', { 'rh/hub': ['CONSULTAR'] });
+    fixture.detectChanges();
+
+    component.toggleAll(true);
+    component.discard();
+
+    expect(component.current()).toEqual({ 'rh/hub': ['CONSULTAR'] });
+    expect(component.changed()).toBe(0);
+  });
+
+  /**
+   * **Trocar de modelo ou de pessoa reinicia a edição.**
+   *
+   * Sem isto, abrir outro usuário mostraria as células do anterior por cima das
+   * dele — e gravar escreveria as permissões erradas na pessoa errada, sem erro
+   * nenhum na tela.
+   */
+  it('trocar o gravado reinicia a edição', () => {
+    component.toggleAll(true);
+    expect(component.changed()).toBeGreaterThan(0);
+
+    fixture.componentRef.setInput('saved', { 'stock/products': ['BAIXAR'] });
+    fixture.detectChanges();
+
+    expect(component.current()).toEqual({ 'stock/products': ['BAIXAR'] });
+    expect(component.changed()).toBe(0);
+  });
+
+  // ─── Só leitura ───────────────────────────────────────────────────────────
+
+  /**
+   * Quem não tem `ALTERAR` enxerga e não mexe.
+   *
+   * O 403 da API pegaria de qualquer jeito, mas uma grade que aceita o clique e
+   * falha ao gravar faz a pessoa refazer o trabalho para descobrir isso.
+   */
+  it('em só leitura, nenhum clique muda nada', () => {
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    component.toggleCell('rh/hub:CONSULTAR');
+    component.toggleColumn('EXCLUIR');
+    component.toggleAll(true);
+
+    expect(component.changed()).toBe(0);
+  });
+
+  // ─── O ponto âmbar ────────────────────────────────────────────────────────
+
+  /**
+   * A marca que impede o reaplicar cego.
+   *
+   * Ela aparece nos dois sentidos: a permissão que o carimbo deu e alguém
+   * tirou, e a que ninguém carimbou e alguém ligou à mão.
+   */
+  it('marca as células que diferem dos carimbos, nos dois sentidos', () => {
+    fixture.componentRef.setInput('saved', { 'stock/movements': ['ALTERAR'] });
+    fixture.componentRef.setInput('stamped', { 'stock/movements': ['EXCLUIR'] });
+    fixture.detectChanges();
+
+    const linha = component.blocks().find(
+      b => b.kind === 'screen' && b.screen.code === 'stock/movements');
+    const cells = linha?.kind === 'screen' ? linha.cells : [];
+
+    expect(cells.find(c => c.permission === 'ALTERAR')?.diverges)
+      .withContext('ligada à mão, o carimbo não dava').toBeTrue();
+    expect(cells.find(c => c.permission === 'EXCLUIR')?.diverges)
+      .withContext('o carimbo dava, alguém tirou').toBeTrue();
+    expect(cells.find(c => c.permission === 'CONSULTAR')?.diverges)
+      .withContext('nem carimbo nem ajuste').toBeFalse();
+  });
+
+  /**
+   * Sem carimbo nenhum não há divergência — é a tela de modelos, onde o
+   * conceito não existe. Marcar tudo lá seria ruído em 385 células.
+   */
+  it('sem carimbo, nenhuma célula diverge', () => {
+    fixture.componentRef.setInput('saved', { 'stock/movements': ['ALTERAR'] });
+    fixture.componentRef.setInput('stamped', {});
+    fixture.detectChanges();
+
+    const linha = component.blocks().find(
+      b => b.kind === 'screen' && b.screen.code === 'stock/movements');
+    const cells = linha?.kind === 'screen' ? linha.cells : [];
+
+    expect(cells.every(c => !c.diverges)).toBeTrue();
+  });
+
+  // ─── Módulos ──────────────────────────────────────────────────────────────
+
+  it('a faixa do módulo traz o placar do que está ligado', () => {
+    component.toggleRow(TELAS[0], true);
+
+    const faixa = component.blocks().find(
+      b => b.kind === 'module' && b.module === 'Estoque');
+
+    expect(faixa?.kind === 'module' ? faixa.allowed : -1).toBe(7);
+    expect(faixa?.kind === 'module' ? faixa.total : -1).toBe(14);
+  });
+
+  it('módulo fechado esconde as linhas e mantém a faixa', () => {
+    component.collapse('Estoque');
+
+    const blocos = component.blocks();
+    expect(blocos.some(b => b.kind === 'module' && b.module === 'Estoque')).toBeTrue();
+    expect(blocos.some(b => b.kind === 'screen' && b.screen.module === 'Estoque')).toBeFalse();
+    expect(blocos.some(b => b.kind === 'screen' && b.screen.module === 'Recursos Humanos'))
+      .withContext('fechar um módulo não fecha os outros').toBeTrue();
+  });
+});

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
@@ -1,4 +1,7 @@
 import { Component, computed, effect, input, linkedSignal, output, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { PkInputComponent } from '../../../../theme/ProautoKimium/pk-input/pk-input.component';
 
 import {
   PERMISSION_LABELS, PERMISSIONS, PermissionCells, PermissionName, ScreenRow,
@@ -50,6 +53,7 @@ function keysOf(cells: PermissionCells): Set<string> {
 @Component({
   selector: 'app-permission-grid',
   standalone: true,
+  imports: [FormsModule, PkInputComponent],
   templateUrl: './permission-grid.component.html',
   styleUrl: './permission-grid.component.scss',
 })

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
@@ -12,7 +12,7 @@ export interface GridCell {
   permission: PermissionName;
   key: string;
   on: boolean;
-  /** Difere do que os carimbos aplicados permitem — o ponto âmbar. */
+  /** Difere do que os modelos aplicados permitem — o ponto âmbar. */
   diverges: boolean;
 }
 
@@ -64,8 +64,8 @@ export class PermissionGridComponent {
   /** O que está gravado. Trocar de modelo ou de pessoa reinicia a edição. */
   readonly saved = input<PermissionCells>({});
 
-  /** O que os carimbos permitem. Vazio na tela de modelos — lá não há carimbo. */
-  readonly stamped = input<PermissionCells>({});
+  /** O que os modelos aplicados permitem. Vazio na tela de modelos. */
+  readonly applied = input<PermissionCells>({});
 
   /** Sem `ALTERAR`, a grade é só leitura. */
   readonly disabled = input<boolean>(false);
@@ -94,7 +94,7 @@ export class PermissionGridComponent {
   });
 
   private readonly savedKeys = computed(() => keysOf(this.saved()));
-  private readonly stampedKeys = computed(() => keysOf(this.stamped()));
+  private readonly appliedKeys = computed(() => keysOf(this.applied()));
 
   readonly changed = computed(() => {
     const agora = this.working();
@@ -120,7 +120,7 @@ export class PermissionGridComponent {
 
   readonly blocks = computed<GridBlock[]>(() => {
     const ligadas = this.working();
-    const carimbadas = this.stampedKeys();
+    const peloModelo = this.appliedKeys();
     const fechados = this.closed();
     const telas = this.visible();
 
@@ -152,9 +152,9 @@ export class PermissionGridComponent {
           permission,
           key: chave,
           on,
-          // Sem carimbo nenhum não há divergência — é a tela de modelos, onde
-          // a coluna do esperado não existe.
-          diverges: carimbadas.size > 0 && on !== carimbadas.has(chave),
+          // Sem modelo aplicado não há divergência — é a tela de modelos, onde
+          // o esperado não existe.
+          diverges: peloModelo.size > 0 && on !== peloModelo.has(chave),
         } satisfies GridCell;
       });
 

--- a/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
+++ b/src/app/components/auth/settings/permissions/permission-grid/permission-grid.component.ts
@@ -1,0 +1,280 @@
+import { Component, computed, effect, input, linkedSignal, output, signal } from '@angular/core';
+
+import {
+  PERMISSION_LABELS, PERMISSIONS, PermissionCells, PermissionName, ScreenRow,
+} from '../../../../../domain/models/permission-admin.model';
+
+/** Uma célula desenhada. */
+export interface GridCell {
+  permission: PermissionName;
+  key: string;
+  on: boolean;
+  /** Difere do que os carimbos aplicados permitem — o ponto âmbar. */
+  diverges: boolean;
+}
+
+/** O que o template percorre: faixas de módulo e linhas de tela, na mesma lista. */
+export type GridBlock =
+  | { kind: 'module'; module: string; open: boolean; allowed: number; total: number }
+  | { kind: 'screen'; screen: ScreenRow; cells: GridCell[]; full: boolean };
+
+const key = (screen: string, permission: string) => `${screen}:${permission}`;
+
+function keysOf(cells: PermissionCells): Set<string> {
+  const chaves = new Set<string>();
+  for (const [tela, permissoes] of Object.entries(cells ?? {})) {
+    for (const permissao of permissoes ?? []) chaves.add(key(tela, permissao));
+  }
+  return chaves;
+}
+
+/**
+ * A grade de 55 telas por 7 permissões — a mesma nas duas telas de configuração.
+ *
+ * O que ela resolve não é desenhar 385 caixinhas, é **deixá-las utilizáveis**:
+ * 55 linhas de uma vez não se lê, e uma ação em massa sem alcance visível é uma
+ * armadilha. Daí as três decisões que valem por todo o resto:
+ *
+ * 1. **Módulo colapsa e mostra o placar.** Dá para achar o bloco errado sem
+ *    abri-lo.
+ * 2. **O alcance de toda ação em massa é o que está VISÍVEL.** Filtrou por
+ *    Estoque, o "liberar tudo" mexe no Estoque. Sem isso, um clique inocente
+ *    mexe em 385 células.
+ * 3. **Gravar é explícito.** Gravação automática em 385 células é o desenho que
+ *    apaga acesso por engano.
+ *
+ * O componente **não grava**: ele mantém a edição e diz quantas células
+ * mudaram. Quem chama decide o que fazer com isso — é a mesma separação que
+ * fez o `pk-calendar` servir a duas telas.
+ */
+@Component({
+  selector: 'app-permission-grid',
+  standalone: true,
+  templateUrl: './permission-grid.component.html',
+  styleUrl: './permission-grid.component.scss',
+})
+export class PermissionGridComponent {
+
+  readonly screens = input<ScreenRow[]>([]);
+
+  /** O que está gravado. Trocar de modelo ou de pessoa reinicia a edição. */
+  readonly saved = input<PermissionCells>({});
+
+  /** O que os carimbos permitem. Vazio na tela de modelos — lá não há carimbo. */
+  readonly stamped = input<PermissionCells>({});
+
+  /** Sem `ALTERAR`, a grade é só leitura. */
+  readonly disabled = input<boolean>(false);
+
+  /** Quantas células diferem do gravado. A barra de gravação vive disto. */
+  readonly changedCount = output<number>();
+
+  readonly permissions = PERMISSIONS;
+  readonly labels = PERMISSION_LABELS;
+
+  readonly filter = signal('');
+  readonly module = signal('todos');
+  readonly closed = signal<ReadonlySet<string>>(new Set());
+
+  /**
+   * A edição em andamento.
+   *
+   * `linkedSignal` e não `signal` + `effect`: quando o pai troca o modelo
+   * selecionado, a edição precisa reiniciar sozinha. Com `effect` isso seria
+   * escrita de sinal dentro de efeito para manter dois estados em sincronia —
+   * o jeito mais fácil de criar um laço que ninguém enxerga.
+   */
+  private readonly working = linkedSignal<PermissionCells, Set<string>>({
+    source: this.saved,
+    computation: cells => keysOf(cells),
+  });
+
+  private readonly savedKeys = computed(() => keysOf(this.saved()));
+  private readonly stampedKeys = computed(() => keysOf(this.stamped()));
+
+  readonly changed = computed(() => {
+    const agora = this.working();
+    const antes = this.savedKeys();
+    let total = 0;
+    for (const chave of agora) if (!antes.has(chave)) total++;
+    for (const chave of antes) if (!agora.has(chave)) total++;
+    return total;
+  });
+
+  readonly modules = computed(() =>
+    [...new Set(this.screens().map(s => s.module))]);
+
+  /** As telas que passam pelo filtro — e o alcance de toda ação em massa. */
+  readonly visible = computed(() => {
+    const termo = this.filter().trim().toLowerCase();
+    const modulo = this.module();
+
+    return this.screens().filter(s =>
+      (modulo === 'todos' || s.module === modulo) &&
+      (!termo || s.label.toLowerCase().includes(termo) || s.code.includes(termo)));
+  });
+
+  readonly blocks = computed<GridBlock[]>(() => {
+    const ligadas = this.working();
+    const carimbadas = this.stampedKeys();
+    const fechados = this.closed();
+    const telas = this.visible();
+
+    const blocos: GridBlock[] = [];
+    let moduloAtual: string | null = null;
+
+    for (const screen of telas) {
+      if (screen.module !== moduloAtual) {
+        moduloAtual = screen.module;
+        const doModulo = telas.filter(s => s.module === moduloAtual);
+        const abertas = doModulo.reduce((total, s) =>
+          total + PERMISSIONS.filter(p => ligadas.has(key(s.code, p))).length, 0);
+
+        blocos.push({
+          kind: 'module',
+          module: moduloAtual,
+          open: !fechados.has(moduloAtual),
+          allowed: abertas,
+          total: doModulo.length * PERMISSIONS.length,
+        });
+      }
+
+      if (fechados.has(screen.module)) continue;
+
+      const cells = PERMISSIONS.map(permission => {
+        const chave = key(screen.code, permission);
+        const on = ligadas.has(chave);
+        return {
+          permission,
+          key: chave,
+          on,
+          // Sem carimbo nenhum não há divergência — é a tela de modelos, onde
+          // a coluna do esperado não existe.
+          diverges: carimbadas.size > 0 && on !== carimbadas.has(chave),
+        } satisfies GridCell;
+      });
+
+      blocos.push({
+        kind: 'screen',
+        screen,
+        cells,
+        full: cells.every(c => c.on),
+      });
+    }
+
+    return blocos;
+  });
+
+  constructor() {
+    effect(() => this.changedCount.emit(this.changed()));
+  }
+
+  // ─── O que o pai chama ─────────────────────────────────────────────────────
+
+  /** A grade como a API a espera: só o que está ligado. */
+  current(): PermissionCells {
+    const cells: PermissionCells = {};
+    for (const chave of [...this.working()].sort()) {
+      const corte = chave.lastIndexOf(':');
+      const tela = chave.slice(0, corte);
+      (cells[tela] ??= []).push(chave.slice(corte + 1));
+    }
+    return cells;
+  }
+
+  /** Volta ao que está gravado. */
+  discard(): void {
+    this.working.set(keysOf(this.saved()));
+  }
+
+  // ─── Edição ────────────────────────────────────────────────────────────────
+
+  toggleCell(chave: string): void {
+    if (this.disabled()) return;
+    this.write(atual => {
+      atual.has(chave) ? atual.delete(chave) : atual.add(chave);
+    });
+  }
+
+  /**
+   * Liga ou desliga uma permissão **nas telas visíveis**.
+   *
+   * Visíveis, e não todas: se alguém filtrou por Estoque, o alcance é o filtro.
+   * O estado de saída é "todas ligadas?" — se já estão, o clique desliga, que é
+   * o que a pessoa espera de um interruptor.
+   */
+  toggleColumn(permission: PermissionName): void {
+    if (this.disabled()) return;
+    const telas = this.visible();
+    const todasLigadas = telas.every(s => this.working().has(key(s.code, permission)));
+    this.write(atual => {
+      for (const screen of telas) {
+        const chave = key(screen.code, permission);
+        todasLigadas ? atual.delete(chave) : atual.add(chave);
+      }
+    });
+  }
+
+  toggleRow(screen: ScreenRow, ligar: boolean): void {
+    if (this.disabled()) return;
+    this.write(atual => {
+      for (const permission of PERMISSIONS) {
+        const chave = key(screen.code, permission);
+        ligar ? atual.add(chave) : atual.delete(chave);
+      }
+    });
+  }
+
+  toggleModule(module: string, ligar: boolean): void {
+    if (this.disabled()) return;
+    this.write(atual => {
+      for (const screen of this.visible().filter(s => s.module === module)) {
+        for (const permission of PERMISSIONS) {
+          const chave = key(screen.code, permission);
+          ligar ? atual.add(chave) : atual.delete(chave);
+        }
+      }
+    });
+  }
+
+  /** Liberar ou bloquear tudo — de novo, só o que está visível. */
+  toggleAll(ligar: boolean): void {
+    if (this.disabled()) return;
+    this.write(atual => {
+      for (const screen of this.visible()) {
+        for (const permission of PERMISSIONS) {
+          const chave = key(screen.code, permission);
+          ligar ? atual.add(chave) : atual.delete(chave);
+        }
+      }
+    });
+  }
+
+  // ─── Filtro e colapso ──────────────────────────────────────────────────────
+
+  setFilter(valor: string): void {
+    this.filter.set(valor);
+  }
+
+  setModule(module: string): void {
+    this.module.set(module);
+  }
+
+  collapse(module: string): void {
+    const fechados = new Set(this.closed());
+    fechados.has(module) ? fechados.delete(module) : fechados.add(module);
+    this.closed.set(fechados);
+  }
+
+  /**
+   * Toda escrita cria um `Set` novo.
+   *
+   * Mutar o de dentro do sinal não dispara nada: a referência continua a mesma,
+   * e a grade ficaria parada enquanto o estado muda por baixo.
+   */
+  private write(mudanca: (atual: Set<string>) => void): void {
+    const proximo = new Set(this.working());
+    mudanca(proximo);
+    this.working.set(proximo);
+  }
+}

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
@@ -127,7 +127,7 @@
 <!-- ─── Criar, duplicar, renomear ───────────────────────────────────────── -->
 <pk-dialog [header]="formTitle()" [visible]="formOpen()" width="480px"
            (visibleChange)="formOpen.set($event)">
-  <div class="pform">
+  <div class="pform" pkDialogContent>
     <div class="pform__row">
       <label class="pform__label" for="tpl-name">Nome</label>
       <input id="tpl-name" class="pshell__field" type="text"
@@ -151,18 +151,18 @@
     @if (formKind() === 'new') {
       <p class="pform__hint">Nasce com <b>tudo fechado</b>. Libere o que ele deve dar.</p>
     }
+  </div>
 
-    <div class="pform__foot">
-      <pk-button pkType="cancel" pkSize="sm" (clicked)="formOpen.set(false)" />
-      <pk-button pkType="save" pkSize="sm" pkLabel="Confirmar" (clicked)="submitForm()" />
-    </div>
+  <div class="pform__foot" pkDialogFooter>
+    <pk-button pkType="cancel" pkSize="sm" (clicked)="formOpen.set(false)" />
+    <pk-button pkType="save" pkSize="sm" pkLabel="Confirmar" (clicked)="submitForm()" />
   </div>
 </pk-dialog>
 
 <!-- ─── Reaplicar ───────────────────────────────────────────────────────── -->
 <pk-dialog header="Reaplicar o modelo" [visible]="reapplyOpen()" width="520px"
            (visibleChange)="reapplyOpen.set($event)">
-  <div class="pform">
+  <div class="pform" pkDialogContent>
     <p class="pform__hint">
       As <b>{{ stampedUsers().length }}</b> pessoas abaixo ficam <b>idênticas</b>
       a este modelo:
@@ -182,12 +182,12 @@
       Todo <b>ajuste individual</b> dessas pessoas se perde — inclusive uma
       permissão que alguém tirou de propósito.
     </p>
+  </div>
 
-    <div class="pform__foot">
-      <pk-button pkType="cancel" pkSize="sm" (clicked)="reapplyOpen.set(false)" />
-      <pk-button pkType="save" pkSize="sm"
-                 [pkLabel]="'Reaplicar a ' + stampedUsers().length"
-                 (clicked)="confirmReapply()" />
-    </div>
+  <div class="pform__foot" pkDialogFooter>
+    <pk-button pkType="cancel" pkSize="sm" (clicked)="reapplyOpen.set(false)" />
+    <pk-button pkType="save" pkSize="sm"
+               [pkLabel]="'Reaplicar a ' + stampedUsers().length"
+               (clicked)="confirmReapply()" />
   </div>
 </pk-dialog>

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
@@ -8,12 +8,11 @@
       <div class="pshell__rail-title">
         Modelos <span>{{ templates().length }}</span>
       </div>
-      <input type="search"
-             class="pshell__field"
-             placeholder="Buscar modelo…"
-             aria-label="Buscar modelo"
-             [value]="search()"
-             (input)="search.set($any($event.target).value)" />
+      <pk-input placeholder="Buscar modelo…"
+                icon="pi pi-search"
+                [ngModel]="search()"
+                (ngModelChange)="search.set($event)"
+                [ngModelOptions]="{ standalone: true }" />
     </div>
 
     <div class="pshell__list">
@@ -127,33 +126,41 @@
 <!-- ─── Criar, duplicar, renomear ───────────────────────────────────────── -->
 <pk-dialog [header]="formTitle()" [visible]="formOpen()" width="480px"
            (visibleChange)="formOpen.set($event)">
-  <div class="pform" pkDialogContent>
-    <div class="pform__row">
-      <label class="pform__label" for="tpl-name">Nome</label>
-      <input id="tpl-name" class="pshell__field" type="text"
-             [value]="formName()" (input)="formName.set($any($event.target).value)" />
-    </div>
 
-    <div class="pform__row">
-      <label class="pform__label" for="tpl-desc">Descrição</label>
-      <input id="tpl-desc" class="pshell__field" type="text"
-             placeholder="Para que serve este modelo"
-             [value]="formDescription()"
-             (input)="formDescription.set($any($event.target).value)" />
-    </div>
+  <!--
+    `pk-form-section` e não uma div solta: o pk-dialog zera o padding do
+    conteúdo de propósito, e é a seção que traz o espaçamento.
+  -->
+  <div pkDialogContent>
+    <div class="pk-form-section">
+      <div class="pform">
+        <pk-input label="Nome"
+                  placeholder="Ex.: Vendas Júnior"
+                  [pkRequired]="true"
+                  [ngModel]="formName()"
+                  (ngModelChange)="formName.set($event)"
+                  [ngModelOptions]="{ standalone: true }" />
 
-    @if (formKind() === 'duplicate') {
-      <p class="pform__hint">
-        Nasce com as mesmas permissões de <b>{{ current()?.name }}</b>. Do zero
-        seriam 385 cliques.
-      </p>
-    }
-    @if (formKind() === 'new') {
-      <p class="pform__hint">Nasce com <b>tudo fechado</b>. Libere o que ele deve dar.</p>
-    }
+        <pk-input label="Descrição"
+                  placeholder="Para que serve este modelo"
+                  [ngModel]="formDescription()"
+                  (ngModelChange)="formDescription.set($event)"
+                  [ngModelOptions]="{ standalone: true }" />
+
+        @if (formKind() === 'duplicate') {
+          <p class="pform__hint">
+            Nasce com as mesmas permissões de <b>{{ current()?.name }}</b>. Do zero
+            seriam 385 cliques.
+          </p>
+        }
+        @if (formKind() === 'new') {
+          <p class="pform__hint">Nasce com <b>tudo fechado</b>. Libere o que ele deve dar.</p>
+        }
+      </div>
+    </div>
   </div>
 
-  <div class="pform__foot" pkDialogFooter>
+  <div pkDialogFooter class="pk-dialog-footer">
     <pk-button pkType="cancel" pkSize="sm" (clicked)="formOpen.set(false)" />
     <pk-button pkType="save" pkSize="sm" pkLabel="Confirmar" (clicked)="submitForm()" />
   </div>
@@ -162,29 +169,33 @@
 <!-- ─── Reaplicar ───────────────────────────────────────────────────────── -->
 <pk-dialog header="Reaplicar o modelo" [visible]="reapplyOpen()" width="520px"
            (visibleChange)="reapplyOpen.set($event)">
-  <div class="pform" pkDialogContent>
-    <p class="pform__hint">
-      As <b>{{ stampedUsers().length }}</b> pessoas abaixo ficam <b>idênticas</b>
-      a este modelo:
-    </p>
 
-    <ul class="pform__people">
-      @for (p of stampedUsers(); track p.id) {
-        <li>{{ p.name }} <span>{{ p.login }}</span></li>
-      }
-    </ul>
+  <div pkDialogContent>
+    <div class="pk-form-section">
+      <h3 class="pk-form-section__title">
+        <i class="pi pi-users"></i> Quem fica idêntico ao modelo
+      </h3>
+
+      <ul class="pform__people">
+        @for (p of stampedUsers(); track p.id) {
+          <li>{{ p.name }} <span>{{ p.login }}</span></li>
+        }
+      </ul>
+    </div>
 
     <!--
       Reaplicar é sempre SUBSTITUIR. Somar não reaplicaria nada: deixaria
       ligado o que o modelo passou a negar. O preço é este aviso.
     -->
-    <p class="pform__danger">
-      Todo <b>ajuste individual</b> dessas pessoas se perde — inclusive uma
-      permissão que alguém tirou de propósito.
-    </p>
+    <div class="pk-form-section">
+      <p class="pform__danger">
+        Todo <b>ajuste individual</b> dessas pessoas se perde — inclusive uma
+        permissão que alguém tirou de propósito.
+      </p>
+    </div>
   </div>
 
-  <div class="pform__foot" pkDialogFooter>
+  <div pkDialogFooter class="pk-dialog-footer">
     <pk-button pkType="cancel" pkSize="sm" (clicked)="reapplyOpen.set(false)" />
     <pk-button pkType="save" pkSize="sm"
                [pkLabel]="'Reaplicar a ' + stampedUsers().length"

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
@@ -1,0 +1,193 @@
+<p-toast></p-toast>
+
+<div class="pshell">
+
+  <!-- ─── Os modelos ─────────────────────────────────────────────────────── -->
+  <aside class="pshell__rail">
+    <div class="pshell__rail-head">
+      <div class="pshell__rail-title">
+        Modelos <span>{{ templates().length }}</span>
+      </div>
+      <input type="search"
+             class="pshell__field"
+             placeholder="Buscar modelo…"
+             aria-label="Buscar modelo"
+             [value]="search()"
+             (input)="search.set($any($event.target).value)" />
+    </div>
+
+    <div class="pshell__list">
+      @for (t of visibleTemplates(); track t.id) {
+        <button type="button"
+                class="pshell__item"
+                [class.pshell__item--off]="!t.active"
+                [attr.aria-current]="t.id === selected()?.id"
+                (click)="select(t)">
+          <b>{{ t.name }}</b>
+          <span>{{ t.allowedCells }} permissões · {{ t.stampedUsers }} carimbados</span>
+        </button>
+      } @empty {
+        <p class="pshell__empty-list">Nenhum modelo com esse nome.</p>
+      }
+    </div>
+
+    @if (canCreate()) {
+      <div class="pshell__rail-foot">
+        <pk-button pkType="new" pkSize="sm" pkLabel="Novo modelo" (clicked)="openNew()" />
+      </div>
+    }
+  </aside>
+
+  <!-- ─── O modelo aberto ────────────────────────────────────────────────── -->
+  <div class="pshell__main">
+
+    @if (selected(); as modelo) {
+
+      <div class="pshell__subject">
+        <div class="pshell__subject-id">
+          <h2>{{ modelo.name }}</h2>
+          <p>
+            {{ modelo.description || 'Sem descrição' }}
+            @if (!modelo.active) { · <b>desativado</b> }
+          </p>
+        </div>
+
+        <div class="pshell__subject-acts">
+          @if (canCreate()) {
+            <pk-button pkType="new" pkSize="sm" pkLabel="Duplicar"
+                       pkIcon="pi pi-copy" (clicked)="openDuplicate()" />
+          }
+          @if (canEdit()) {
+            <pk-button pkType="edit" pkSize="sm" pkLabel="Renomear" (clicked)="openRename()" />
+            <pk-button pkType="cancel" pkSize="sm"
+                       [pkLabel]="modelo.active ? 'Desativar' : 'Reativar'"
+                       (clicked)="toggleActive()" />
+          }
+        </div>
+      </div>
+
+      <!--
+        O aviso que impede a correção silenciosa: mexer aqui NÃO alcança quem
+        já foi carimbado, e sem isto dito na cara ninguém descobre.
+      -->
+      @if (stampedUsers().length) {
+        <div class="pshell__note">
+          <span>
+            <b>{{ stampedUsers().length }}</b>
+            {{ stampedUsers().length === 1 ? 'pessoa usou' : 'pessoas usaram' }} este carimbo.
+            Mudar a grade aqui <b>não altera nenhuma delas</b>.
+          </span>
+          @if (canApply()) {
+            <span class="pshell__note-act">
+              <pk-button pkType="refresh" pkSize="sm"
+                         [pkLabel]="'Reaplicar a ' + stampedUsers().length"
+                         (clicked)="reapplyOpen.set(true)" />
+            </span>
+          }
+        </div>
+      }
+
+      <app-permission-grid
+        [screens]="screens()"
+        [saved]="modelo.cells"
+        [disabled]="!canEdit()"
+        (changedCount)="changed.set($event)" />
+
+      <div class="pshell__save" [attr.data-dirty]="changed() > 0">
+        <div class="pshell__legend">
+          <i><span class="sw sw--on"></span> permitido</i>
+          <i><span class="sw"></span> negado</i>
+        </div>
+
+        <div class="pshell__save-msg">
+          @if (changed() > 0) {
+            <b>{{ changed() }}</b> {{ changed() === 1 ? 'célula' : 'células' }} sem gravar
+          } @else {
+            Nada para gravar
+          }
+        </div>
+
+        @if (canEdit()) {
+          <div class="pshell__save-acts">
+            <pk-button pkType="cancel" pkSize="sm" pkLabel="Descartar" (clicked)="discard()" />
+            <pk-button pkType="save" pkSize="sm" pkLabel="Salvar modelo"
+                       [pkLoading]="saving()" (clicked)="save()" />
+          </div>
+        }
+      </div>
+
+    } @else {
+      <div class="pshell__blank">
+        {{ loading() ? 'Carregando…' : 'Escolha um modelo à esquerda.' }}
+      </div>
+    }
+  </div>
+</div>
+
+<!-- ─── Criar, duplicar, renomear ───────────────────────────────────────── -->
+<pk-dialog [header]="formTitle()" [visible]="formOpen()" width="480px"
+           (visibleChange)="formOpen.set($event)">
+  <div class="pform">
+    <div class="pform__row">
+      <label class="pform__label" for="tpl-name">Nome</label>
+      <input id="tpl-name" class="pshell__field" type="text"
+             [value]="formName()" (input)="formName.set($any($event.target).value)" />
+    </div>
+
+    <div class="pform__row">
+      <label class="pform__label" for="tpl-desc">Descrição</label>
+      <input id="tpl-desc" class="pshell__field" type="text"
+             placeholder="Para que serve este modelo"
+             [value]="formDescription()"
+             (input)="formDescription.set($any($event.target).value)" />
+    </div>
+
+    @if (formKind() === 'duplicate') {
+      <p class="pform__hint">
+        Nasce com as mesmas permissões de <b>{{ current()?.name }}</b>. Do zero
+        seriam 385 cliques.
+      </p>
+    }
+    @if (formKind() === 'new') {
+      <p class="pform__hint">Nasce com <b>tudo fechado</b>. Libere o que ele deve dar.</p>
+    }
+
+    <div class="pform__foot">
+      <pk-button pkType="cancel" pkSize="sm" (clicked)="formOpen.set(false)" />
+      <pk-button pkType="save" pkSize="sm" pkLabel="Confirmar" (clicked)="submitForm()" />
+    </div>
+  </div>
+</pk-dialog>
+
+<!-- ─── Reaplicar ───────────────────────────────────────────────────────── -->
+<pk-dialog header="Reaplicar o modelo" [visible]="reapplyOpen()" width="520px"
+           (visibleChange)="reapplyOpen.set($event)">
+  <div class="pform">
+    <p class="pform__hint">
+      As <b>{{ stampedUsers().length }}</b> pessoas abaixo ficam <b>idênticas</b>
+      a este modelo:
+    </p>
+
+    <ul class="pform__people">
+      @for (p of stampedUsers(); track p.id) {
+        <li>{{ p.name }} <span>{{ p.login }}</span></li>
+      }
+    </ul>
+
+    <!--
+      Reaplicar é sempre SUBSTITUIR. Somar não reaplicaria nada: deixaria
+      ligado o que o modelo passou a negar. O preço é este aviso.
+    -->
+    <p class="pform__danger">
+      Todo <b>ajuste individual</b> dessas pessoas se perde — inclusive uma
+      permissão que alguém tirou de propósito.
+    </p>
+
+    <div class="pform__foot">
+      <pk-button pkType="cancel" pkSize="sm" (clicked)="reapplyOpen.set(false)" />
+      <pk-button pkType="save" pkSize="sm"
+                 [pkLabel]="'Reaplicar a ' + stampedUsers().length"
+                 (clicked)="confirmReapply()" />
+    </div>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.html
@@ -23,7 +23,7 @@
                 [attr.aria-current]="t.id === selected()?.id"
                 (click)="select(t)">
           <b>{{ t.name }}</b>
-          <span>{{ t.allowedCells }} permissões · {{ t.stampedUsers }} carimbados</span>
+          <span>{{ t.allowedCells }} permissões · aplicado a {{ t.appliedToUsers }}</span>
         </button>
       } @empty {
         <p class="pshell__empty-list">Nenhum modelo com esse nome.</p>
@@ -66,20 +66,21 @@
       </div>
 
       <!--
-        O aviso que impede a correção silenciosa: mexer aqui NÃO alcança quem
-        já foi carimbado, e sem isto dito na cara ninguém descobre.
+        O aviso que impede a correção silenciosa: mexer aqui NÃO alcança quem já
+        recebeu o modelo, e sem isto dito na cara ninguém descobre.
       -->
-      @if (stampedUsers().length) {
+      @if (appliedToUsers().length) {
         <div class="pshell__note">
           <span>
-            <b>{{ stampedUsers().length }}</b>
-            {{ stampedUsers().length === 1 ? 'pessoa usou' : 'pessoas usaram' }} este carimbo.
-            Mudar a grade aqui <b>não altera nenhuma delas</b>.
+            Este modelo já foi aplicado a <b>{{ appliedToUsers().length }}</b>
+            {{ appliedToUsers().length === 1 ? 'pessoa' : 'pessoas' }}.
+            Alterá-lo aqui <b>não muda o que elas podem hoje</b> — a aplicação
+            copiou as permissões para dentro delas.
           </span>
           @if (canApply()) {
             <span class="pshell__note-act">
               <pk-button pkType="refresh" pkSize="sm"
-                         [pkLabel]="'Reaplicar a ' + stampedUsers().length"
+                         [pkLabel]="'Reaplicar a ' + appliedToUsers().length"
                          (clicked)="reapplyOpen.set(true)" />
             </span>
           }
@@ -177,7 +178,7 @@
       </h3>
 
       <ul class="pform__people">
-        @for (p of stampedUsers(); track p.id) {
+        @for (p of appliedToUsers(); track p.id) {
           <li>{{ p.name }} <span>{{ p.login }}</span></li>
         }
       </ul>
@@ -198,7 +199,7 @@
   <div pkDialogFooter class="pk-dialog-footer">
     <pk-button pkType="cancel" pkSize="sm" (clicked)="reapplyOpen.set(false)" />
     <pk-button pkType="save" pkSize="sm"
-               [pkLabel]="'Reaplicar a ' + stampedUsers().length"
+               [pkLabel]="'Reaplicar a ' + appliedToUsers().length"
                (clicked)="confirmReapply()" />
   </div>
 </pk-dialog>

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.scss
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.scss
@@ -1,0 +1,63 @@
+@use '../permission-shell' as *;
+
+// O que é só desta tela. O esqueleto vem do parcial compartilhado — as duas
+// telas de permissão têm a mesma moldura, e mantê-la em dois arquivos garantiria
+// que elas divergissem sozinhas.
+
+.pshell__blank {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-muted);
+  font-size: 13px;
+}
+
+.pshell__empty-list {
+  margin: 12px 10px;
+  font-size: 12px;
+  color: var(--app-text-muted);
+}
+
+.pform__hint {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--app-text-muted);
+  line-height: 1.55;
+
+  b { color: var(--app-text); font-weight: 600; }
+}
+
+// O aviso que precede a única ação desta tela que apaga trabalho de alguém.
+.pform__danger {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-control);
+  background: var(--app-warning-soft);
+  border: 1px solid var(--app-warning);
+  color: var(--app-warning);
+  font-size: 12.5px;
+  line-height: 1.55;
+
+  b { font-weight: 700; }
+}
+
+.pform__people {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  max-height: 180px;
+  overflow-y: auto;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-control);
+
+  li {
+    padding: 7px 12px;
+    font-size: 12.5px;
+    border-bottom: 1px solid var(--app-border);
+
+    &:last-child { border-bottom: 0; }
+
+    span { color: var(--app-text-subtle); font-size: 11px; margin-left: 6px; }
+  }
+}

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 
 import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkInputComponent } from '../../../../theme/ProautoKimium/pk-input/pk-input.component';
 import { PkDialogComponent } from '../../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
 import { PermissionGridComponent } from '../permission-grid/permission-grid.component';
 import { PermissionAdminService } from '../../../../../infrastructure/services/permission/permission-admin.service';
@@ -28,7 +30,10 @@ const SCREEN = 'settings/permissions/templates';
 @Component({
   selector: 'app-permission-templates',
   standalone: true,
-  imports: [ToastModule, PkButtonComponent, PkDialogComponent, PermissionGridComponent],
+  imports: [
+    FormsModule, ToastModule,
+    PkButtonComponent, PkInputComponent, PkDialogComponent, PermissionGridComponent,
+  ],
   templateUrl: './permission-templates.component.html',
   styleUrl: './permission-templates.component.scss',
   providers: [MessageService],

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
@@ -17,12 +17,13 @@ import {
 const SCREEN = 'settings/permissions/templates';
 
 /**
- * O que o carimbo contém.
+ * O que um modelo contém.
  *
  * A tela existe para configurar **modelos**, não pessoas — e a diferença é a
- * coisa mais importante que ela precisa comunicar. Mexer aqui não muda o acesso
- * de ninguém que já foi carimbado; por isso o aviso do topo diz quantas pessoas
- * usaram o modelo e é o único lugar de onde parte um "reaplicar".
+ * coisa mais importante que ela precisa comunicar. Aplicar um modelo **copia**
+ * as permissões para dentro da pessoa; mexer aqui depois não alcança ninguém
+ * que já recebeu. Por isso o aviso do topo diz a quantas pessoas ele já foi
+ * aplicado, e é o único lugar de onde parte um "reaplicar".
  *
  * Sem esse aviso o risco é silencioso: alguém corrige o modelo, sai satisfeito,
  * e ninguém no sistema foi corrigido.
@@ -49,7 +50,7 @@ export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
   readonly screens = signal<ScreenRow[]>([]);
   readonly templates = signal<TemplateSummary[]>([]);
   readonly selected = signal<TemplateGrid | null>(null);
-  readonly stampedUsers = signal<UserSummary[]>([]);
+  readonly appliedToUsers = signal<UserSummary[]>([]);
 
   readonly search = signal('');
   readonly changed = signal(0);
@@ -119,16 +120,16 @@ export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
     if (this.changed() > 0 && !confirm(
       'Há alterações não gravadas neste modelo. Trocar de modelo descarta.')) return;
 
-    this.stampedUsers.set([]);
+    this.appliedToUsers.set([]);
     this.api.templateGrid(template.id).subscribe({
       next: grade => this.selected.set(grade),
       error: () => this.falhou('Não foi possível abrir o modelo.'),
     });
-    this.api.stampedWith(template.id).subscribe({
-      next: pessoas => this.stampedUsers.set(pessoas),
+    this.api.appliedTo(template.id).subscribe({
+      next: pessoas => this.appliedToUsers.set(pessoas),
       // Sem a lista o aviso perde o botão, mas a grade continua editável — não
       // vale interromper o trabalho por causa disso.
-      error: () => this.stampedUsers.set([]),
+      error: () => this.appliedToUsers.set([]),
     });
   }
 
@@ -150,7 +151,7 @@ export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
           summary: 'Modelo gravado',
           detail: resultado.cellsChanged === 0
             ? 'Nada mudou.'
-            : `${resultado.cellsChanged} células alteradas. Quem já foi carimbado não mudou.`,
+            : `${resultado.cellsChanged} células alteradas. Quem já recebeu este modelo não mudou.`,
         });
       },
       error: () => {
@@ -245,7 +246,7 @@ export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
         this.toast.add({
           severity: 'success',
           summary: modelo.active ? 'Modelo desativado' : 'Modelo reativado',
-          detail: 'Quem já foi carimbado com ele não perdeu nada.',
+          detail: 'Quem já recebeu este modelo não perdeu nada.',
         });
       },
       error: () => this.falhou('Não foi possível alterar o modelo.'),
@@ -263,7 +264,7 @@ export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
    */
   confirmReapply(): void {
     const modelo = this.current();
-    const pessoas = this.stampedUsers();
+    const pessoas = this.appliedToUsers();
     if (!modelo || !pessoas.length) return;
 
     this.api.apply(modelo.id, pessoas.map(p => p.id), 'SUBSTITUIR').subscribe({

--- a/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
+++ b/src/app/components/auth/settings/permissions/templates/permission-templates.component.ts
@@ -1,0 +1,287 @@
+import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+
+import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PermissionGridComponent } from '../permission-grid/permission-grid.component';
+import { PermissionAdminService } from '../../../../../infrastructure/services/permission/permission-admin.service';
+import { PermissionStore } from '../../../../../infrastructure/state/permission.store';
+import { TabDirtyCheck } from '../../../../../infrastructure/routing/tab-dirty-check';
+import {
+  ScreenRow, TemplateGrid, TemplateSummary, UserSummary,
+} from '../../../../../domain/models/permission-admin.model';
+
+const SCREEN = 'settings/permissions/templates';
+
+/**
+ * O que o carimbo contém.
+ *
+ * A tela existe para configurar **modelos**, não pessoas — e a diferença é a
+ * coisa mais importante que ela precisa comunicar. Mexer aqui não muda o acesso
+ * de ninguém que já foi carimbado; por isso o aviso do topo diz quantas pessoas
+ * usaram o modelo e é o único lugar de onde parte um "reaplicar".
+ *
+ * Sem esse aviso o risco é silencioso: alguém corrige o modelo, sai satisfeito,
+ * e ninguém no sistema foi corrigido.
+ */
+@Component({
+  selector: 'app-permission-templates',
+  standalone: true,
+  imports: [ToastModule, PkButtonComponent, PkDialogComponent, PermissionGridComponent],
+  templateUrl: './permission-templates.component.html',
+  styleUrl: './permission-templates.component.scss',
+  providers: [MessageService],
+})
+export class PermissionTemplatesComponent implements OnInit, TabDirtyCheck {
+
+  private readonly api = inject(PermissionAdminService);
+  private readonly toast = inject(MessageService);
+  private readonly permissions = inject(PermissionStore);
+
+  private readonly grid = viewChild(PermissionGridComponent);
+
+  readonly screens = signal<ScreenRow[]>([]);
+  readonly templates = signal<TemplateSummary[]>([]);
+  readonly selected = signal<TemplateGrid | null>(null);
+  readonly stampedUsers = signal<UserSummary[]>([]);
+
+  readonly search = signal('');
+  readonly changed = signal(0);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+
+  /** Sem `ALTERAR` a grade abre em leitura, e os botões de gravar somem. */
+  readonly canEdit = computed(() => this.permissions.can(SCREEN, 'ALTERAR'));
+  readonly canCreate = computed(() => this.permissions.can(SCREEN, 'INCLUIR'));
+  readonly canApply = computed(() =>
+    this.permissions.can('settings/permissions/users', 'CONFIGURAR'));
+
+  readonly visibleTemplates = computed(() => {
+    const termo = this.search().trim().toLowerCase();
+    return this.templates().filter(t => !termo || t.name.toLowerCase().includes(termo));
+  });
+
+  readonly current = computed(() =>
+    this.templates().find(t => t.id === this.selected()?.id) ?? null);
+
+  // ─── Diálogo de criar / duplicar / renomear ────────────────────────────────
+
+  readonly formOpen = signal(false);
+  readonly formKind = signal<'new' | 'duplicate' | 'rename'>('new');
+  readonly formName = signal('');
+  readonly formDescription = signal('');
+
+  readonly formTitle = computed(() => ({
+    new: 'Novo modelo',
+    duplicate: `Duplicar ${this.current()?.name ?? ''}`,
+    rename: 'Renomear modelo',
+  }[this.formKind()]));
+
+  // ─── Diálogo de reaplicar ──────────────────────────────────────────────────
+
+  readonly reapplyOpen = signal(false);
+
+  /** A aba avisa antes de fechar com célula por gravar. */
+  isTabDirty(): boolean {
+    return this.changed() > 0;
+  }
+
+  ngOnInit(): void {
+    this.loading.set(true);
+    this.api.screens().subscribe({
+      next: telas => this.screens.set(telas),
+      error: () => this.falhou('Não foi possível carregar o catálogo de telas.'),
+    });
+    this.reloadTemplates(true);
+  }
+
+  private reloadTemplates(selectFirst = false): void {
+    this.api.templates().subscribe({
+      next: modelos => {
+        this.templates.set(modelos);
+        this.loading.set(false);
+        if (selectFirst && modelos.length) this.select(modelos[0]);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.falhou('Não foi possível carregar os modelos.');
+      },
+    });
+  }
+
+  select(template: TemplateSummary): void {
+    if (this.changed() > 0 && !confirm(
+      'Há alterações não gravadas neste modelo. Trocar de modelo descarta.')) return;
+
+    this.stampedUsers.set([]);
+    this.api.templateGrid(template.id).subscribe({
+      next: grade => this.selected.set(grade),
+      error: () => this.falhou('Não foi possível abrir o modelo.'),
+    });
+    this.api.stampedWith(template.id).subscribe({
+      next: pessoas => this.stampedUsers.set(pessoas),
+      // Sem a lista o aviso perde o botão, mas a grade continua editável — não
+      // vale interromper o trabalho por causa disso.
+      error: () => this.stampedUsers.set([]),
+    });
+  }
+
+  // ─── Gravar ────────────────────────────────────────────────────────────────
+
+  save(): void {
+    const grade = this.grid();
+    const modelo = this.selected();
+    if (!grade || !modelo) return;
+
+    this.saving.set(true);
+    this.api.saveTemplateGrid(modelo.id, grade.current()).subscribe({
+      next: resultado => {
+        this.saving.set(false);
+        this.selected.set({ ...modelo, cells: grade.current() });
+        this.reloadTemplates();
+        this.toast.add({
+          severity: 'success',
+          summary: 'Modelo gravado',
+          detail: resultado.cellsChanged === 0
+            ? 'Nada mudou.'
+            : `${resultado.cellsChanged} células alteradas. Quem já foi carimbado não mudou.`,
+        });
+      },
+      error: () => {
+        this.saving.set(false);
+        this.falhou('Não foi possível gravar o modelo.');
+      },
+    });
+  }
+
+  discard(): void {
+    this.grid()?.discard();
+  }
+
+  // ─── Criar, duplicar, renomear, desativar ──────────────────────────────────
+
+  openNew(): void {
+    this.formKind.set('new');
+    this.formName.set('');
+    this.formDescription.set('');
+    this.formOpen.set(true);
+  }
+
+  openDuplicate(): void {
+    const modelo = this.current();
+    if (!modelo) return;
+    this.formKind.set('duplicate');
+    this.formName.set(`${modelo.name} (cópia)`);
+    this.formDescription.set(modelo.description ?? '');
+    this.formOpen.set(true);
+  }
+
+  openRename(): void {
+    const modelo = this.current();
+    if (!modelo) return;
+    this.formKind.set('rename');
+    this.formName.set(modelo.name);
+    this.formDescription.set(modelo.description ?? '');
+    this.formOpen.set(true);
+  }
+
+  submitForm(): void {
+    const nome = this.formName().trim();
+    if (!nome) {
+      this.falhou('O modelo precisa de um nome.');
+      return;
+    }
+
+    const descricao = this.formDescription().trim() || null;
+
+    if (this.formKind() === 'rename') {
+      const modelo = this.current();
+      if (!modelo) return;
+      this.api.editTemplate(modelo.id, { name: nome, description: descricao ?? '' }).subscribe({
+        next: () => {
+          this.formOpen.set(false);
+          this.selected.set({ ...this.selected()!, name: nome, description: descricao });
+          this.reloadTemplates();
+          this.toast.add({ severity: 'success', summary: 'Modelo renomeado' });
+        },
+        error: erro => this.falhou(this.mensagem(erro, 'Não foi possível renomear.')),
+      });
+      return;
+    }
+
+    const origem = this.formKind() === 'duplicate' ? this.current()?.id : undefined;
+
+    this.api.createTemplate(nome, descricao, origem).subscribe({
+      next: criado => {
+        this.formOpen.set(false);
+        this.reloadTemplates();
+        this.select(criado);
+        this.toast.add({
+          severity: 'success',
+          summary: 'Modelo criado',
+          detail: origem
+            ? `Nasceu com as ${criado.allowedCells} permissões do original.`
+            : 'Nasceu com tudo fechado. Libere o que ele deve dar.',
+        });
+      },
+      error: erro => this.falhou(this.mensagem(erro, 'Não foi possível criar o modelo.')),
+    });
+  }
+
+  toggleActive(): void {
+    const modelo = this.current();
+    if (!modelo) return;
+
+    this.api.editTemplate(modelo.id, { active: !modelo.active }).subscribe({
+      next: () => {
+        this.selected.set({ ...this.selected()!, active: !modelo.active });
+        this.reloadTemplates();
+        this.toast.add({
+          severity: 'success',
+          summary: modelo.active ? 'Modelo desativado' : 'Modelo reativado',
+          detail: 'Quem já foi carimbado com ele não perdeu nada.',
+        });
+      },
+      error: () => this.falhou('Não foi possível alterar o modelo.'),
+    });
+  }
+
+  // ─── Reaplicar ─────────────────────────────────────────────────────────────
+
+  /**
+   * O reaplicar sempre SUBSTITUI — é o que ele significa.
+   *
+   * Somar não "reaplica" nada: deixaria ligado o que o modelo passou a negar, e
+   * a pessoa continuaria diferente do modelo. O preço é apagar ajuste
+   * individual, e é por isso que o diálogo escreve isso antes do clique.
+   */
+  confirmReapply(): void {
+    const modelo = this.current();
+    const pessoas = this.stampedUsers();
+    if (!modelo || !pessoas.length) return;
+
+    this.api.apply(modelo.id, pessoas.map(p => p.id), 'SUBSTITUIR').subscribe({
+      next: resultado => {
+        this.reapplyOpen.set(false);
+        this.toast.add({
+          severity: 'success',
+          summary: `Reaplicado em ${resultado.users} pessoas`,
+          detail: `${resultado.cellsChanged} células alteradas.`,
+        });
+      },
+      error: () => this.falhou('Não foi possível reaplicar o modelo.'),
+    });
+  }
+
+  // ─── Miudezas ──────────────────────────────────────────────────────────────
+
+  private mensagem(erro: unknown, padrao: string): string {
+    const corpo = (erro as { error?: { message?: string } })?.error;
+    return corpo?.message ?? padrao;
+  }
+
+  private falhou(detail: string): void {
+    this.toast.add({ severity: 'error', summary: 'Não deu', detail });
+  }
+}

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.html
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.html
@@ -8,12 +8,11 @@
       <div class="pshell__rail-title">
         Usuários <span>{{ users().length }}</span>
       </div>
-      <input type="search"
-             class="pshell__field"
-             placeholder="Buscar pessoa…"
-             aria-label="Buscar pessoa"
-             [value]="search()"
-             (input)="search.set($any($event.target).value)" />
+      <pk-input placeholder="Buscar pessoa…"
+                icon="pi pi-search"
+                [ngModel]="search()"
+                (ngModelChange)="search.set($event)"
+                [ngModelOptions]="{ standalone: true }" />
     </div>
 
     <div class="pshell__list">
@@ -127,10 +126,18 @@
 <!-- ─── Aplicar modelo ──────────────────────────────────────────────────── -->
 <pk-dialog header="Aplicar modelo" [visible]="applyOpen()" width="580px"
            (visibleChange)="applyOpen.set($event)">
-  <div class="pform" pkDialogContent>
 
-    <div class="pform__row">
-      <span class="pform__label">Modelo</span>
+  <!--
+    Três seções do tema em vez de rótulos inventados: o pk-dialog zera o
+    padding do conteúdo, e é a `pk-form-section` que traz o espaçamento e o
+    traço entre os blocos.
+  -->
+  <div pkDialogContent>
+    <div class="pk-form-section">
+      <h3 class="pk-form-section__title">
+        <i class="pi pi-bookmark"></i> Modelo
+      </h3>
+
       <div class="pform__opts">
         @for (t of templates(); track t.id) {
           <button type="button" class="pform__chip"
@@ -140,11 +147,12 @@
       </div>
     </div>
 
-    <div class="pform__row">
-      <span class="pform__label">
-        Pessoas · {{ applyTargets().length }} selecionadas
-      </span>
-      <div class="pform__people pform__people--pick">
+    <div class="pk-form-section">
+      <h3 class="pk-form-section__title">
+        <i class="pi pi-users"></i> Pessoas · {{ applyTargets().length }} selecionadas
+      </h3>
+
+      <div class="pform__people">
         @for (u of users(); track u.id) {
           <button type="button"
                   class="pform__person"
@@ -161,30 +169,36 @@
       As duas consequências, escritas antes do clique. É a única escolha desta
       feature que apaga trabalho de alguém.
     -->
-    <div class="pform__row">
-      <button type="button" class="pform__mode"
-              [attr.aria-pressed]="applyMode() === 'SOMAR'"
-              (click)="applyMode.set('SOMAR')">
-        <div>
-          <b>Somar — liga o que o modelo permite</b>
-          <span>Nada é desligado. É o que faz “Vendas + Estoque” funcionar:
-            o segundo carimbo não apaga o primeiro.</span>
-        </div>
-      </button>
+    <div class="pk-form-section">
+      <h3 class="pk-form-section__title">
+        <i class="pi pi-sliders-h"></i> Como aplicar
+      </h3>
 
-      <button type="button" class="pform__mode"
-              [attr.aria-pressed]="applyMode() === 'SUBSTITUIR'"
-              (click)="applyMode.set('SUBSTITUIR')">
-        <div>
-          <b>Substituir — grava exatamente o modelo</b>
-          <span class="pform__warn">Liga e desliga. As pessoas ficam idênticas ao
-            modelo, e todo ajuste individual delas se perde.</span>
-        </div>
-      </button>
+      <div class="pform">
+        <button type="button" class="pform__mode"
+                [attr.aria-pressed]="applyMode() === 'SOMAR'"
+                (click)="applyMode.set('SOMAR')">
+          <div>
+            <b>Somar — liga o que o modelo permite</b>
+            <span>Nada é desligado. É o que faz “Vendas + Estoque” funcionar:
+              o segundo carimbo não apaga o primeiro.</span>
+          </div>
+        </button>
+
+        <button type="button" class="pform__mode"
+                [attr.aria-pressed]="applyMode() === 'SUBSTITUIR'"
+                (click)="applyMode.set('SUBSTITUIR')">
+          <div>
+            <b>Substituir — grava exatamente o modelo</b>
+            <span class="pform__warn">Liga e desliga. As pessoas ficam idênticas ao
+              modelo, e todo ajuste individual delas se perde.</span>
+          </div>
+        </button>
+      </div>
     </div>
   </div>
 
-  <div class="pform__foot" pkDialogFooter>
+  <div pkDialogFooter class="pk-dialog-footer">
     <pk-button pkType="cancel" pkSize="sm" (clicked)="applyOpen.set(false)" />
     <pk-button pkType="save" pkSize="sm"
                [pkLabel]="'Aplicar a ' + applyTargets().length"
@@ -196,9 +210,13 @@
 <pk-dialog [header]="'Copiar permissões para ' + (selected()?.name ?? '')"
            [visible]="copyOpen()" width="480px"
            (visibleChange)="copyOpen.set($event)">
-  <div class="pform" pkDialogContent>
-    <div class="pform__row">
-      <span class="pform__label">Copiar de quem</span>
+
+  <div pkDialogContent>
+    <div class="pk-form-section">
+      <h3 class="pk-form-section__title">
+        <i class="pi pi-clone"></i> Copiar de quem
+      </h3>
+
       <div class="pform__people">
         @for (u of copyCandidates(); track u.id) {
           <button type="button"
@@ -212,13 +230,15 @@
       </div>
     </div>
 
-    <p class="pform__danger">
-      A grade inteira de <b>{{ selected()?.name }}</b> é substituída, e os
-      carimbos dela passam a ser os da pessoa de origem.
-    </p>
+    <div class="pk-form-section">
+      <p class="pform__danger">
+        A grade inteira de <b>{{ selected()?.name }}</b> é substituída, e os
+        carimbos dela passam a ser os da pessoa de origem.
+      </p>
+    </div>
   </div>
 
-  <div class="pform__foot" pkDialogFooter>
+  <div pkDialogFooter class="pk-dialog-footer">
     <pk-button pkType="cancel" pkSize="sm" (clicked)="copyOpen.set(false)" />
     <pk-button pkType="save" pkSize="sm" pkLabel="Copiar" (clicked)="confirmCopy()" />
   </div>

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.html
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.html
@@ -127,7 +127,7 @@
 <!-- ─── Aplicar modelo ──────────────────────────────────────────────────── -->
 <pk-dialog header="Aplicar modelo" [visible]="applyOpen()" width="580px"
            (visibleChange)="applyOpen.set($event)">
-  <div class="pform">
+  <div class="pform" pkDialogContent>
 
     <div class="pform__row">
       <span class="pform__label">Modelo</span>
@@ -182,13 +182,13 @@
         </div>
       </button>
     </div>
+  </div>
 
-    <div class="pform__foot">
-      <pk-button pkType="cancel" pkSize="sm" (clicked)="applyOpen.set(false)" />
-      <pk-button pkType="save" pkSize="sm"
-                 [pkLabel]="'Aplicar a ' + applyTargets().length"
-                 (clicked)="confirmApply()" />
-    </div>
+  <div class="pform__foot" pkDialogFooter>
+    <pk-button pkType="cancel" pkSize="sm" (clicked)="applyOpen.set(false)" />
+    <pk-button pkType="save" pkSize="sm"
+               [pkLabel]="'Aplicar a ' + applyTargets().length"
+               (clicked)="confirmApply()" />
   </div>
 </pk-dialog>
 
@@ -196,7 +196,7 @@
 <pk-dialog [header]="'Copiar permissões para ' + (selected()?.name ?? '')"
            [visible]="copyOpen()" width="480px"
            (visibleChange)="copyOpen.set($event)">
-  <div class="pform">
+  <div class="pform" pkDialogContent>
     <div class="pform__row">
       <span class="pform__label">Copiar de quem</span>
       <div class="pform__people">
@@ -216,10 +216,10 @@
       A grade inteira de <b>{{ selected()?.name }}</b> é substituída, e os
       carimbos dela passam a ser os da pessoa de origem.
     </p>
+  </div>
 
-    <div class="pform__foot">
-      <pk-button pkType="cancel" pkSize="sm" (clicked)="copyOpen.set(false)" />
-      <pk-button pkType="save" pkSize="sm" pkLabel="Copiar" (clicked)="confirmCopy()" />
-    </div>
+  <div class="pform__foot" pkDialogFooter>
+    <pk-button pkType="cancel" pkSize="sm" (clicked)="copyOpen.set(false)" />
+    <pk-button pkType="save" pkSize="sm" pkLabel="Copiar" (clicked)="confirmCopy()" />
   </div>
 </pk-dialog>

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.html
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.html
@@ -23,7 +23,7 @@
                 [attr.aria-current]="u.id === selected()?.id"
                 (click)="select(u)">
           <b>{{ u.name }}</b>
-          <span>{{ u.templates.length ? u.templates.join(' · ') : 'sem carimbo' }}</span>
+          <span>{{ u.templates.length ? u.templates.join(' · ') : 'nenhum modelo aplicado' }}</span>
         </button>
       } @empty {
         <p class="pshell__empty-list">Ninguém com esse nome.</p>
@@ -46,17 +46,33 @@
       <div class="pshell__subject">
         <div class="pshell__subject-id">
           <h2>{{ pessoa.name }}</h2>
-          <p>
-            {{ pessoa.login }}
-            @if (pessoa.appliedTemplates.length) {
-              · carimbado com
+          <p>{{ pessoa.login }}</p>
+
+          <!--
+            Os modelos aplicados, com o desfazer em cada um.
+            Antes eram texto corrido: "carimbado com A, B" — que dizia o que
+            aconteceu e não oferecia saída nenhuma, e foi de onde veio a
+            pergunta "como eu removo um carimbo?".
+          -->
+          @if (pessoa.appliedTemplates.length) {
+            <div class="pshell__applied">
+              <span class="pshell__applied-label">Modelos aplicados</span>
+
               @for (t of pessoa.appliedTemplates; track t.id) {
-                <b>{{ t.name }}</b>{{ $last ? '' : ', ' }}
+                <span class="pshell__applied-chip">
+                  {{ t.name }}
+                  @if (canConfigure()) {
+                    <button type="button"
+                            [attr.aria-label]="'Desfazer ' + t.name"
+                            [title]="'Desfazer ' + t.name"
+                            (click)="openUndo(t)">×</button>
+                  }
+                </span>
               }
-            } @else {
-              · <b>sem carimbo nenhum</b>
-            }
-          </p>
+            </div>
+          } @else {
+            <p class="pshell__applied-none">Nenhum modelo aplicado.</p>
+          }
         </div>
 
         <div class="pshell__subject-acts">
@@ -78,7 +94,7 @@
           <span>
             <b>{{ divergences() }}</b>
             {{ divergences() === 1 ? 'célula difere' : 'células diferem' }}
-            dos carimbos aplicados — marcadas com o ponto âmbar.
+            dos modelos aplicados — marcadas com o ponto âmbar.
             Reaplicar um modelo por cima devolveria esses valores.
           </span>
         </div>
@@ -87,7 +103,7 @@
       <app-permission-grid
         [screens]="screens()"
         [saved]="pessoa.cells"
-        [stamped]="pessoa.stamped"
+        [applied]="pessoa.appliedCells"
         [disabled]="!canEdit()"
         (changedCount)="changed.set($event)" />
 
@@ -95,7 +111,7 @@
         <div class="pshell__legend">
           <i><span class="sw sw--on"></span> permitido</i>
           <i><span class="sw"></span> negado</i>
-          <i><span class="sw sw--diverges"></span> difere do carimbo</i>
+          <i><span class="sw sw--diverges"></span> difere do modelo aplicado</i>
         </div>
 
         <div class="pshell__save-msg">
@@ -181,7 +197,7 @@
           <div>
             <b>Somar — liga o que o modelo permite</b>
             <span>Nada é desligado. É o que faz “Vendas + Estoque” funcionar:
-              o segundo carimbo não apaga o primeiro.</span>
+              a segunda aplicação não apaga a primeira.</span>
           </div>
         </button>
 
@@ -203,6 +219,47 @@
     <pk-button pkType="save" pkSize="sm"
                [pkLabel]="'Aplicar a ' + applyTargets().length"
                (clicked)="confirmApply()" />
+  </div>
+</pk-dialog>
+
+<!-- ─── Desfazer a aplicação de um modelo ───────────────────────────────── -->
+<pk-dialog [header]="'Desfazer ' + (undoTemplate()?.name ?? '')"
+           [visible]="undoOpen()" width="480px"
+           (visibleChange)="undoOpen.set($event)">
+
+  <div pkDialogContent>
+    <div class="pk-form-section">
+      <p class="pform__hint">
+        Desliga em <b>{{ selected()?.name }}</b> as permissões que
+        <b>{{ undoTemplate()?.name }}</b> deu.
+      </p>
+
+      <!--
+        O que fica de pé é a informação que faz alguém usar o botão. Sem ela,
+        "desfazer" parece que derruba tudo.
+      -->
+      @if (undoKeeps() > 0) {
+        <p class="pform__hint">
+          O que os outros <b>{{ undoKeeps() }}</b>
+          {{ undoKeeps() === 1 ? 'modelo aplicado também dá' : 'modelos aplicados também dão' }}
+          <b>fica de pé</b>.
+        </p>
+      } @else {
+        <p class="pform__hint">
+          É o único modelo aplicado nesta pessoa — depois disto ela fica só com
+          o que você tiver ligado à mão.
+        </p>
+      }
+
+      <p class="pform__hint">
+        O modelo continua existindo, e quem mais o recebeu não é afetado.
+      </p>
+    </div>
+  </div>
+
+  <div pkDialogFooter class="pk-dialog-footer">
+    <pk-button pkType="cancel" pkSize="sm" (clicked)="undoOpen.set(false)" />
+    <pk-button pkType="delete" pkSize="sm" pkLabel="Desfazer" (clicked)="confirmUndo()" />
   </div>
 </pk-dialog>
 
@@ -233,7 +290,7 @@
     <div class="pk-form-section">
       <p class="pform__danger">
         A grade inteira de <b>{{ selected()?.name }}</b> é substituída, e os
-        carimbos dela passam a ser os da pessoa de origem.
+        modelos aplicados nela passam a ser os da pessoa de origem.
       </p>
     </div>
   </div>

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.html
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.html
@@ -1,0 +1,225 @@
+<p-toast></p-toast>
+
+<div class="pshell">
+
+  <!-- ─── As pessoas ─────────────────────────────────────────────────────── -->
+  <aside class="pshell__rail">
+    <div class="pshell__rail-head">
+      <div class="pshell__rail-title">
+        Usuários <span>{{ users().length }}</span>
+      </div>
+      <input type="search"
+             class="pshell__field"
+             placeholder="Buscar pessoa…"
+             aria-label="Buscar pessoa"
+             [value]="search()"
+             (input)="search.set($any($event.target).value)" />
+    </div>
+
+    <div class="pshell__list">
+      @for (u of visibleUsers(); track u.id) {
+        <button type="button"
+                class="pshell__item"
+                [class.pshell__item--off]="!u.active"
+                [attr.aria-current]="u.id === selected()?.id"
+                (click)="select(u)">
+          <b>{{ u.name }}</b>
+          <span>{{ u.templates.length ? u.templates.join(' · ') : 'sem carimbo' }}</span>
+        </button>
+      } @empty {
+        <p class="pshell__empty-list">Ninguém com esse nome.</p>
+      }
+    </div>
+
+    @if (canConfigure()) {
+      <div class="pshell__rail-foot">
+        <pk-button pkType="new" pkSize="sm" pkLabel="Aplicar a vários"
+                   pkIcon="pi pi-users" (clicked)="openApplyToMany()" />
+      </div>
+    }
+  </aside>
+
+  <!-- ─── A pessoa aberta ────────────────────────────────────────────────── -->
+  <div class="pshell__main">
+
+    @if (selected(); as pessoa) {
+
+      <div class="pshell__subject">
+        <div class="pshell__subject-id">
+          <h2>{{ pessoa.name }}</h2>
+          <p>
+            {{ pessoa.login }}
+            @if (pessoa.appliedTemplates.length) {
+              · carimbado com
+              @for (t of pessoa.appliedTemplates; track t.id) {
+                <b>{{ t.name }}</b>{{ $last ? '' : ', ' }}
+              }
+            } @else {
+              · <b>sem carimbo nenhum</b>
+            }
+          </p>
+        </div>
+
+        <div class="pshell__subject-acts">
+          @if (canConfigure()) {
+            <pk-button pkType="new" pkSize="sm" pkLabel="Aplicar modelo"
+                       pkIcon="pi pi-bookmark" (clicked)="openApplyToCurrent()" />
+            <pk-button pkType="upload" pkSize="sm" pkLabel="Copiar de outro"
+                       pkIcon="pi pi-clone" (clicked)="openCopy()" />
+          }
+        </div>
+      </div>
+
+      <!--
+        O ponto âmbar contado. Sem este número, decidir se reaplicar um modelo
+        é seguro depende de alguém varrer 385 células com o olho.
+      -->
+      @if (divergences() > 0) {
+        <div class="pshell__note">
+          <span>
+            <b>{{ divergences() }}</b>
+            {{ divergences() === 1 ? 'célula difere' : 'células diferem' }}
+            dos carimbos aplicados — marcadas com o ponto âmbar.
+            Reaplicar um modelo por cima devolveria esses valores.
+          </span>
+        </div>
+      }
+
+      <app-permission-grid
+        [screens]="screens()"
+        [saved]="pessoa.cells"
+        [stamped]="pessoa.stamped"
+        [disabled]="!canEdit()"
+        (changedCount)="changed.set($event)" />
+
+      <div class="pshell__save" [attr.data-dirty]="changed() > 0">
+        <div class="pshell__legend">
+          <i><span class="sw sw--on"></span> permitido</i>
+          <i><span class="sw"></span> negado</i>
+          <i><span class="sw sw--diverges"></span> difere do carimbo</i>
+        </div>
+
+        <div class="pshell__save-msg">
+          @if (changed() > 0) {
+            <b>{{ changed() }}</b> {{ changed() === 1 ? 'célula' : 'células' }} sem gravar
+          } @else {
+            Nada para gravar
+          }
+        </div>
+
+        @if (canEdit()) {
+          <div class="pshell__save-acts">
+            <pk-button pkType="cancel" pkSize="sm" pkLabel="Descartar" (clicked)="discard()" />
+            <pk-button pkType="save" pkSize="sm" pkLabel="Salvar permissões"
+                       [pkLoading]="saving()" (clicked)="save()" />
+          </div>
+        }
+      </div>
+
+    } @else {
+      <div class="pshell__blank">
+        {{ loading() ? 'Carregando…' : 'Escolha uma pessoa à esquerda.' }}
+      </div>
+    }
+  </div>
+</div>
+
+<!-- ─── Aplicar modelo ──────────────────────────────────────────────────── -->
+<pk-dialog header="Aplicar modelo" [visible]="applyOpen()" width="580px"
+           (visibleChange)="applyOpen.set($event)">
+  <div class="pform">
+
+    <div class="pform__row">
+      <span class="pform__label">Modelo</span>
+      <div class="pform__opts">
+        @for (t of templates(); track t.id) {
+          <button type="button" class="pform__chip"
+                  [attr.aria-pressed]="t.id === applyTemplateId()"
+                  (click)="applyTemplateId.set(t.id)">{{ t.name }}</button>
+        }
+      </div>
+    </div>
+
+    <div class="pform__row">
+      <span class="pform__label">
+        Pessoas · {{ applyTargets().length }} selecionadas
+      </span>
+      <div class="pform__people pform__people--pick">
+        @for (u of users(); track u.id) {
+          <button type="button"
+                  class="pform__person"
+                  [attr.aria-pressed]="isTarget(u.id)"
+                  (click)="toggleTarget(u.id)">
+            <span class="pform__tick" aria-hidden="true"></span>
+            {{ u.name }} <span class="pform__login">{{ u.login }}</span>
+          </button>
+        }
+      </div>
+    </div>
+
+    <!--
+      As duas consequências, escritas antes do clique. É a única escolha desta
+      feature que apaga trabalho de alguém.
+    -->
+    <div class="pform__row">
+      <button type="button" class="pform__mode"
+              [attr.aria-pressed]="applyMode() === 'SOMAR'"
+              (click)="applyMode.set('SOMAR')">
+        <div>
+          <b>Somar — liga o que o modelo permite</b>
+          <span>Nada é desligado. É o que faz “Vendas + Estoque” funcionar:
+            o segundo carimbo não apaga o primeiro.</span>
+        </div>
+      </button>
+
+      <button type="button" class="pform__mode"
+              [attr.aria-pressed]="applyMode() === 'SUBSTITUIR'"
+              (click)="applyMode.set('SUBSTITUIR')">
+        <div>
+          <b>Substituir — grava exatamente o modelo</b>
+          <span class="pform__warn">Liga e desliga. As pessoas ficam idênticas ao
+            modelo, e todo ajuste individual delas se perde.</span>
+        </div>
+      </button>
+    </div>
+
+    <div class="pform__foot">
+      <pk-button pkType="cancel" pkSize="sm" (clicked)="applyOpen.set(false)" />
+      <pk-button pkType="save" pkSize="sm"
+                 [pkLabel]="'Aplicar a ' + applyTargets().length"
+                 (clicked)="confirmApply()" />
+    </div>
+  </div>
+</pk-dialog>
+
+<!-- ─── Copiar de outra pessoa ──────────────────────────────────────────── -->
+<pk-dialog [header]="'Copiar permissões para ' + (selected()?.name ?? '')"
+           [visible]="copyOpen()" width="480px"
+           (visibleChange)="copyOpen.set($event)">
+  <div class="pform">
+    <div class="pform__row">
+      <span class="pform__label">Copiar de quem</span>
+      <div class="pform__people">
+        @for (u of copyCandidates(); track u.id) {
+          <button type="button"
+                  class="pform__person"
+                  [attr.aria-pressed]="u.id === copySourceId()"
+                  (click)="copySourceId.set(u.id)">
+            <span class="pform__tick" aria-hidden="true"></span>
+            {{ u.name }} <span class="pform__login">{{ u.login }}</span>
+          </button>
+        }
+      </div>
+    </div>
+
+    <p class="pform__danger">
+      A grade inteira de <b>{{ selected()?.name }}</b> é substituída, e os
+      carimbos dela passam a ser os da pessoa de origem.
+    </p>
+
+    <div class="pform__foot">
+      <pk-button pkType="cancel" pkSize="sm" (clicked)="copyOpen.set(false)" />
+      <pk-button pkType="save" pkSize="sm" pkLabel="Copiar" (clicked)="confirmCopy()" />
+    </div>
+  </div>
+</pk-dialog>

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.html
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.html
@@ -23,7 +23,10 @@
                 [attr.aria-current]="u.id === selected()?.id"
                 (click)="select(u)">
           <b>{{ u.name }}</b>
-          <span>{{ u.templates.length ? u.templates.join(' · ') : 'nenhum modelo aplicado' }}</span>
+          <span>
+            @if (u.developer) { desenvolvedor · acesso total }
+            @else { {{ u.templates.length ? u.templates.join(' · ') : 'nenhum modelo aplicado' }} }
+          </span>
         </button>
       } @empty {
         <p class="pshell__empty-list">Ninguém com esse nome.</p>
@@ -76,7 +79,7 @@
         </div>
 
         <div class="pshell__subject-acts">
-          @if (canConfigure()) {
+          @if (canConfigure() && !pessoa.developer) {
             <pk-button pkType="new" pkSize="sm" pkLabel="Aplicar modelo"
                        pkIcon="pi pi-bookmark" (clicked)="openApplyToCurrent()" />
             <pk-button pkType="upload" pkSize="sm" pkLabel="Copiar de outro"
@@ -89,7 +92,22 @@
         O ponto âmbar contado. Sem este número, decidir se reaplicar um modelo
         é seguro depende de alguém varrer 385 células com o olho.
       -->
-      @if (divergences() > 0) {
+      <!--
+        A conta que não se tranca. Sem este aviso, a grade toda marcada e sem
+        botão parece defeito.
+      -->
+      @if (pessoa.developer) {
+        <div class="pshell__note">
+          <span>
+            <b>Conta de desenvolvedor.</b> Ela tem acesso a tudo por definição, e
+            por isso a grade abre só para leitura — é o que garante que sempre
+            exista alguém capaz de reabrir o sistema. Para tirar isso, só pelo
+            banco.
+          </span>
+        </div>
+      }
+
+      @if (divergences() > 0 && !pessoa.developer) {
         <div class="pshell__note">
           <span>
             <b>{{ divergences() }}</b>

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.scss
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.scss
@@ -1,0 +1,98 @@
+@use '../permission-shell' as *;
+
+.pshell__blank {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--app-text-muted);
+  font-size: 13px;
+}
+
+.pshell__empty-list {
+  margin: 12px 10px;
+  font-size: 12px;
+  color: var(--app-text-muted);
+}
+
+.pform__hint {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--app-text-muted);
+  line-height: 1.55;
+}
+
+.pform__danger {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-control);
+  background: var(--app-warning-soft);
+  border: 1px solid var(--app-warning);
+  color: var(--app-warning);
+  font-size: 12.5px;
+  line-height: 1.55;
+
+  b { font-weight: 700; }
+}
+
+// ─── Escolher pessoas ───────────────────────────────────────────────────────
+//
+// Lista com marca, e não `multiselect`: com sete pessoas o dropdown esconde
+// atrás de um clique justamente a informação que decide o alcance da ação.
+.pform__people {
+  display: flex;
+  flex-direction: column;
+  max-height: 190px;
+  overflow-y: auto;
+  border: 1px solid var(--app-border);
+  border-radius: var(--radius-control);
+}
+
+.pform__person {
+  cursor: pointer;
+  border: 0;
+  border-bottom: 1px solid var(--app-border);
+  background: transparent;
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--app-text);
+
+  &:last-child { border-bottom: 0; }
+  &:hover { background: var(--app-surface-2); }
+  &:focus-visible { outline: none; box-shadow: var(--app-focus-ring); }
+
+  &[aria-pressed='true'] { background: var(--app-action-soft); font-weight: 600; }
+}
+
+.pform__tick {
+  width: 15px;
+  height: 15px;
+  border-radius: 4px;
+  border: 1.5px solid var(--app-border-strong);
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.pform__person[aria-pressed='true'] .pform__tick {
+  background: var(--app-success);
+  border-color: var(--app-success);
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 1px;
+    width: 4px;
+    height: 8px;
+    border: solid var(--app-on-action);
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+  }
+}
+
+.pform__login { color: var(--app-text-subtle); font-size: 11px; margin-left: auto; }

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../../../domain/models/permission-admin.model';
 
 /**
- * A tela que carimba modelo em gente.
+ * A tela que aplica modelo em gente.
  *
  * O teste que dá nome a este arquivo é o do **diálogo**, e ele existe por um
  * defeito real: o `pk-dialog` projeta por atributo (`pkDialogContent`), e sem
@@ -32,9 +32,9 @@ describe('PermissionUsersComponent', () => {
 
   const MODELOS: TemplateSummary[] = [
     { id: 't-vendedor', name: 'VENDEDOR', description: null, active: true,
-      allowedCells: 7, stampedUsers: 2 },
+      allowedCells: 7, appliedToUsers: 2 },
     { id: 't-almox', name: 'ALMOXARIFADO', description: null, active: true,
-      allowedCells: 9, stampedUsers: 3 },
+      allowedCells: 9, appliedToUsers: 3 },
   ];
 
   const PESSOAS: UserSummary[] = [
@@ -45,13 +45,13 @@ describe('PermissionUsersComponent', () => {
   const GRADE: UserGrid = {
     id: 'u-1', name: 'Weslley Almeida', login: 'weslley',
     cells: { 'stock/movements': ['CONSULTAR'] },
-    stamped: { 'stock/movements': ['CONSULTAR', 'EXCLUIR'] },
+    appliedCells: { 'stock/movements': ['CONSULTAR', 'EXCLUIR'] },
     appliedTemplates: [],
   };
 
   beforeEach(async () => {
     api = jasmine.createSpyObj<PermissionAdminService>('PermissionAdminService', [
-      'screens', 'templates', 'users', 'userGrid', 'saveUserGrid', 'apply', 'copyFrom',
+      'screens', 'templates', 'users', 'userGrid', 'saveUserGrid', 'apply', 'copyFrom', 'undoApply',
     ]);
     api.screens.and.returnValue(of(TELAS));
     api.templates.and.returnValue(of(MODELOS));
@@ -81,6 +81,7 @@ describe('PermissionUsersComponent', () => {
   afterEach(() => {
     component.applyOpen.set(false);
     component.copyOpen.set(false);
+    component.undoOpen.set(false);
     fixture.detectChanges();
   });
 
@@ -143,7 +144,7 @@ describe('PermissionUsersComponent', () => {
   /**
    * Abrir pela pessoa aberta já vem com ela marcada.
    *
-   * Sem isso o caminho mais comum — carimbar quem está na tela — exigiria
+   * Sem isso o caminho mais comum — aplicar em quem está na tela — exigiria
    * procurar a própria pessoa numa lista de sete.
    */
   it('aplicar a partir da pessoa aberta já vem com ela marcada', () => {
@@ -189,20 +190,73 @@ describe('PermissionUsersComponent', () => {
     expect(api.apply).not.toHaveBeenCalled();
   });
 
+  // ─── Desfazer a aplicação ─────────────────────────────────────────────────
+
+  /**
+   * O diálogo precisa dizer **o que fica de pé** antes do clique.
+   *
+   * Sem esse número, "desfazer" parece que derruba tudo — e o medo de derrubar
+   * tudo é o que faz ninguém usar o botão, que era o problema original.
+   */
+  it('o desfazer conta os outros modelos que ficam de pé', () => {
+    api.userGrid.and.returnValue(of({
+      ...GRADE,
+      appliedTemplates: [
+        { id: 't-base', name: 'Base', appliedAt: '2026-08-01T10:00:00Z',
+          appliedBy: 'migration', mode: 'SOMAR' as const },
+        { id: 't-almox', name: 'ALMOXARIFADO', appliedAt: '2026-08-20T10:00:00Z',
+          appliedBy: 'murillo', mode: 'SOMAR' as const },
+      ],
+    }));
+    component.select(PESSOAS[0]);
+
+    component.openUndo({
+      id: 't-almox', name: 'ALMOXARIFADO', appliedAt: '2026-08-20T10:00:00Z',
+      appliedBy: 'murillo', mode: 'SOMAR',
+    });
+
+    expect(component.undoKeeps())
+      .withContext('sobra o Base')
+      .toBe(1);
+  });
+
+  it('desfazer chama a API com a pessoa aberta e o modelo escolhido', () => {
+    api.undoApply.and.returnValue(of({ users: 1, cellsChanged: 6 }));
+
+    component.openUndo({
+      id: 't-almox', name: 'ALMOXARIFADO', appliedAt: '2026-08-20T10:00:00Z',
+      appliedBy: 'murillo', mode: 'SOMAR',
+    });
+    component.confirmUndo();
+
+    expect(api.undoApply).toHaveBeenCalledWith('u-1', 't-almox');
+  });
+
+  it('o diálogo de desfazer abre com conteúdo', () => {
+    component.openUndo({
+      id: 't-almox', name: 'ALMOXARIFADO', appliedAt: '2026-08-20T10:00:00Z',
+      appliedBy: 'murillo', mode: 'SOMAR',
+    });
+    fixture.detectChanges();
+
+    expect(noDialogo('.pk-form-section .pform__hint')).not.toBeNull();
+    expect(noDialogo('.pk-dialog-footer pk-button')).not.toBeNull();
+  });
+
   // ─── A divergência ────────────────────────────────────────────────────────
 
   /**
    * O número que o aviso do topo mostra.
    *
-   * A grade veio com `CONSULTAR` ligada e o carimbo dava `CONSULTAR` e
+   * A grade veio com `CONSULTAR` ligada e o modelo dava `CONSULTAR` e
    * `EXCLUIR` — então uma célula difere: a que alguém desligou.
    */
-  it('conta as células que diferem dos carimbos', () => {
+  it('conta as células que diferem dos modelos aplicados', () => {
     expect(component.divergences()).toBe(1);
   });
 
-  it('sem carimbo nenhum, não há divergência a apontar', () => {
-    api.userGrid.and.returnValue(of({ ...GRADE, stamped: {} }));
+  it('sem modelo aplicado, não há divergência a apontar', () => {
+    api.userGrid.and.returnValue(of({ ...GRADE, appliedCells: {} }));
     component.select(PESSOAS[0]);
 
     expect(component.divergences()).toBe(0);

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
 import { PermissionUsersComponent } from './permission-users.component';
@@ -49,7 +50,15 @@ describe('PermissionUsersComponent', () => {
     appliedTemplates: [],
   };
 
+  /** O `?login=` que o botão da tela de Admin manda. Vazio por padrão. */
+  let loginNaUrl: string | null;
+
+  const rota = {
+    snapshot: { queryParamMap: { get: (_: string) => loginNaUrl } },
+  };
+
   beforeEach(async () => {
+    loginNaUrl = null;
     api = jasmine.createSpyObj<PermissionAdminService>('PermissionAdminService', [
       'screens', 'templates', 'users', 'userGrid', 'saveUserGrid', 'apply', 'copyFrom', 'undoApply',
     ]);
@@ -67,6 +76,7 @@ describe('PermissionUsersComponent', () => {
         { provide: PermissionAdminService, useValue: api },
         // Quem abre esta tela tem tudo — o que se testa aqui não é a porta.
         { provide: PermissionStore, useValue: { can: () => true, canOpen: () => true } },
+        { provide: ActivatedRoute, useValue: rota },
       ],
     }).compileComponents();
 
@@ -74,6 +84,19 @@ describe('PermissionUsersComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
+
+  /**
+   * Monta de novo, depois de mexer no `?login=`.
+   *
+   * O `beforeEach` já criou uma instância — e o que estes testes medem acontece
+   * no `ngOnInit`, então precisam de uma instância nova com a URL já trocada.
+   */
+  const montar = () => {
+    api.userGrid.calls.reset();
+    fixture = TestBed.createComponent(PermissionUsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  };
 
   /** O diálogo do PrimeNG é modal e pode sair do elemento do componente. */
   const noDialogo = (seletor: string) => document.body.querySelector(seletor);
@@ -260,5 +283,31 @@ describe('PermissionUsersComponent', () => {
     component.select(PESSOAS[0]);
 
     expect(component.divergences()).toBe(0);
+  });
+
+  // ─── O atalho vindo da tela de Admin ──────────────────────────────────────
+
+  /**
+   * **O botão de permissões do Admin manda `?login=`.**
+   *
+   * Sem isto, quem clica no Ricardo cai no primeiro da lista e precisa
+   * procurá-lo de novo. É um atrito pequeno, e é assim que um atalho deixa de
+   * ser usado.
+   */
+  it('abre na pessoa que veio no link', () => {
+    loginNaUrl = 'ricardo';
+    const outra = { ...GRADE, id: 'u-2', name: 'Ricardo Souza', login: 'ricardo' };
+    api.userGrid.and.returnValue(of(outra));
+
+    montar();
+
+    expect(api.userGrid).toHaveBeenCalledWith('u-2');
+  });
+
+  /** Sem link, abre no primeiro — que é o comportamento de sempre. */
+  it('sem link, abre no primeiro da lista', () => {
+    montar();
+
+    expect(api.userGrid).toHaveBeenCalledWith('u-1');
   });
 });

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
@@ -108,12 +108,27 @@ describe('PermissionUsersComponent', () => {
       .not.toBeNull();
   });
 
-  /** O rodapé vai para o slot próprio, e some junto se o atributo cair. */
-  it('o rodapé do diálogo traz os botões', () => {
+  /**
+   * O rodapé usa a classe do tema, e não uma minha.
+   *
+   * `pk-dialog-footer` é quem traz padding, traço e alinhamento à direita — o
+   * `pk-dialog` zera os dois slots de propósito, esperando que o conteúdo use
+   * `pk-form-section` e o rodapé use esta classe. Recriar isso por fora foi o
+   * que deixou os diálogos sem respiro.
+   */
+  it('o rodapé do diálogo usa a classe do tema e traz os botões', () => {
     component.openApplyToCurrent();
     fixture.detectChanges();
 
-    expect(noDialogo('.pform__foot pk-button')).not.toBeNull();
+    expect(noDialogo('.pk-dialog-footer pk-button')).not.toBeNull();
+  });
+
+  /** O conteúdo respira porque está numa seção do tema, não numa div solta. */
+  it('o conteúdo do diálogo vive dentro de pk-form-section', () => {
+    component.openApplyToCurrent();
+    fixture.detectChanges();
+
+    expect(noDialogo('.pk-form-section .pform__mode')).not.toBeNull();
   });
 
   it('o diálogo de copiar também abre com conteúdo', () => {

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
@@ -39,12 +39,12 @@ describe('PermissionUsersComponent', () => {
   ];
 
   const PESSOAS: UserSummary[] = [
-    { id: 'u-1', name: 'Weslley Almeida', login: 'weslley', active: true, templates: ['Base'] },
-    { id: 'u-2', name: 'Ricardo Souza', login: 'ricardo', active: true, templates: [] },
+    { id: 'u-1', name: 'Weslley Almeida', login: 'weslley', active: true, developer: false, templates: ['Base'] },
+    { id: 'u-2', name: 'Ricardo Souza', login: 'ricardo', active: true, developer: false, templates: [] },
   ];
 
   const GRADE: UserGrid = {
-    id: 'u-1', name: 'Weslley Almeida', login: 'weslley',
+    id: 'u-1', name: 'Weslley Almeida', login: 'weslley', developer: false,
     cells: { 'stock/movements': ['CONSULTAR'] },
     appliedCells: { 'stock/movements': ['CONSULTAR', 'EXCLUIR'] },
     appliedTemplates: [],
@@ -309,5 +309,29 @@ describe('PermissionUsersComponent', () => {
     montar();
 
     expect(api.userGrid).toHaveBeenCalledWith('u-1');
+  });
+
+  // ─── A conta que não se tranca ────────────────────────────────────────────
+
+  /**
+   * **A grade do desenvolvedor abre em leitura.**
+   *
+   * Ele tem tudo por resolução, não pela tabela — escrever ali não mudaria
+   * nada, e a API recusa. Se a tela deixasse editar, o clique acabaria num
+   * erro que parece defeito.
+   */
+  it('a grade de um desenvolvedor não é editável', () => {
+    api.userGrid.and.returnValue(of({ ...GRADE, developer: true }));
+    montar();
+
+    expect(component.canEdit()).toBeFalse();
+  });
+
+  /** E a tela diz por quê, senão a grade sem botão parece defeito. */
+  it('a tela explica que é conta de desenvolvedor', () => {
+    api.userGrid.and.returnValue(of({ ...GRADE, developer: true }));
+    montar();
+
+    expect(fixture.nativeElement.textContent).toContain('Conta de desenvolvedor');
   });
 });

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.spec.ts
@@ -1,0 +1,195 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+
+import { PermissionUsersComponent } from './permission-users.component';
+import { PermissionAdminService } from '../../../../../infrastructure/services/permission/permission-admin.service';
+import { PermissionStore } from '../../../../../infrastructure/state/permission.store';
+import {
+  ScreenRow, TemplateSummary, UserGrid, UserSummary,
+} from '../../../../../domain/models/permission-admin.model';
+
+/**
+ * A tela que carimba modelo em gente.
+ *
+ * O teste que dá nome a este arquivo é o do **diálogo**, e ele existe por um
+ * defeito real: o `pk-dialog` projeta por atributo (`pkDialogContent`), e sem
+ * esse atributo ele abre **vazio**. Nada quebra — o build passa, o console fica
+ * limpo, a caixa aparece na tela sem nada dentro.
+ *
+ * É a família de falha que já mordeu este projeto antes: componente montado sem
+ * o que ele precisava, e o sintoma sendo só a ausência de alguma coisa.
+ */
+describe('PermissionUsersComponent', () => {
+  let fixture: ComponentFixture<PermissionUsersComponent>;
+  let component: PermissionUsersComponent;
+  let api: jasmine.SpyObj<PermissionAdminService>;
+
+  const TELAS: ScreenRow[] = [
+    { code: 'stock/movements', label: 'Movimentações', module: 'Estoque', sortOrder: 10 },
+  ];
+
+  const MODELOS: TemplateSummary[] = [
+    { id: 't-vendedor', name: 'VENDEDOR', description: null, active: true,
+      allowedCells: 7, stampedUsers: 2 },
+    { id: 't-almox', name: 'ALMOXARIFADO', description: null, active: true,
+      allowedCells: 9, stampedUsers: 3 },
+  ];
+
+  const PESSOAS: UserSummary[] = [
+    { id: 'u-1', name: 'Weslley Almeida', login: 'weslley', active: true, templates: ['Base'] },
+    { id: 'u-2', name: 'Ricardo Souza', login: 'ricardo', active: true, templates: [] },
+  ];
+
+  const GRADE: UserGrid = {
+    id: 'u-1', name: 'Weslley Almeida', login: 'weslley',
+    cells: { 'stock/movements': ['CONSULTAR'] },
+    stamped: { 'stock/movements': ['CONSULTAR', 'EXCLUIR'] },
+    appliedTemplates: [],
+  };
+
+  beforeEach(async () => {
+    api = jasmine.createSpyObj<PermissionAdminService>('PermissionAdminService', [
+      'screens', 'templates', 'users', 'userGrid', 'saveUserGrid', 'apply', 'copyFrom',
+    ]);
+    api.screens.and.returnValue(of(TELAS));
+    api.templates.and.returnValue(of(MODELOS));
+    api.users.and.returnValue(of(PESSOAS));
+    api.userGrid.and.returnValue(of(GRADE));
+    api.apply.and.returnValue(of({ users: 1, cellsChanged: 7 }));
+
+    await TestBed.configureTestingModule({
+      imports: [PermissionUsersComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        { provide: PermissionAdminService, useValue: api },
+        // Quem abre esta tela tem tudo — o que se testa aqui não é a porta.
+        { provide: PermissionStore, useValue: { can: () => true, canOpen: () => true } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PermissionUsersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  /** O diálogo do PrimeNG é modal e pode sair do elemento do componente. */
+  const noDialogo = (seletor: string) => document.body.querySelector(seletor);
+
+  afterEach(() => {
+    component.applyOpen.set(false);
+    component.copyOpen.set(false);
+    fixture.detectChanges();
+  });
+
+  // ─── O contrato de projeção ───────────────────────────────────────────────
+
+  /**
+   * **O teste do diálogo vazio.**
+   *
+   * Sem `pkDialogContent` no conteúdo, o `pk-dialog` abre e não mostra nada —
+   * e nenhuma camada reclama. Este teste falha na hora em que alguém copiar um
+   * diálogo esquecendo o atributo.
+   */
+  it('o diálogo de aplicar modelo abre COM conteúdo dentro', () => {
+    component.openApplyToCurrent();
+    fixture.detectChanges();
+
+    expect(noDialogo('.pform__mode'))
+      .withContext('as duas opções de modo têm que estar dentro do diálogo')
+      .not.toBeNull();
+    expect(noDialogo('.pform__chip'))
+      .withContext('os modelos para escolher')
+      .not.toBeNull();
+    expect(noDialogo('.pform__person'))
+      .withContext('as pessoas para marcar')
+      .not.toBeNull();
+  });
+
+  /** O rodapé vai para o slot próprio, e some junto se o atributo cair. */
+  it('o rodapé do diálogo traz os botões', () => {
+    component.openApplyToCurrent();
+    fixture.detectChanges();
+
+    expect(noDialogo('.pform__foot pk-button')).not.toBeNull();
+  });
+
+  it('o diálogo de copiar também abre com conteúdo', () => {
+    component.openCopy();
+    fixture.detectChanges();
+
+    expect(noDialogo('.pform__person')).not.toBeNull();
+  });
+
+  // ─── Comportamento ────────────────────────────────────────────────────────
+
+  /**
+   * Abrir pela pessoa aberta já vem com ela marcada.
+   *
+   * Sem isso o caminho mais comum — carimbar quem está na tela — exigiria
+   * procurar a própria pessoa numa lista de sete.
+   */
+  it('aplicar a partir da pessoa aberta já vem com ela marcada', () => {
+    component.openApplyToCurrent();
+
+    expect(component.applyTargets()).toEqual(['u-1']);
+  });
+
+  it('aplicar a vários abre sem ninguém marcado', () => {
+    component.openApplyToMany();
+
+    expect(component.applyTargets()).toEqual([]);
+  });
+
+  /**
+   * **SOMAR é o padrão, e isso não é detalhe.**
+   *
+   * Se o diálogo abrisse em SUBSTITUIR, o clique distraído no caminho mais
+   * comum apagaria ajuste individual de todo mundo que ele alcança.
+   */
+  it('o modo começa em SOMAR', () => {
+    component.openApplyToMany();
+
+    expect(component.applyMode()).toBe('SOMAR');
+  });
+
+  it('aplicar manda o modelo, as pessoas e o modo escolhidos', () => {
+    component.openApplyToCurrent();
+    component.applyTemplateId.set('t-almox');
+    component.toggleTarget('u-2');
+    component.applyMode.set('SUBSTITUIR');
+
+    component.confirmApply();
+
+    expect(api.apply).toHaveBeenCalledWith('t-almox', ['u-1', 'u-2'], 'SUBSTITUIR');
+  });
+
+  it('sem ninguém marcado, não chama a API', () => {
+    component.openApplyToMany();
+
+    component.confirmApply();
+
+    expect(api.apply).not.toHaveBeenCalled();
+  });
+
+  // ─── A divergência ────────────────────────────────────────────────────────
+
+  /**
+   * O número que o aviso do topo mostra.
+   *
+   * A grade veio com `CONSULTAR` ligada e o carimbo dava `CONSULTAR` e
+   * `EXCLUIR` — então uma célula difere: a que alguém desligou.
+   */
+  it('conta as células que diferem dos carimbos', () => {
+    expect(component.divergences()).toBe(1);
+  });
+
+  it('sem carimbo nenhum, não há divergência a apontar', () => {
+    api.userGrid.and.returnValue(of({ ...GRADE, stamped: {} }));
+    component.select(PESSOAS[0]);
+
+    expect(component.divergences()).toBe(0);
+  });
+});

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.ts
@@ -59,7 +59,17 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
   readonly loading = signal(false);
   readonly saving = signal(false);
 
-  readonly canEdit = computed(() => this.permissions.can(SCREEN, 'ALTERAR'));
+  /**
+   * A grade abre em leitura quando falta `ALTERAR` — ou quando a pessoa é
+   * desenvolvedora.
+   *
+   * No segundo caso não é falta de permissão de quem está olhando: é que
+   * escrever ali não mudaria nada. As authorities do desenvolvedor vêm da
+   * resolução, não da tabela, e uma tela que aceita o clique e não muda nada é
+   * pior que uma que diz não.
+   */
+  readonly canEdit = computed(() =>
+    this.permissions.can(SCREEN, 'ALTERAR') && !this.selected()?.developer);
   readonly canConfigure = computed(() => this.permissions.can(SCREEN, 'CONFIGURAR'));
 
   readonly visibleUsers = computed(() => {

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.ts
@@ -1,0 +1,274 @@
+import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+
+import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkDialogComponent } from '../../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
+import { PermissionGridComponent } from '../permission-grid/permission-grid.component';
+import { PermissionAdminService } from '../../../../../infrastructure/services/permission/permission-admin.service';
+import { PermissionStore } from '../../../../../infrastructure/state/permission.store';
+import { TabDirtyCheck } from '../../../../../infrastructure/routing/tab-dirty-check';
+import {
+  ApplyMode, PermissionCells, ScreenRow, TemplateSummary, UserGrid, UserSummary,
+} from '../../../../../domain/models/permission-admin.model';
+
+const SCREEN = 'settings/permissions/users';
+
+/**
+ * O que uma pessoa pode — e **aqui é a verdade**.
+ *
+ * Nada nesta tela é herdado: toda célula é editável e nenhuma vem de um pai. O
+ * modelo já carimbou; o que ficou escrito na pessoa é o que vale, e é por isso
+ * que "o que o João pode?" se responde olhando o João.
+ *
+ * O ponto âmbar é a única concessão ao histórico: ele marca a célula que difere
+ * dos carimbos aplicados. Sem ele, reaplicar um modelo é um clique cego que
+ * devolve permissões que alguém tirou de propósito.
+ */
+@Component({
+  selector: 'app-permission-users',
+  standalone: true,
+  imports: [ToastModule, PkButtonComponent, PkDialogComponent, PermissionGridComponent],
+  templateUrl: './permission-users.component.html',
+  styleUrl: './permission-users.component.scss',
+  providers: [MessageService],
+})
+export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
+
+  private readonly api = inject(PermissionAdminService);
+  private readonly toast = inject(MessageService);
+  private readonly permissions = inject(PermissionStore);
+
+  private readonly grid = viewChild(PermissionGridComponent);
+
+  readonly screens = signal<ScreenRow[]>([]);
+  readonly users = signal<UserSummary[]>([]);
+  readonly templates = signal<TemplateSummary[]>([]);
+  readonly selected = signal<UserGrid | null>(null);
+
+  readonly search = signal('');
+  readonly changed = signal(0);
+  readonly loading = signal(false);
+  readonly saving = signal(false);
+
+  readonly canEdit = computed(() => this.permissions.can(SCREEN, 'ALTERAR'));
+  readonly canConfigure = computed(() => this.permissions.can(SCREEN, 'CONFIGURAR'));
+
+  readonly visibleUsers = computed(() => {
+    const termo = this.search().trim().toLowerCase();
+    return this.users().filter(u => !termo
+      || u.name.toLowerCase().includes(termo)
+      || u.login.toLowerCase().includes(termo));
+  });
+
+  /**
+   * Quantas células diferem dos carimbos aplicados.
+   *
+   * É o que o aviso do topo conta. Calculado no front a partir do que a API já
+   * mandou — uma segunda requisição para descobrir um número que está na tela
+   * seria trabalho por nada.
+   */
+  readonly divergences = computed(() => {
+    const pessoa = this.selected();
+    if (!pessoa) return 0;
+
+    const chaves = (cells: PermissionCells) => {
+      const set = new Set<string>();
+      for (const [tela, acoes] of Object.entries(cells ?? {})) {
+        for (const acao of acoes ?? []) set.add(`${tela}:${acao}`);
+      }
+      return set;
+    };
+
+    const agora = chaves(pessoa.cells);
+    const carimbado = chaves(pessoa.stamped);
+    if (!carimbado.size) return 0;
+
+    let total = 0;
+    for (const chave of agora) if (!carimbado.has(chave)) total++;
+    for (const chave of carimbado) if (!agora.has(chave)) total++;
+    return total;
+  });
+
+  // ─── Diálogo: aplicar modelo ───────────────────────────────────────────────
+
+  readonly applyOpen = signal(false);
+  readonly applyTargets = signal<string[]>([]);
+  readonly applyTemplateId = signal<string | null>(null);
+  readonly applyMode = signal<ApplyMode>('SOMAR');
+
+  readonly applyTemplateName = computed(() =>
+    this.templates().find(t => t.id === this.applyTemplateId())?.name ?? '');
+
+  // ─── Diálogo: copiar de outra pessoa ───────────────────────────────────────
+
+  readonly copyOpen = signal(false);
+  readonly copySourceId = signal<string | null>(null);
+
+  readonly copyCandidates = computed(() =>
+    this.users().filter(u => u.id !== this.selected()?.id));
+
+  isTabDirty(): boolean {
+    return this.changed() > 0;
+  }
+
+  ngOnInit(): void {
+    this.loading.set(true);
+
+    this.api.screens().subscribe({
+      next: telas => this.screens.set(telas),
+      error: () => this.falhou('Não foi possível carregar o catálogo de telas.'),
+    });
+
+    this.api.templates().subscribe({
+      next: modelos => this.templates.set(modelos.filter(m => m.active)),
+      error: () => this.falhou('Não foi possível carregar os modelos.'),
+    });
+
+    this.reloadUsers(true);
+  }
+
+  private reloadUsers(selectFirst = false): void {
+    this.api.users().subscribe({
+      next: pessoas => {
+        this.users.set(pessoas);
+        this.loading.set(false);
+        if (selectFirst && pessoas.length) this.select(pessoas[0]);
+      },
+      error: () => {
+        this.loading.set(false);
+        this.falhou('Não foi possível carregar os usuários.');
+      },
+    });
+  }
+
+  select(user: UserSummary): void {
+    if (this.changed() > 0 && !confirm(
+      'Há alterações não gravadas nesta pessoa. Trocar descarta.')) return;
+
+    this.api.userGrid(user.id).subscribe({
+      next: grade => this.selected.set(grade),
+      error: () => this.falhou('Não foi possível abrir as permissões desta pessoa.'),
+    });
+  }
+
+  private reloadSelected(): void {
+    const pessoa = this.selected();
+    if (!pessoa) return;
+    this.api.userGrid(pessoa.id).subscribe({ next: grade => this.selected.set(grade) });
+  }
+
+  // ─── Gravar ────────────────────────────────────────────────────────────────
+
+  save(): void {
+    const grade = this.grid();
+    const pessoa = this.selected();
+    if (!grade || !pessoa) return;
+
+    this.saving.set(true);
+    this.api.saveUserGrid(pessoa.id, grade.current()).subscribe({
+      next: resultado => {
+        this.saving.set(false);
+        this.reloadSelected();
+        this.toast.add({
+          severity: 'success',
+          summary: 'Permissões gravadas',
+          detail: `${resultado.cellsChanged} células alteradas. Vale a partir da próxima requisição dela.`,
+        });
+      },
+      error: () => {
+        this.saving.set(false);
+        this.falhou('Não foi possível gravar as permissões.');
+      },
+    });
+  }
+
+  discard(): void {
+    this.grid()?.discard();
+  }
+
+  // ─── Aplicar modelo ────────────────────────────────────────────────────────
+
+  openApplyToCurrent(): void {
+    const pessoa = this.selected();
+    if (!pessoa) return;
+    this.applyTargets.set([pessoa.id]);
+    this.applyTemplateId.set(this.templates()[0]?.id ?? null);
+    this.applyMode.set('SOMAR');
+    this.applyOpen.set(true);
+  }
+
+  openApplyToMany(): void {
+    this.applyTargets.set([]);
+    this.applyTemplateId.set(this.templates()[0]?.id ?? null);
+    this.applyMode.set('SOMAR');
+    this.applyOpen.set(true);
+  }
+
+  toggleTarget(userId: string): void {
+    const alvos = new Set(this.applyTargets());
+    alvos.has(userId) ? alvos.delete(userId) : alvos.add(userId);
+    this.applyTargets.set([...alvos]);
+  }
+
+  isTarget(userId: string): boolean {
+    return this.applyTargets().includes(userId);
+  }
+
+  confirmApply(): void {
+    const modelo = this.applyTemplateId();
+    const alvos = this.applyTargets();
+    if (!modelo || !alvos.length) {
+      this.falhou('Escolha um modelo e pelo menos uma pessoa.');
+      return;
+    }
+
+    this.api.apply(modelo, alvos, this.applyMode()).subscribe({
+      next: resultado => {
+        this.applyOpen.set(false);
+        this.reloadUsers();
+        this.reloadSelected();
+        this.toast.add({
+          severity: 'success',
+          summary: `${this.applyTemplateName()} aplicado a ${resultado.users}`,
+          detail: `${resultado.cellsChanged} células alteradas.`,
+        });
+      },
+      error: () => this.falhou('Não foi possível aplicar o modelo.'),
+    });
+  }
+
+  // ─── Copiar de outra pessoa ────────────────────────────────────────────────
+
+  openCopy(): void {
+    this.copySourceId.set(null);
+    this.copyOpen.set(true);
+  }
+
+  confirmCopy(): void {
+    const pessoa = this.selected();
+    const origem = this.copySourceId();
+    if (!pessoa || !origem) {
+      this.falhou('Escolha de quem copiar.');
+      return;
+    }
+
+    this.api.copyFrom(pessoa.id, origem).subscribe({
+      next: resultado => {
+        this.copyOpen.set(false);
+        this.reloadUsers();
+        this.reloadSelected();
+        this.toast.add({
+          severity: 'success',
+          summary: 'Permissões copiadas',
+          detail: `${resultado.cellsChanged} células alteradas.`,
+        });
+      },
+      error: () => this.falhou('Não foi possível copiar as permissões.'),
+    });
+  }
+
+  private falhou(detail: string): void {
+    this.toast.add({ severity: 'error', summary: 'Não deu', detail });
+  }
+}

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.ts
@@ -11,7 +11,7 @@ import { PermissionAdminService } from '../../../../../infrastructure/services/p
 import { PermissionStore } from '../../../../../infrastructure/state/permission.store';
 import { TabDirtyCheck } from '../../../../../infrastructure/routing/tab-dirty-check';
 import {
-  ApplyMode, PermissionCells, ScreenRow, TemplateSummary, UserGrid, UserSummary,
+  AppliedTemplate, ApplyMode, PermissionCells, ScreenRow, TemplateSummary, UserGrid, UserSummary,
 } from '../../../../../domain/models/permission-admin.model';
 
 const SCREEN = 'settings/permissions/users';
@@ -19,12 +19,13 @@ const SCREEN = 'settings/permissions/users';
 /**
  * O que uma pessoa pode — e **aqui é a verdade**.
  *
- * Nada nesta tela é herdado: toda célula é editável e nenhuma vem de um pai. O
- * modelo já carimbou; o que ficou escrito na pessoa é o que vale, e é por isso
- * que "o que o João pode?" se responde olhando o João.
+ * Nada nesta tela é herdado: toda célula é editável e nenhuma vem de um pai.
+ * Aplicar um modelo copiou as permissões para dentro da pessoa; o que ficou
+ * escrito nela é o que vale, e é por isso que "o que o João pode?" se responde
+ * olhando o João.
  *
  * O ponto âmbar é a única concessão ao histórico: ele marca a célula que difere
- * dos carimbos aplicados. Sem ele, reaplicar um modelo é um clique cego que
+ * dos modelos aplicados. Sem ele, reaplicar um modelo é um clique cego que
  * devolve permissões que alguém tirou de propósito.
  */
 @Component({
@@ -67,7 +68,7 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
   });
 
   /**
-   * Quantas células diferem dos carimbos aplicados.
+   * Quantas células diferem dos modelos aplicados.
    *
    * É o que o aviso do topo conta. Calculado no front a partir do que a API já
    * mandou — uma segunda requisição para descobrir um número que está na tela
@@ -86,12 +87,12 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
     };
 
     const agora = chaves(pessoa.cells);
-    const carimbado = chaves(pessoa.stamped);
-    if (!carimbado.size) return 0;
+    const peloModelo = chaves(pessoa.appliedCells);
+    if (!peloModelo.size) return 0;
 
     let total = 0;
-    for (const chave of agora) if (!carimbado.has(chave)) total++;
-    for (const chave of carimbado) if (!agora.has(chave)) total++;
+    for (const chave of agora) if (!peloModelo.has(chave)) total++;
+    for (const chave of peloModelo) if (!agora.has(chave)) total++;
     return total;
   });
 
@@ -104,6 +105,26 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
 
   readonly applyTemplateName = computed(() =>
     this.templates().find(t => t.id === this.applyTemplateId())?.name ?? '');
+
+  // ─── Diálogo: desfazer a aplicação de um modelo ────────────────────────────
+
+  readonly undoOpen = signal(false);
+  readonly undoTemplate = signal<AppliedTemplate | null>(null);
+
+  /**
+   * O que **sobra** se este modelo for desfeito.
+   *
+   * Calculado aqui para o diálogo poder dizer, antes do clique, que as telas
+   * dos outros modelos ficam de pé. Sem esse número, "desfazer" parece que
+   * derruba tudo — que é justamente o medo que impede alguém de usar o botão.
+   */
+  readonly undoKeeps = computed(() => {
+    const alvo = this.undoTemplate();
+    const pessoa = this.selected();
+    if (!alvo || !pessoa) return 0;
+
+    return pessoa.appliedTemplates.filter(t => t.id !== alvo.id).length;
+  });
 
   // ─── Diálogo: copiar de outra pessoa ───────────────────────────────────────
 
@@ -240,6 +261,42 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
         });
       },
       error: () => this.falhou('Não foi possível aplicar o modelo.'),
+    });
+  }
+
+  // ─── Desfazer a aplicação de um modelo ─────────────────────────────────────
+
+  openUndo(template: AppliedTemplate): void {
+    this.undoTemplate.set(template);
+    this.undoOpen.set(true);
+  }
+
+  /**
+   * Desfazer desliga o que **aquele** modelo deu, e nada mais.
+   *
+   * O que outro modelo aplicado também dá fica de pé — é o que separa
+   * "desfazer" de "bloquear tudo". Quem faz a conta é a API, que conhece a
+   * grade dos outros modelos.
+   */
+  confirmUndo(): void {
+    const pessoa = this.selected();
+    const modelo = this.undoTemplate();
+    if (!pessoa || !modelo) return;
+
+    this.api.undoApply(pessoa.id, modelo.id).subscribe({
+      next: resultado => {
+        this.undoOpen.set(false);
+        this.reloadUsers();
+        this.reloadSelected();
+        this.toast.add({
+          severity: 'success',
+          summary: `${modelo.name} desfeito`,
+          detail: resultado.cellsChanged === 0
+            ? 'Nenhuma permissão saiu — outros modelos já davam tudo o que ele dava.'
+            : `${resultado.cellsChanged} permissões desligadas.`,
+        });
+      },
+      error: () => this.falhou('Não foi possível desfazer a aplicação.'),
     });
   }
 

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
@@ -44,6 +45,7 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
   private readonly api = inject(PermissionAdminService);
   private readonly toast = inject(MessageService);
   private readonly permissions = inject(PermissionStore);
+  private readonly route = inject(ActivatedRoute);
 
   private readonly grid = viewChild(PermissionGridComponent);
 
@@ -159,13 +161,25 @@ export class PermissionUsersComponent implements OnInit, TabDirtyCheck {
       next: pessoas => {
         this.users.set(pessoas);
         this.loading.set(false);
-        if (selectFirst && pessoas.length) this.select(pessoas[0]);
+        if (selectFirst && pessoas.length) this.select(this.pedidaNaUrl(pessoas) ?? pessoas[0]);
       },
       error: () => {
         this.loading.set(false);
         this.falhou('Não foi possível carregar os usuários.');
       },
     });
+  }
+
+  /**
+   * A pessoa que veio no link, se veio.
+   *
+   * O botão de permissões na tela de Admin manda `?login=`. Sem isto, quem
+   * clica no Ricardo cai no primeiro da lista e precisa procurá-lo de novo —
+   * um atrito pequeno que, repetido, faz a pessoa parar de usar o atalho.
+   */
+  private pedidaNaUrl(pessoas: UserSummary[]): UserSummary | null {
+    const login = this.route.snapshot.queryParamMap.get('login');
+    return login ? pessoas.find(u => u.login === login) ?? null : null;
   }
 
   select(user: UserSummary): void {

--- a/src/app/components/auth/settings/permissions/users/permission-users.component.ts
+++ b/src/app/components/auth/settings/permissions/users/permission-users.component.ts
@@ -1,8 +1,10 @@
 import { Component, OnInit, computed, inject, signal, viewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 
 import { PkButtonComponent } from '../../../../theme/ProautoKimium/pk-button/pk-button.component';
+import { PkInputComponent } from '../../../../theme/ProautoKimium/pk-input/pk-input.component';
 import { PkDialogComponent } from '../../../../theme/ProautoKimium/pk-dialog/pk-dialog.component';
 import { PermissionGridComponent } from '../permission-grid/permission-grid.component';
 import { PermissionAdminService } from '../../../../../infrastructure/services/permission/permission-admin.service';
@@ -28,7 +30,10 @@ const SCREEN = 'settings/permissions/users';
 @Component({
   selector: 'app-permission-users',
   standalone: true,
-  imports: [ToastModule, PkButtonComponent, PkDialogComponent, PermissionGridComponent],
+  imports: [
+    FormsModule, ToastModule,
+    PkButtonComponent, PkInputComponent, PkDialogComponent, PermissionGridComponent,
+  ],
   templateUrl: './permission-users.component.html',
   styleUrl: './permission-users.component.scss',
   providers: [MessageService],

--- a/src/app/domain/models/permission-admin.model.ts
+++ b/src/app/domain/models/permission-admin.model.ts
@@ -45,7 +45,7 @@ export interface TemplateSummary {
   description: string | null;
   active: boolean;
   allowedCells: number;
-  stampedUsers: number;
+  appliedToUsers: number;
 }
 
 export interface TemplateGrid {
@@ -78,14 +78,14 @@ export interface UserGrid {
   login: string;
   cells: PermissionCells;
   /**
-   * O que os carimbos aplicados nesta pessoa permitem.
+   * O que os modelos aplicados nesta pessoa permitem.
    *
    * A diferença para `cells` é o ponto âmbar da tela. É derivado no servidor a
    * partir de `user_templates`, e por isso **não distingue** a célula que
    * alguém ajustou da célula que divergiu porque o modelo mudou depois — daí o
-   * rótulo ser "difere dos carimbos aplicados".
+   * rótulo ser "difere dos modelos aplicados".
    */
-  stamped: PermissionCells;
+  appliedCells: PermissionCells;
   appliedTemplates: AppliedTemplate[];
 }
 

--- a/src/app/domain/models/permission-admin.model.ts
+++ b/src/app/domain/models/permission-admin.model.ts
@@ -61,6 +61,12 @@ export interface UserSummary {
   name: string;
   login: string;
   active: boolean;
+  /**
+   * Conta de desenvolvedor: tem tudo por resolução, e a grade dela não se
+   * edita. É a saída de emergência do controle de acesso — o que garante que
+   * sempre exista alguém capaz de reabrir o sistema.
+   */
+  developer: boolean;
   templates: string[];
 }
 
@@ -76,6 +82,7 @@ export interface UserGrid {
   id: string;
   name: string;
   login: string;
+  developer: boolean;
   cells: PermissionCells;
   /**
    * O que os modelos aplicados nesta pessoa permitem.

--- a/src/app/domain/models/permission-admin.model.ts
+++ b/src/app/domain/models/permission-admin.model.ts
@@ -1,0 +1,104 @@
+/**
+ * O vocabulário das telas de configuração de permissão.
+ *
+ * O que a API chama de `cells` é sempre o mesmo formato do
+ * `GET api/me/permissions`: tela apontando para as ações ligadas. **Ausente é
+ * negado** — a grade viaja completa, e não em pedaços.
+ */
+
+/** `{ 'stock/movements': ['CONSULTAR', 'EXCLUIR'] }` */
+export type PermissionCells = Record<string, string[]>;
+
+/**
+ * As sete, na ordem do enum da API.
+ *
+ * Esta ordem é a das colunas do grid. Reordenar "para ficar alfabético" muda a
+ * tela e desalinha a leitura de quem já decorou onde fica o Excluir.
+ */
+export const PERMISSIONS = [
+  'ALTERAR', 'EXCLUIR', 'CONSULTAR', 'CONFIGURAR', 'INCLUIR', 'ENVIAR', 'BAIXAR',
+] as const;
+
+export type PermissionName = typeof PERMISSIONS[number];
+
+/** O rótulo curto de cada coluna. O nome inteiro não cabe em 62px. */
+export const PERMISSION_LABELS: Record<PermissionName, string> = {
+  ALTERAR: 'Alt',
+  EXCLUIR: 'Exc',
+  CONSULTAR: 'Cons',
+  CONFIGURAR: 'Conf',
+  INCLUIR: 'Inc',
+  ENVIAR: 'Env',
+  BAIXAR: 'Baix',
+};
+
+export interface ScreenRow {
+  code: string;
+  label: string;
+  module: string;
+  sortOrder: number;
+}
+
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  active: boolean;
+  allowedCells: number;
+  stampedUsers: number;
+}
+
+export interface TemplateGrid {
+  id: string;
+  name: string;
+  description: string | null;
+  active: boolean;
+  cells: PermissionCells;
+}
+
+export interface UserSummary {
+  id: string;
+  name: string;
+  login: string;
+  active: boolean;
+  templates: string[];
+}
+
+export interface AppliedTemplate {
+  id: string;
+  name: string;
+  appliedAt: string;
+  appliedBy: string | null;
+  mode: ApplyMode;
+}
+
+export interface UserGrid {
+  id: string;
+  name: string;
+  login: string;
+  cells: PermissionCells;
+  /**
+   * O que os carimbos aplicados nesta pessoa permitem.
+   *
+   * A diferença para `cells` é o ponto âmbar da tela. É derivado no servidor a
+   * partir de `user_templates`, e por isso **não distingue** a célula que
+   * alguém ajustou da célula que divergiu porque o modelo mudou depois — daí o
+   * rótulo ser "difere dos carimbos aplicados".
+   */
+  stamped: PermissionCells;
+  appliedTemplates: AppliedTemplate[];
+}
+
+/**
+ * SOMAR liga o que o modelo permite e não desliga nada; SUBSTITUIR grava o
+ * modelo exato.
+ *
+ * É a única escolha desta feature que apaga trabalho de alguém, e por isso a
+ * tela escreve as duas consequências antes do clique.
+ */
+export type ApplyMode = 'SOMAR' | 'SUBSTITUIR';
+
+export interface ApplyResult {
+  users: number;
+  cellsChanged: number;
+}

--- a/src/app/infrastructure/directives/pk-can.directive.spec.ts
+++ b/src/app/infrastructure/directives/pk-can.directive.spec.ts
@@ -1,0 +1,113 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+import { PkCanDirective } from './pk-can.directive';
+import { PermissionStore } from '../state/permission.store';
+import { environment } from '../../../environments/environment';
+
+@Component({
+  standalone: true,
+  imports: [PkCanDirective],
+  template: `
+    <button *pkCan="'stock/movements:EXCLUIR'" id="excluir">Excluir</button>
+    <button *pkCan="'stock/movements:ALTERAR'" id="alterar">Alterar</button>
+    <button *pkCan="'stock/movements'" id="tela">Qualquer</button>
+  `,
+})
+class HostDeTeste {}
+
+/**
+ * A peça que faz o controle **por ação** existir na tela.
+ *
+ * Antes dela não havia nada parecido: só a galeria escondia algo, com um
+ * `isAdmin` cravado no componente.
+ *
+ * O que se protege aqui é o comportamento **antes** de a resposta chegar. A
+ * diretiva monta junto com a tela, e as permissões vêm por HTTP depois — sem
+ * reagir, o botão ficaria escondido para sempre em quem abriu a página antes
+ * da resposta.
+ */
+describe('PkCanDirective', () => {
+  let http: HttpTestingController;
+
+  const url = `${environment.apiUrl}/me/permissions`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HostDeTeste],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  const montar = () => {
+    const fixture = TestBed.createComponent(HostDeTeste);
+    fixture.detectChanges();
+    return fixture;
+  };
+
+  const existe = (fixture: ReturnType<typeof montar>, id: string) =>
+    !!fixture.nativeElement.querySelector(`#${id}`);
+
+  const carregar = (mapa: Record<string, string[]>) => {
+    TestBed.inject(PermissionStore).ensureLoaded().subscribe();
+    http.expectOne(url).flush(mapa);
+  };
+
+  /**
+   * **Sem permissão, o elemento não existe no DOM** — não é `display: none`.
+   *
+   * Esconder por CSS deixaria o botão clicável por quem abrisse o inspetor, e a
+   * requisição sairia. O 403 da API pegaria, mas o front não pode ser o que
+   * convida a tentar.
+   */
+  it('sem permissão, o botão não é criado', () => {
+    carregar({ 'stock/movements': ['ALTERAR'] });
+    const fixture = montar();
+
+    expect(existe(fixture, 'excluir')).toBeFalse();
+    expect(existe(fixture, 'alterar')).toBeTrue();
+  });
+
+  /**
+   * **O caso da corrida.**
+   *
+   * A tela monta antes de a resposta chegar. Sem reagir à chegada, o botão
+   * ficaria escondido para sempre — e o sintoma seria "às vezes o botão some",
+   * na máquina de quem tem internet ruim.
+   */
+  it('o botão aparece quando as permissões chegam depois da tela montar', () => {
+    const fixture = montar();
+    expect(existe(fixture, 'excluir')).toBeFalse();
+
+    carregar({ 'stock/movements': ['EXCLUIR'] });
+    fixture.detectChanges();
+
+    expect(existe(fixture, 'excluir')).toBeTrue();
+  });
+
+  /** Código sem ação vale a tela toda: `*pkCan="'stock/movements'"`. */
+  it('sem ação no código, basta ter qualquer permissão na tela', () => {
+    carregar({ 'stock/movements': ['INCLUIR'] });
+    const fixture = montar();
+
+    expect(existe(fixture, 'tela')).toBeTrue();
+    expect(existe(fixture, 'excluir')).toBeFalse();
+  });
+
+  it('tela que não veio no mapa esconde tudo', () => {
+    carregar({ 'rh/hub': ['CONSULTAR'] });
+    const fixture = montar();
+
+    expect(existe(fixture, 'excluir')).toBeFalse();
+    expect(existe(fixture, 'alterar')).toBeFalse();
+    expect(existe(fixture, 'tela')).toBeFalse();
+  });
+});

--- a/src/app/infrastructure/directives/pk-can.directive.ts
+++ b/src/app/infrastructure/directives/pk-can.directive.ts
@@ -1,0 +1,59 @@
+import {
+  Directive,
+  TemplateRef,
+  ViewContainerRef,
+  effect,
+  inject,
+  input,
+} from '@angular/core';
+
+import { PermissionStore } from '../state/permission.store';
+
+/**
+ * Mostra o elemento só se a pessoa tiver a permissão.
+ *
+ * ```html
+ * <pk-button *pkCan="'stock/movements:EXCLUIR'" pkLabel="Excluir" />
+ * ```
+ *
+ * É a peça que faz o controle **por ação** existir na tela. Antes disto não
+ * havia nada parecido: só a galeria escondia algo, com um `isAdmin` cravado no
+ * componente.
+ *
+ * **A tela e a API têm que concordar.** Botão visível com endpoint negado vira
+ * 403 na cara de quem clicou — e o 403 não diz qual permissão faltou. Por isso
+ * o código aqui é o mesmo da authority: `tela:ACAO`, copiável de um lado para o
+ * outro sem tradução.
+ */
+@Directive({
+  selector: '[pkCan]',
+  standalone: true,
+})
+export class PkCanDirective {
+
+  private readonly template = inject(TemplateRef<unknown>);
+  private readonly container = inject(ViewContainerRef);
+  private readonly permissions = inject(PermissionStore);
+
+  /** `'stock/movements:EXCLUIR'`, ou só `'stock/movements'` para a tela toda. */
+  readonly pkCan = input.required<string>();
+
+  private rendered = false;
+
+  constructor() {
+    // `effect` e não `ngOnInit`: as permissões chegam por HTTP depois que a
+    // tela já montou. Sem reagir, o botão ficaria escondido para sempre em
+    // quem abriu a página antes da resposta chegar.
+    effect(() => {
+      const allowed = this.permissions.canByCode(this.pkCan());
+
+      if (allowed && !this.rendered) {
+        this.container.createEmbeddedView(this.template);
+        this.rendered = true;
+      } else if (!allowed && this.rendered) {
+        this.container.clear();
+        this.rendered = false;
+      }
+    });
+  }
+}

--- a/src/app/infrastructure/guard/auth.guard.spec.ts
+++ b/src/app/infrastructure/guard/auth.guard.spec.ts
@@ -4,7 +4,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { provideRouter } from '@angular/router';
-import { isObservable, firstValueFrom, of } from 'rxjs';
+import { Observable, isObservable, firstValueFrom } from 'rxjs';
 
 import { AuthGuard } from './auth.guard';
 import { AuthService } from '../services/auth.service';
@@ -127,8 +127,29 @@ describe('AuthGuard', () => {
    * Rota sem `screen` não participa do controle: a de acesso negado, as
    * notificações, o início. Trancá-las deixaria a pessoa sem nem o aviso.
    */
-  it('rota sem screen passa direto, sem consultar nada', async () => {
-    expect(await decidir(undefined)).toBeTrue();
-    http.expectNone(url);
+  it('rota sem screen passa, e mesmo assim carrega as permissões', async () => {
+    expect(await decidir(undefined, {})).toBeTrue();
+  });
+
+  /**
+   * **O bug de 2026-08-26, e é por isso que este teste existe.**
+   *
+   * Depois do login a primeira rota é `/home`, que não declara tela. Com o
+   * `if (!screen) return true` na frente do `ensureLoaded`, o guard devolvia
+   * `true` sem nunca carregar — e o menu ficava vazio para sempre, inclusive
+   * para o admin.
+   *
+   * O teste anterior a este chegou a AFIRMAR o comportamento errado
+   * (`http.expectNone`), o que mostra o quanto ele parecia razoável.
+   */
+  it('carrega as permissões mesmo na rota que não participa do controle', () => {
+    const resultado = guard.canActivate(rota(undefined));
+
+    // Precisa assinar: o observable é frio, e quem assina de verdade é o
+    // Router. Sem isto a requisição não sai nem no código certo.
+    (resultado as Observable<boolean>).subscribe();
+
+    // Se o guard tivesse voltado antes, não haveria requisição para casar.
+    http.expectOne(url).flush({ 'rh/hub': ['CONSULTAR'] });
   });
 });

--- a/src/app/infrastructure/guard/auth.guard.spec.ts
+++ b/src/app/infrastructure/guard/auth.guard.spec.ts
@@ -1,23 +1,134 @@
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
 import { provideRouter } from '@angular/router';
+import { isObservable, firstValueFrom, of } from 'rxjs';
 
 import { AuthGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
+import { PermissionStore } from '../state/permission.store';
+import { environment } from '../../../environments/environment';
 
 /**
- * O stub gerado pelo CLI tratava o guard como função (`authGuard`). Ele virou
- * classe e o spec nunca foi atualizado — o que derrubava a compilação da suíte
- * INTEIRA, não só deste arquivo.
+ * A porta de cada tela.
+ *
+ * Errar aqui não é um bug pequeno: ou tranca gente que devia entrar, ou deixa
+ * entrar quem não devia. E o modo de falha mais desagradável é o terceiro — a
+ * **corrida**: decidir antes de as permissões chegarem barra todo mundo no
+ * primeiro clique, uma vez, de forma intermitente.
  */
 describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let auth: jasmine.SpyObj<AuthService>;
+  let http: HttpTestingController;
+  let router: Router;
+
+  const url = `${environment.apiUrl}/me/permissions`;
+
+  const rota = (screen?: string) =>
+    ({ data: screen ? { screen } : {} }) as unknown as ActivatedRouteSnapshot;
+
   beforeEach(() => {
+    auth = jasmine.createSpyObj<AuthService>('AuthService', [
+      'isLoggedIn', 'getUserRoles', 'logout',
+    ]);
+    auth.isLoggedIn.and.returnValue(true);
+    auth.getUserRoles.and.returnValue(['USER']);
+
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: AuthService, useValue: auth },
+      ],
     });
+
+    guard = TestBed.inject(AuthGuard);
+    http = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
   });
 
-  it('should be created', () => {
-    expect(TestBed.inject(AuthGuard)).toBeTruthy();
+  /** Roda o guard e resolve, seja ele síncrono ou não. */
+  const decidir = async (screen?: string, mapa?: Record<string, string[]>) => {
+    const resultado = guard.canActivate(rota(screen));
+    if (!isObservable(resultado)) return resultado;
+
+    const promessa = firstValueFrom(resultado);
+    if (mapa !== undefined) http.expectOne(url).flush(mapa);
+    return promessa;
+  };
+
+  // ─── Antes de qualquer permissão ──────────────────────────────────────────
+
+  it('sem login, manda para o login', async () => {
+    auth.isLoggedIn.and.returnValue(false);
+
+    expect(await decidir('rh/hub')).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  /**
+   * **O cliente é checado antes das permissões, e não depois.**
+   *
+   * Ele não participa deste sistema: não tem linha em `user_permissions`. Se a
+   * checagem viesse depois, ele cairia no mapa vazio e veria "acesso negado"
+   * em vez de voltar para o portal dele.
+   */
+  it('cliente volta para o portal, sem consultar permissão', async () => {
+    auth.getUserRoles.and.returnValue(['CLIENTE']);
+
+    expect(await decidir('rh/hub')).toBeFalse();
+    expect(auth.logout).toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledWith(['/cliente']);
+    http.expectNone(url);
+  });
+
+  // ─── A decisão ────────────────────────────────────────────────────────────
+
+  /**
+   * **A corrida.**
+   *
+   * As permissões chegam por HTTP depois do login, e o guard roda no primeiro
+   * clique. Se ele decidisse na hora, decidiria com o mapa vazio — barrando
+   * todo mundo uma vez, de forma intermitente. Este teste prova que ele espera:
+   * a resposta só é enviada DEPOIS de o guard ter sido chamado.
+   */
+  it('espera as permissões chegarem antes de decidir', async () => {
+    const resultado = guard.canActivate(rota('rh/hub'));
+
+    expect(isObservable(resultado)).toBeTrue();
+
+    const promessa = firstValueFrom(resultado as never);
+    http.expectOne(url).flush({ 'rh/hub': ['CONSULTAR'] });
+
+    expect(await promessa).toBeTrue();
+  });
+
+  it('sem permissão na tela, manda para acesso negado', async () => {
+    expect(await decidir('stock/movements', { 'rh/hub': ['CONSULTAR'] })).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/unauthorized']);
+  });
+
+  /**
+   * Qualquer uma das sete abre a tela — não só `CONSULTAR`. É o técnico que
+   * lança um reembolso sem poder ver os dos outros.
+   */
+  it('abre a tela com qualquer permissão', async () => {
+    expect(await decidir('documentos/rh/reimbursements',
+      { 'documentos/rh/reimbursements': ['INCLUIR'] })).toBeTrue();
+  });
+
+  /**
+   * Rota sem `screen` não participa do controle: a de acesso negado, as
+   * notificações, o início. Trancá-las deixaria a pessoa sem nem o aviso.
+   */
+  it('rota sem screen passa direto, sem consultar nada', async () => {
+    expect(await decidir(undefined)).toBeTrue();
+    http.expectNone(url);
   });
 });

--- a/src/app/infrastructure/guard/auth.guard.ts
+++ b/src/app/infrastructure/guard/auth.guard.ts
@@ -42,13 +42,18 @@ export class AuthGuard implements CanActivate {
 
     const screen = route.data?.['screen'] as string | undefined;
 
-    // Rota sem tela declarada é rota que não participa do controle — a de
-    // acesso negado, as notificações, o próprio início. Trancá-las deixaria a
-    // pessoa sem nem o aviso de que foi barrada.
-    if (!screen) return true;
-
+    // O `ensureLoaded` vem ANTES da checagem de `screen`, e isso não é estilo.
+    //
+    // Depois do login a primeira rota é `/home`, que não declara tela. Com o
+    // `if (!screen) return true` na frente, o guard devolvia `true` e nunca
+    // carregava as permissões — o menu ficava vazio para sempre, inclusive
+    // para o admin. Aconteceu de verdade em 2026-08-26.
     return this.permissions.ensureLoaded().pipe(
       map(() => {
+        // Rota sem tela não participa do controle: acesso negado, notificações,
+        // o próprio início. Trancá-las deixaria a pessoa sem nem o aviso.
+        if (!screen) return true;
+
         if (this.permissions.canOpen(screen)) return true;
 
         this.router.navigate(['/unauthorized']);

--- a/src/app/infrastructure/guard/auth.guard.ts
+++ b/src/app/infrastructure/guard/auth.guard.ts
@@ -1,41 +1,59 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { Observable, map } from 'rxjs';
+
 import { AuthService } from '../services/auth.service';
+import { PermissionStore } from '../state/permission.store';
 
 /** Papel do portal do cliente. Nunca entra na área interna. */
 const CLIENT_ROLE = 'CLIENTE';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
+
+  private readonly permissions = inject(PermissionStore);
+
   constructor(private auth: AuthService, private router: Router) {}
 
-  canActivate(route: ActivatedRouteSnapshot): boolean {
+  /**
+   * Devolve `Observable` e não `boolean` **por causa de uma corrida**.
+   *
+   * As permissões chegam por HTTP depois do login. O guard roda no primeiro
+   * clique — se decidisse na hora, decidiria com o mapa vazio e barraria todo
+   * mundo, uma vez, de forma intermitente. Esperar o `ensureLoaded` faz a
+   * decisão acontecer com o dado na mão.
+   */
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> | boolean {
     if (!this.auth.isLoggedIn()) {
       this.router.navigate(['/login']);
       return false;
     }
 
-    const userRoles = this.auth.getUserRoles();
-
-    // Cliente não entra na área interna em hipótese nenhuma — e a checagem
-    // vem ANTES das roles da rota porque a maioria delas não declara role
-    // nenhuma: sem isto, um cliente logado aqui veria todas essas telas.
-    if (userRoles.includes(CLIENT_ROLE)) {
+    // Cliente não entra na área interna em hipótese nenhuma — e a checagem vem
+    // ANTES de qualquer permissão porque ele não participa deste sistema: o
+    // portal tem sessão e escopo próprios, e ele não tem linha em
+    // `user_permissions`. Sem isto, um cliente logado aqui cairia no mapa
+    // vazio e veria a tela de acesso negado em vez de voltar para o portal.
+    if (this.auth.getUserRoles().includes(CLIENT_ROLE)) {
       this.auth.logout();
       this.router.navigate(['/cliente']);
       return false;
     }
 
-    const requiredRoles = route.data?.['roles'] as string[] | undefined;
+    const screen = route.data?.['screen'] as string | undefined;
 
-    if (requiredRoles && requiredRoles.length > 0) {
-      const hasRole = requiredRoles.some(r => userRoles.includes(r));
+    // Rota sem tela declarada é rota que não participa do controle — a de
+    // acesso negado, as notificações, o próprio início. Trancá-las deixaria a
+    // pessoa sem nem o aviso de que foi barrada.
+    if (!screen) return true;
 
-      if(!hasRole){
+    return this.permissions.ensureLoaded().pipe(
+      map(() => {
+        if (this.permissions.canOpen(screen)) return true;
+
         this.router.navigate(['/unauthorized']);
         return false;
-      }
-    }
-    return true;
+      }),
+    );
   }
 }

--- a/src/app/infrastructure/services/auth.service.ts
+++ b/src/app/infrastructure/services/auth.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
+import { PermissionStore } from '../state/permission.store';
 import { environment } from '../../../environments/environment';
 
 import {
@@ -21,6 +22,8 @@ import {
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 
+  private readonly permissions = inject(PermissionStore);
+
   constructor(private http: HttpClient) {}
 
   login(login: string, password: string): Observable<LoginResponseDTO> {
@@ -33,8 +36,16 @@ export class AuthService {
     );
   }
 
+  /**
+   * Esquece o token **e as permissões**.
+   *
+   * Sem o `clear`, o próximo login herdaria o mapa do anterior: quem entrasse
+   * depois do admin veria o menu do admin até a requisição nova responder. É
+   * curto, e é exatamente o tipo de janela em que alguém clica.
+   */
   logout(): void {
     localStorage.removeItem('token');
+    this.permissions.clear();
   }
 
   getToken(): string | null {

--- a/src/app/infrastructure/services/menu.service.ts
+++ b/src/app/infrastructure/services/menu.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { PermissionStore } from '../state/permission.store';
 import { APP_MENU, AppMenuItem, MOBILE_NAV } from '../../layouts/auth-layout/menu.config';
-import { AuthService } from './auth.service';
 
 /** Item de menu achatado — usado pela busca e pelo breadcrumb da topbar. */
 export interface FlatMenuItem {
@@ -29,7 +28,6 @@ export class MenuService {
 
   private readonly permissions = inject(PermissionStore);
 
-  private readonly auth = inject(AuthService);
 
   private cacheKey: string | null = null;
   private cachedMenu: AppMenuItem[] = [];
@@ -76,15 +74,15 @@ export class MenuService {
   // ── Interno ───────────────────────────────────────────────────────────────
 
   /**
-   * A chave do cache passou a incluir as telas.
+   * A chave do cache são as telas que a pessoa enxerga.
    *
-   * Antes eram só as roles, que não mudam enquanto a sessão vive. As permissões
-   * chegam **depois** do login, por HTTP: sem elas na chave, o menu ficaria
-   * congelado no que foi calculado antes da resposta chegar — vazio.
+   * As permissões chegam **depois** do login, por HTTP: sem elas na chave, o
+   * menu ficaria congelado no que foi calculado antes da resposta chegar —
+   * vazio. As roles saíram da chave no passo 6, junto com o resto: elas não
+   * decidem mais nada de menu.
    */
   private refreshIfNeeded(): void {
-    const key = this.auth.getUserRoles().slice().sort().join('|')
-      + '::' + Object.keys(this.permissions.permissions()).sort().join('|');
+    const key = Object.keys(this.permissions.permissions()).sort().join('|');
 
     if (key === this.cacheKey) return;
 

--- a/src/app/infrastructure/services/menu.service.ts
+++ b/src/app/infrastructure/services/menu.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { PermissionStore } from '../state/permission.store';
 import { APP_MENU, AppMenuItem, MOBILE_NAV } from '../../layouts/auth-layout/menu.config';
 import { AuthService } from './auth.service';
 
@@ -25,6 +26,8 @@ export interface FlatMenuItem {
  */
 @Injectable({ providedIn: 'root' })
 export class MenuService {
+
+  private readonly permissions = inject(PermissionStore);
 
   private readonly auth = inject(AuthService);
 
@@ -72,27 +75,44 @@ export class MenuService {
 
   // ── Interno ───────────────────────────────────────────────────────────────
 
+  /**
+   * A chave do cache passou a incluir as telas.
+   *
+   * Antes eram só as roles, que não mudam enquanto a sessão vive. As permissões
+   * chegam **depois** do login, por HTTP: sem elas na chave, o menu ficaria
+   * congelado no que foi calculado antes da resposta chegar — vazio.
+   */
   private refreshIfNeeded(): void {
-    const key = this.auth.getUserRoles().slice().sort().join('|');
+    const key = this.auth.getUserRoles().slice().sort().join('|')
+      + '::' + Object.keys(this.permissions.permissions()).sort().join('|');
+
     if (key === this.cacheKey) return;
 
     this.cacheKey = key;
-    this.cachedMenu = this.filterByRoles(APP_MENU);
+    this.cachedMenu = this.filterByAccess(APP_MENU);
     this.cachedFlat = this.flatten(this.cachedMenu);
     this.cachedMobile = MOBILE_NAV.filter(item => this.isAllowed(item));
   }
 
+  /**
+   * Item sem `screen` aparece para todo logado.
+   *
+   * São os que não participam do controle — início, notificações — e as pastas,
+   * que não têm rota própria: elas somem sozinhas quando todos os filhos somem,
+   * pelo último `filter` do método abaixo.
+   */
   private isAllowed(item: AppMenuItem): boolean {
-    return !item.roles?.length || this.auth.hasRole(item.roles);
+    if (!item.screen) return true;
+    return this.permissions.canOpen(item.screen);
   }
 
   /** Remove itens sem permissão e grupos que ficaram vazios (recursivo). */
-  private filterByRoles(items: AppMenuItem[]): AppMenuItem[] {
+  private filterByAccess(items: AppMenuItem[]): AppMenuItem[] {
     return items
       .filter(item => this.isAllowed(item))
       .map(item => ({
         ...item,
-        items: item.items ? this.filterByRoles(item.items) : undefined,
+        items: item.items ? this.filterByAccess(item.items) : undefined,
       }))
       .filter(item => !item.items || item.items.length > 0);
   }

--- a/src/app/infrastructure/services/permission/permission-admin.service.ts
+++ b/src/app/infrastructure/services/permission/permission-admin.service.ts
@@ -35,13 +35,13 @@ export class PermissionAdminService {
   }
 
   /**
-   * Quem já foi carimbado com este modelo.
+   * A quem este modelo já foi aplicado.
    *
-   * A tela precisa dos ids, e não só do total: o aviso "3 usuários usaram este
-   * carimbo" só vale acompanhado de um botão que sabe em quem mexer.
+   * A tela precisa dos ids, e não só do total: o aviso "aplicado a 3 pessoas"
+   * só vale acompanhado de um botão que sabe em quem mexer.
    */
-  stampedWith(templateId: string): Observable<UserSummary[]> {
-    return this.http.get<UserSummary[]>(`${this.url}/templates/${templateId}/stamped-users`);
+  appliedTo(templateId: string): Observable<UserSummary[]> {
+    return this.http.get<UserSummary[]>(`${this.url}/templates/${templateId}/applied-to`);
   }
 
   templateGrid(templateId: string): Observable<TemplateGrid> {
@@ -88,6 +88,17 @@ export class PermissionAdminService {
   apply(templateId: string, userIds: string[], mode: ApplyMode): Observable<ApplyResult> {
     return this.http.post<ApplyResult>(`${this.url}/templates/${templateId}/apply`,
       { userIds, mode });
+  }
+
+  /**
+   * Desfaz a aplicação de um modelo numa pessoa.
+   *
+   * Desliga o que **aquele** modelo deu, menos o que outro modelo aplicado
+   * também dá — apagar só o registro não tiraria permissão nenhuma, porque ele
+   * é anotação e não fonte.
+   */
+  undoApply(userId: string, templateId: string): Observable<ApplyResult> {
+    return this.http.delete<ApplyResult>(`${this.url}/users/${userId}/templates/${templateId}`);
   }
 
   copyFrom(userId: string, sourceUserId: string): Observable<ApplyResult> {

--- a/src/app/infrastructure/services/permission/permission-admin.service.ts
+++ b/src/app/infrastructure/services/permission/permission-admin.service.ts
@@ -1,0 +1,97 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { environment } from '../../../../environments/environment';
+import {
+  ApplyMode, ApplyResult, PermissionCells, ScreenRow,
+  TemplateGrid, TemplateSummary, UserGrid, UserSummary,
+} from '../../../domain/models/permission-admin.model';
+
+/**
+ * As telas que configuram quem pode o quê.
+ *
+ * Separado do `PermissionStore`, que guarda as permissões **de quem está
+ * logado**: aquele é consultado a cada render de menu e a cada `*pkCan`, este
+ * só existe dentro de duas telas. Misturar os dois faria o store carregar
+ * catálogo e lista de usuários no login de todo mundo.
+ */
+@Injectable({ providedIn: 'root' })
+export class PermissionAdminService {
+
+  private readonly http = inject(HttpClient);
+  private readonly url = `${environment.apiUrl}/permissions`;
+
+  // ─── Catálogo ──────────────────────────────────────────────────────────────
+
+  screens(): Observable<ScreenRow[]> {
+    return this.http.get<ScreenRow[]>(`${this.url}/screens`);
+  }
+
+  // ─── Modelos ───────────────────────────────────────────────────────────────
+
+  templates(): Observable<TemplateSummary[]> {
+    return this.http.get<TemplateSummary[]>(`${this.url}/templates`);
+  }
+
+  /**
+   * Quem já foi carimbado com este modelo.
+   *
+   * A tela precisa dos ids, e não só do total: o aviso "3 usuários usaram este
+   * carimbo" só vale acompanhado de um botão que sabe em quem mexer.
+   */
+  stampedWith(templateId: string): Observable<UserSummary[]> {
+    return this.http.get<UserSummary[]>(`${this.url}/templates/${templateId}/stamped-users`);
+  }
+
+  templateGrid(templateId: string): Observable<TemplateGrid> {
+    return this.http.get<TemplateGrid>(`${this.url}/templates/${templateId}/grid`);
+  }
+
+  /** Criar. Com `copyFromId`, é o duplicar — não é outro endpoint. */
+  createTemplate(name: string, description: string | null,
+                 copyFromId?: string): Observable<TemplateSummary> {
+    return this.http.post<TemplateSummary>(`${this.url}/templates`,
+      { name, description, copyFromId: copyFromId ?? null });
+  }
+
+  editTemplate(templateId: string,
+               changes: { name?: string; description?: string; active?: boolean }): Observable<void> {
+    return this.http.patch<void>(`${this.url}/templates/${templateId}`, changes);
+  }
+
+  /**
+   * Grava a grade inteira do modelo.
+   *
+   * `PUT` e não `PATCH`: o corpo é a grade completa e **ausente é negado**. Se
+   * ausência significasse "não mexer", desmarcar uma célula não teria como ser
+   * expresso — o corpo ficaria igual ao de antes.
+   */
+  saveTemplateGrid(templateId: string, cells: PermissionCells): Observable<ApplyResult> {
+    return this.http.put<ApplyResult>(`${this.url}/templates/${templateId}/grid`, { cells });
+  }
+
+  // ─── Pessoas ───────────────────────────────────────────────────────────────
+
+  users(): Observable<UserSummary[]> {
+    return this.http.get<UserSummary[]>(`${this.url}/users`);
+  }
+
+  userGrid(userId: string): Observable<UserGrid> {
+    return this.http.get<UserGrid>(`${this.url}/users/${userId}/grid`);
+  }
+
+  saveUserGrid(userId: string, cells: PermissionCells): Observable<ApplyResult> {
+    return this.http.put<ApplyResult>(`${this.url}/users/${userId}/grid`, { cells });
+  }
+
+  apply(templateId: string, userIds: string[], mode: ApplyMode): Observable<ApplyResult> {
+    return this.http.post<ApplyResult>(`${this.url}/templates/${templateId}/apply`,
+      { userIds, mode });
+  }
+
+  copyFrom(userId: string, sourceUserId: string): Observable<ApplyResult> {
+    return this.http.post<ApplyResult>(
+      `${this.url}/users/${userId}/copy-from/${sourceUserId}`, {});
+  }
+}

--- a/src/app/infrastructure/state/permission.store.spec.ts
+++ b/src/app/infrastructure/state/permission.store.spec.ts
@@ -1,0 +1,134 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+import { PermissionStore } from './permission.store';
+import { environment } from '../../../environments/environment';
+
+/**
+ * O que a pessoa logada pode.
+ *
+ * O que se protege aqui não é a leitura do mapa — é o **carregamento**: uma
+ * requisição só para muitos perguntadores, e o mapa disponível antes de alguém
+ * decidir com base nele. Errar isso não dá erro: dá tela sumindo de forma
+ * intermitente, na máquina de quem tem internet ruim.
+ */
+describe('PermissionStore', () => {
+  let store: PermissionStore;
+  let http: HttpTestingController;
+
+  const url = `${environment.apiUrl}/me/permissions`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
+    store = TestBed.inject(PermissionStore);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => http.verify());
+
+  const responder = (mapa: Record<string, string[]>) => {
+    http.expectOne(url).flush(mapa);
+  };
+
+  // ─── O carregamento ───────────────────────────────────────────────────────
+
+  /**
+   * **Uma requisição, não cinco.**
+   *
+   * O menu renderiza vários itens de uma vez, e cada um pergunta. Sem
+   * compartilhar a chamada em andamento, cada pergunta viraria um GET.
+   */
+  it('perguntas simultâneas compartilham a mesma requisição', () => {
+    store.ensureLoaded().subscribe();
+    store.ensureLoaded().subscribe();
+    store.ensureLoaded().subscribe();
+
+    responder({ 'rh/hub': ['CONSULTAR'] });
+    // O `http.verify()` do afterEach falha se tiver sobrado requisição.
+  });
+
+  it('depois de carregado, não vai ao servidor de novo', () => {
+    store.ensureLoaded().subscribe();
+    responder({ 'rh/hub': ['CONSULTAR'] });
+
+    store.ensureLoaded().subscribe();
+
+    http.expectNone(url);
+  });
+
+  /**
+   * Falhar não pode travar a navegação num erro que ninguém entende.
+   *
+   * Mapa vazio quer dizer "não vê nada", e a tela de acesso negado explica —
+   * melhor que uma tela branca sem mensagem.
+   */
+  it('erro na chamada vira mapa vazio, não exceção', () => {
+    let resultado: unknown = 'nao chamou';
+    store.ensureLoaded().subscribe(mapa => (resultado = mapa));
+
+    http.expectOne(url).flush('erro', { status: 500, statusText: 'Server Error' });
+
+    expect(resultado).toEqual({});
+    expect(store.loaded()).toBeTrue();
+  });
+
+  // ─── As perguntas ─────────────────────────────────────────────────────────
+
+  /**
+   * **Qualquer uma das sete abre a tela.**
+   *
+   * Usar `CONSULTAR` como porta fecharia um caso real: um técnico que precisa
+   * *lançar* um reembolso sem poder *ver* os dos outros entra na tela e não
+   * enxerga a lista.
+   */
+  it('abre a tela com qualquer permissão, inclusive sem CONSULTAR', () => {
+    store.ensureLoaded().subscribe();
+    responder({ 'documentos/rh/reimbursements': ['INCLUIR'] });
+
+    expect(store.canOpen('documentos/rh/reimbursements')).toBeTrue();
+    expect(store.can('documentos/rh/reimbursements', 'CONSULTAR')).toBeFalse();
+  });
+
+  it('tela que não veio no mapa está fechada', () => {
+    store.ensureLoaded().subscribe();
+    responder({ 'rh/hub': ['CONSULTAR'] });
+
+    expect(store.canOpen('stock/movements')).toBeFalse();
+    expect(store.can('stock/movements', 'CONSULTAR')).toBeFalse();
+  });
+
+  /** O código é o mesmo da authority da API — copiável de um lado ao outro. */
+  it('canByCode entende tela:ACAO e tela sozinha', () => {
+    store.ensureLoaded().subscribe();
+    responder({ 'stock/movements': ['EXCLUIR'] });
+
+    expect(store.canByCode('stock/movements:EXCLUIR')).toBeTrue();
+    expect(store.canByCode('stock/movements:ALTERAR')).toBeFalse();
+    expect(store.canByCode('stock/movements')).toBeTrue();
+  });
+
+  /**
+   * **Sem isto, o próximo login herda o menu do anterior.**
+   *
+   * Quem entrasse depois do admin veria as telas do admin até a requisição nova
+   * responder. É uma janela curta, e é exatamente nela que alguém clica.
+   */
+  it('clear esquece o mapa e faz buscar de novo', () => {
+    store.ensureLoaded().subscribe();
+    responder({ 'rh/hub': ['CONSULTAR'] });
+
+    store.clear();
+
+    expect(store.canOpen('rh/hub')).toBeFalse();
+    store.ensureLoaded().subscribe();
+    responder({});
+  });
+});

--- a/src/app/infrastructure/state/permission.store.ts
+++ b/src/app/infrastructure/state/permission.store.ts
@@ -1,0 +1,110 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, computed, inject, signal } from '@angular/core';
+import { Observable, catchError, map, of, shareReplay, tap } from 'rxjs';
+
+import { environment } from '../../../environments/environment';
+
+/** O que a API devolve: `{ 'stock/movements': ['CONSULTAR', 'EXCLUIR'] }`. */
+export type PermissionMap = Record<string, string[]>;
+
+/**
+ * O que a pessoa logada pode fazer, por tela.
+ *
+ * Vem de `GET api/me/permissions` e **não do token**: duzentas strings de ~25
+ * caracteres passariam de 5 KB, e o token viaja em toda requisição.
+ *
+ * O mapa é a forma certa para quem consome. O guard pergunta "entra nesta
+ * tela?" a cada item de menu e a cada render — com lista de `tela:ACAO` isso
+ * seria varrer duzentas strings procurando prefixo.
+ */
+@Injectable({ providedIn: 'root' })
+export class PermissionStore {
+
+  private readonly http = inject(HttpClient);
+
+  private readonly _permissions = signal<PermissionMap>({});
+  private readonly _loaded = signal(false);
+
+  readonly permissions = this._permissions.asReadonly();
+  readonly loaded = this._loaded.asReadonly();
+
+  /**
+   * A requisição em andamento, compartilhada.
+   *
+   * Sem isto, os cinco itens de menu que renderizam juntos disparariam cinco
+   * chamadas iguais. O `shareReplay` faz todos esperarem a mesma.
+   */
+  private pending?: Observable<PermissionMap>;
+
+  /**
+   * Garante que as permissões chegaram antes de alguém decidir com base nelas.
+   *
+   * **É o que resolve a corrida.** O guard roda no primeiro clique, e as
+   * permissões chegam por HTTP — sem esperar, ele decidiria com o mapa vazio e
+   * barraria todo mundo no primeiro acesso, uma vez, de forma intermitente.
+   * Esse é o tipo de defeito que só aparece na máquina de quem tem internet
+   * ruim.
+   */
+  ensureLoaded(): Observable<PermissionMap> {
+    if (this._loaded()) return of(this._permissions());
+    if (this.pending) return this.pending;
+
+    this.pending = this.http.get<PermissionMap>(`${environment.apiUrl}/me/permissions`).pipe(
+      map(map => map ?? {}),
+      tap(map => {
+        this._permissions.set(map);
+        this._loaded.set(true);
+        this.pending = undefined;
+      }),
+      // Falhar aqui não pode travar a navegação num erro que ninguém entende.
+      // Mapa vazio significa "não vê nada", e a tela de acesso negado explica —
+      // que é melhor que uma tela branca sem mensagem.
+      catchError(() => {
+        this._permissions.set({});
+        this._loaded.set(true);
+        this.pending = undefined;
+        return of({} as PermissionMap);
+      }),
+      shareReplay(1),
+    );
+
+    return this.pending;
+  }
+
+  /**
+   * A pessoa vê esta tela?
+   *
+   * **Qualquer uma das sete basta.** Usar `CONSULTAR` como porta fecharia um
+   * caso real: um técnico que precisa *lançar* um reembolso sem poder *ver* os
+   * dos outros entra na tela e não enxerga a lista.
+   */
+  canOpen(screen: string): boolean {
+    return (this._permissions()[screen]?.length ?? 0) > 0;
+  }
+
+  /** A pessoa pode esta ação nesta tela? Usado pela diretiva `*pkCan`. */
+  can(screen: string, permission: string): boolean {
+    return this._permissions()[screen]?.includes(permission) ?? false;
+  }
+
+  /**
+   * `'stock/movements:EXCLUIR'` — o mesmo formato da authority da API.
+   *
+   * Existe para o `*pkCan` receber uma string só no template, que é o que faz
+   * ele caber numa linha: `<pk-button *pkCan="'stock/movements:EXCLUIR'">`.
+   */
+  canByCode(code: string): boolean {
+    const [screen, permission] = code.split(':', 2);
+    return permission ? this.can(screen, permission) : this.canOpen(screen);
+  }
+
+  /** Quantas telas a pessoa enxerga — usado pelo menu para saber se há algo. */
+  readonly screenCount = computed(() => Object.keys(this._permissions()).length);
+
+  /** No logout, esquece. Senão o próximo login herda as permissões do anterior. */
+  clear(): void {
+    this._permissions.set({});
+    this._loaded.set(false);
+    this.pending = undefined;
+  }
+}

--- a/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.html
+++ b/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.html
@@ -1,5 +1,5 @@
 <nav class="bottom-nav" aria-label="Navegação rápida">
-  @for (item of items; track item.label) {
+  @for (item of items(); track item.label) {
     <a class="bottom-nav__item"
        [routerLink]="item.routerLink"
        routerLinkActive="is-active"

--- a/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.ts
+++ b/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, computed } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import { MenuService } from '../../../infrastructure/services/menu.service';
@@ -16,5 +16,6 @@ export class BottomNavComponent {
 
   private readonly menuService = inject(MenuService);
 
-  readonly items: AppMenuItem[] = this.menuService.mobileItems();
+  /** `computed` pelo mesmo motivo do drawer: as permissões chegam depois. */
+  readonly items = computed<AppMenuItem[]>(() => this.menuService.mobileItems());
 }

--- a/src/app/layouts/auth-layout/menu.config.ts
+++ b/src/app/layouts/auth-layout/menu.config.ts
@@ -16,7 +16,16 @@ export interface AppMenuItem {
   /** Link externo — mutuamente exclusivo com routerLink. */
   url?: string;
   target?: string;
-  /** Papéis que enxergam o item. Ausente = visível para todos os logados. */
+  /**
+   * A tela que este item abre, no catálogo de permissões.
+   *
+   * Ausente = visível para todos os logados: são os itens que não participam do
+   * controle (início, notificações) e as pastas, que aparecem se algum filho
+   * aparecer.
+   */
+  screen?: string;
+
+  /** @deprecated Sai no passo 6. Quem decide agora é o `screen`. */
   roles?: string[];
   badge?: string | number;
   items?: AppMenuItem[];
@@ -31,26 +40,26 @@ export const APP_MENU: AppMenuItem[] = [
   {
     label: 'Documentos',
     icon: 'pi pi-fw pi-folder',
-    routerLink: ['documentos'],
+    routerLink: ['documentos'], screen: 'documentos',
   },
   {
     label: 'Galeria',
     icon: 'pi pi-fw pi-images',
-    routerLink: ['documentos/galeria'],
+    routerLink: ['documentos/galeria'], screen: 'documentos/galeria',
   },
   {
     label: 'RH - Recursos Humanos',
     icon: 'pi pi-fw pi-users',
     items: [
-      { label: 'Painel RH', icon: 'pi pi-fw pi-th-large', routerLink: ['rh/hub'], roles: ['ADMIN', 'RH'] },
+      { label: 'Painel RH', icon: 'pi pi-fw pi-th-large', routerLink: ['rh/hub'], screen: 'rh/hub', roles: ['ADMIN', 'RH'] },
       {
         label: 'Aprovações',
         icon: 'pi pi-fw pi-check-circle',
         roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], roles: ['ADMIN', 'RH'] },
-          { label: 'Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], roles: ['ADMIN', 'RH'] },
-          { label: 'Atestados', icon: 'pi pi-fw pi-file-check', routerLink: ['rh/medical-certificates'], roles: ['ADMIN', 'RH'] },
+          { label: 'Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], screen: 'rh/vacation-requests', roles: ['ADMIN', 'RH'] },
+          { label: 'Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], screen: 'rh/reimbursements', roles: ['ADMIN', 'RH'] },
+          { label: 'Atestados', icon: 'pi pi-fw pi-file-check', routerLink: ['rh/medical-certificates'], screen: 'rh/medical-certificates', roles: ['ADMIN', 'RH'] },
         ],
       },
       {
@@ -58,9 +67,9 @@ export const APP_MENU: AppMenuItem[] = [
         icon: 'pi pi-fw pi-user',
         roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], roles: ['ADMIN', 'RH'] },
-          { label: 'Visão de Equipe', icon: 'pi pi-fw pi-users', routerLink: ['rh/team-overview'], roles: ['ADMIN', 'RH'] },
-          { label: 'Calendário', icon: 'pi pi-fw pi-calendar', routerLink: ['rh/calendar'], roles: ['ADMIN', 'RH'] },
+          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], screen: 'rh/employees', roles: ['ADMIN', 'RH'] },
+          { label: 'Visão de Equipe', icon: 'pi pi-fw pi-users', routerLink: ['rh/team-overview'], screen: 'rh/team-overview', roles: ['ADMIN', 'RH'] },
+          { label: 'Calendário', icon: 'pi pi-fw pi-calendar', routerLink: ['rh/calendar'], screen: 'rh/calendar', roles: ['ADMIN', 'RH'] },
         ],
       },
       {
@@ -68,9 +77,9 @@ export const APP_MENU: AppMenuItem[] = [
         icon: 'pi pi-fw pi-sitemap',
         roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Estrutura', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], roles: ['ADMIN', 'RH'] },
-          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], roles: ['ADMIN', 'RH'] },
-          { label: 'Equipamentos', icon: 'pi pi-fw pi-desktop', routerLink: ['rh/equipment-assignments'], roles: ['ADMIN', 'RH'] },
+          { label: 'Estrutura', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], screen: 'rh/organizational-structure', roles: ['ADMIN', 'RH'] },
+          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], screen: 'rh/career-structure', roles: ['ADMIN', 'RH'] },
+          { label: 'Equipamentos', icon: 'pi pi-fw pi-desktop', routerLink: ['rh/equipment-assignments'], screen: 'rh/equipment-assignments', roles: ['ADMIN', 'RH'] },
         ],
       },
       {
@@ -78,9 +87,9 @@ export const APP_MENU: AppMenuItem[] = [
         icon: 'pi pi-fw pi-wrench',
         roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Calculadoras', icon: 'pi pi-fw pi-calculator', routerLink: ['rh/calculators'], roles: ['ADMIN', 'RH'] },
-          { label: 'Holerit', icon: 'pi pi-fw pi-file', routerLink: ['rh/holerit'], roles: ['ADMIN', 'RH'] },
-          { label: 'Coletar Holerite', icon: 'pi pi-fw pi-file-arrow-up', routerLink: ['rh/holerit/extractor'], roles: ['ADMIN', 'RH'] },
+          { label: 'Calculadoras', icon: 'pi pi-fw pi-calculator', routerLink: ['rh/calculators'], screen: 'rh/calculators', roles: ['ADMIN', 'RH'] },
+          { label: 'Holerit', icon: 'pi pi-fw pi-file', routerLink: ['rh/holerit'], screen: 'rh/holerit', roles: ['ADMIN', 'RH'] },
+          { label: 'Coletar Holerite', icon: 'pi pi-fw pi-file-arrow-up', routerLink: ['rh/holerit/extractor'], screen: 'rh/holerit/extractor', roles: ['ADMIN', 'RH'] },
         ],
       },
       {
@@ -88,9 +97,9 @@ export const APP_MENU: AppMenuItem[] = [
         icon: 'pi pi-fw pi-megaphone',
         roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Mural de Avisos', icon: 'pi pi-fw pi-megaphone', routerLink: ['rh/announcements'], roles: ['ADMIN', 'RH'] },
-          { label: 'Notificações', icon: 'pi pi-fw pi-bell', routerLink: ['rh/notifications'], roles: ['ADMIN', 'RH'] },
-          { label: 'Portal de Vagas', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/painel-de-vagas'], roles: ['ADMIN', 'RH'] },
+          { label: 'Mural de Avisos', icon: 'pi pi-fw pi-megaphone', routerLink: ['rh/announcements'], screen: 'rh/announcements', roles: ['ADMIN', 'RH'] },
+          { label: 'Notificações', icon: 'pi pi-fw pi-bell', routerLink: ['rh/notifications'], screen: 'rh/notifications', roles: ['ADMIN', 'RH'] },
+          { label: 'Portal de Vagas', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/painel-de-vagas'], screen: 'rh/painel-de-vagas', roles: ['ADMIN', 'RH'] },
         ],
       },
     ],
@@ -99,61 +108,61 @@ export const APP_MENU: AppMenuItem[] = [
     label: 'Financeiro',
     icon: 'pi pi-fw pi-money-bill',
     items: [
-      { label: 'Gerar Recibos Locação', icon: 'pi pi-fw pi-file-export', routerLink: ['finance/rent-receipt-generator'], roles: ['ADMIN', 'FINANCEIRO'] },
+      { label: 'Gerar Recibos Locação', icon: 'pi pi-fw pi-file-export', routerLink: ['finance/rent-receipt-generator'], screen: 'finance/rent-receipt-generator', roles: ['ADMIN', 'FINANCEIRO'] },
     ],
   },
   {
     label: 'Empresa',
     icon: 'pi pi-fw pi-building',
     items: [
-      { label: 'Clientes', icon: 'pi pi-fw pi-user', routerLink: ['company/customers'], roles: ['ADMIN', 'RH', 'MARKETING'] },
-      { label: 'Coletar Dados NFe', icon: 'pi pi-fw pi-file', routerLink: ['company/nfe-collector'], roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] },
-      { label: 'Remover Senha do Excel', icon: 'pi pi-fw pi-lock', routerLink: ['company/excel'] },
-      { label: 'Abastecimento', icon: 'pi pi-fw pi-gauge', routerLink: ['company/fuel-supply'], roles: ['ADMIN', 'COMPRADOR'] },
-      { label: 'Hub de Abastecimento', icon: 'pi pi-fw pi-chart-line', routerLink: ['company/fuel-hub'], roles: ['ADMIN', 'COMPRADOR'] },
-      { label: 'Guia de Utilização', icon: 'pi pi-fw pi-file-pdf', routerLink: ['company/guide'], roles: ['ADMIN', 'CONTRATOS'] },
-      { label: 'Equipamentos', icon: 'pi pi-fw pi-wrench', routerLink: ['company/equipments'], roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] },
+      { label: 'Clientes', icon: 'pi pi-fw pi-user', routerLink: ['company/customers'], screen: 'company/customers', roles: ['ADMIN', 'RH', 'MARKETING'] },
+      { label: 'Coletar Dados NFe', icon: 'pi pi-fw pi-file', routerLink: ['company/nfe-collector'], screen: 'company/nfe-collector', roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] },
+      { label: 'Remover Senha do Excel', icon: 'pi pi-fw pi-lock', routerLink: ['company/excel'], screen: 'company/excel' },
+      { label: 'Abastecimento', icon: 'pi pi-fw pi-gauge', routerLink: ['company/fuel-supply'], screen: 'company/fuel-supply', roles: ['ADMIN', 'COMPRADOR'] },
+      { label: 'Hub de Abastecimento', icon: 'pi pi-fw pi-chart-line', routerLink: ['company/fuel-hub'], screen: 'company/fuel-hub', roles: ['ADMIN', 'COMPRADOR'] },
+      { label: 'Guia de Utilização', icon: 'pi pi-fw pi-file-pdf', routerLink: ['company/guide'], screen: 'company/guide', roles: ['ADMIN', 'CONTRATOS'] },
+      { label: 'Equipamentos', icon: 'pi pi-fw pi-wrench', routerLink: ['company/equipments'], screen: 'company/equipments', roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] },
     ],
   },
   {
     label: 'Comunicação',
     icon: 'pi pi-fw pi-comments',
     items: [
-      { label: 'Newsletter', icon: 'pi pi-fw pi-envelope', routerLink: ['communication/newsletter'], roles: ['ADMIN', 'MARKETING'] },
-      { label: 'Disparo de Emails', icon: 'pi pi-fw pi-send', routerLink: ['communication/email'], roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] },
-      { label: 'Comunicação Protegida', icon: 'pi pi-fw pi-lock', routerLink: ['communication/secrets'], roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] },
-      { label: 'Assinatura de Email', icon: 'pi pi-fw pi-file', routerLink: ['communication/email-signature'], roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] },
-      { label: 'Contato', icon: 'pi pi-fw pi-phone', routerLink: ['communication/contact'], roles: ['ADMIN', 'SUPPORT'] },
+      { label: 'Newsletter', icon: 'pi pi-fw pi-envelope', routerLink: ['communication/newsletter'], screen: 'communication/newsletter', roles: ['ADMIN', 'MARKETING'] },
+      { label: 'Disparo de Emails', icon: 'pi pi-fw pi-send', routerLink: ['communication/email'], screen: 'communication/email', roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] },
+      { label: 'Comunicação Protegida', icon: 'pi pi-fw pi-lock', routerLink: ['communication/secrets'], screen: 'communication/secrets', roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] },
+      { label: 'Assinatura de Email', icon: 'pi pi-fw pi-file', routerLink: ['communication/email-signature'], screen: 'communication/email-signature', roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] },
+      { label: 'Contato', icon: 'pi pi-fw pi-phone', routerLink: ['communication/contact'], screen: 'communication/contact', roles: ['ADMIN', 'SUPPORT'] },
     ],
   },
   {
     label: 'Estoque',
     icon: 'pi pi-fw pi-box',
     items: [
-      { label: 'Hub das Máquinas', icon: 'pi pi-fw pi-th-large', routerLink: ['stock/hub'], roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
-      { label: 'Programação', icon: 'pi pi-fw pi-table', routerLink: ['stock/programacao'], roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
-      { label: 'Hub do Estoque', icon: 'pi pi-fw pi-chart-bar', routerLink: ['stock/inventory-hub'], roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Produtos', icon: 'pi pi-fw pi-box', routerLink: ['stock/products'], roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Movimentações', icon: 'pi pi-fw pi-arrow-right-arrow-left', routerLink: ['stock/movements'], roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Alertas de saída', icon: 'pi pi-fw pi-bell', routerLink: ['stock/alerts'], roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
+      { label: 'Hub das Máquinas', icon: 'pi pi-fw pi-th-large', routerLink: ['stock/hub'], screen: 'stock/hub', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
+      { label: 'Programação', icon: 'pi pi-fw pi-table', routerLink: ['stock/programacao'], screen: 'stock/programacao', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
+      { label: 'Hub do Estoque', icon: 'pi pi-fw pi-chart-bar', routerLink: ['stock/inventory-hub'], screen: 'stock/inventory-hub', roles: ['ADMIN', 'ALMOXARIFADO'] },
+      { label: 'Produtos', icon: 'pi pi-fw pi-box', routerLink: ['stock/products'], screen: 'stock/products', roles: ['ADMIN', 'ALMOXARIFADO'] },
+      { label: 'Movimentações', icon: 'pi pi-fw pi-arrow-right-arrow-left', routerLink: ['stock/movements'], screen: 'stock/movements', roles: ['ADMIN', 'ALMOXARIFADO'] },
+      { label: 'Alertas de saída', icon: 'pi pi-fw pi-bell', routerLink: ['stock/alerts'], screen: 'stock/alerts', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
     ],
   },
   {
     label: 'Ferramentas',
     icon: 'pi pi-fw pi-wrench',
     items: [
-      { label: 'PDF', icon: 'pi pi-fw pi-file-pdf', routerLink: ['tools/pdf'] },
-      { label: 'Certificados em lote', icon: 'pi pi-fw pi-verified', routerLink: ['tools/certificados'], roles: ['ADMIN'] },
+      { label: 'PDF', icon: 'pi pi-fw pi-file-pdf', routerLink: ['tools/pdf'], screen: 'tools/pdf' },
+      { label: 'Certificados em lote', icon: 'pi pi-fw pi-verified', routerLink: ['tools/certificados'], screen: 'tools/certificados', roles: ['ADMIN'] },
     ],
   },
   {
     label: 'Configurações',
     icon: 'pi pi-fw pi-cog',
     items: [
-      { label: 'Produtos do site', icon: 'pi pi-fw pi-tags', routerLink: ['settings/products/website'], roles: ['ADMIN', 'DESIGN'] },
-      { label: 'Faq', icon: 'pi pi-fw pi-question-circle', routerLink: ['faq/manager'], roles: ['ADMIN'] },
-      { label: 'Perfil', icon: 'pi pi-fw pi-id-card', routerLink: ['profile-manager'], roles: ['ADMIN'] },
-      { label: 'Admin', icon: 'pi pi-fw pi-shield', routerLink: ['settings/admin'], roles: ['ADMIN'] },
+      { label: 'Produtos do site', icon: 'pi pi-fw pi-tags', routerLink: ['settings/products/website'], screen: 'settings/products/website', roles: ['ADMIN', 'DESIGN'] },
+      { label: 'Faq', icon: 'pi pi-fw pi-question-circle', routerLink: ['faq/manager'], screen: 'faq/manager', roles: ['ADMIN'] },
+      { label: 'Perfil', icon: 'pi pi-fw pi-id-card', routerLink: ['profile-manager'], screen: 'profile-manager', roles: ['ADMIN'] },
+      { label: 'Admin', icon: 'pi pi-fw pi-shield', routerLink: ['settings/admin'], screen: 'settings/admin', roles: ['ADMIN'] },
     ],
   },
   {
@@ -177,7 +186,7 @@ export const APP_MENU: AppMenuItem[] = [
  */
 export const MOBILE_NAV: AppMenuItem[] = [
   { label: 'Início', icon: 'pi pi-home', routerLink: ['home'] },
-  { label: 'Documentos', icon: 'pi pi-folder', routerLink: ['documentos'] },
-  { label: 'Avisos', icon: 'pi pi-megaphone', routerLink: ['documentos/rh/announcements'] },
-  { label: 'Perfil', icon: 'pi pi-user', routerLink: ['perfil'] },
+  { label: 'Documentos', icon: 'pi pi-folder', routerLink: ['documentos'], screen: 'documentos' },
+  { label: 'Avisos', icon: 'pi pi-megaphone', routerLink: ['documentos/rh/announcements'], screen: 'documentos/rh/announcements' },
+  { label: 'Perfil', icon: 'pi pi-user', routerLink: ['perfil'], screen: 'perfil' },
 ];

--- a/src/app/layouts/auth-layout/menu.config.ts
+++ b/src/app/layouts/auth-layout/menu.config.ts
@@ -163,6 +163,8 @@ export const APP_MENU: AppMenuItem[] = [
       { label: 'Faq', icon: 'pi pi-fw pi-question-circle', routerLink: ['faq/manager'], screen: 'faq/manager', roles: ['ADMIN'] },
       { label: 'Perfil', icon: 'pi pi-fw pi-id-card', routerLink: ['profile-manager'], screen: 'profile-manager', roles: ['ADMIN'] },
       { label: 'Admin', icon: 'pi pi-fw pi-shield', routerLink: ['settings/admin'], screen: 'settings/admin', roles: ['ADMIN'] },
+      { label: 'Modelos de permissão', icon: 'pi pi-fw pi-bookmark', routerLink: ['settings/permissions/templates'], screen: 'settings/permissions/templates', roles: ['ADMIN'] },
+      { label: 'Permissões por usuário', icon: 'pi pi-fw pi-lock', routerLink: ['settings/permissions/users'], screen: 'settings/permissions/users', roles: ['ADMIN'] },
     ],
   },
   {

--- a/src/app/layouts/auth-layout/menu.config.ts
+++ b/src/app/layouts/auth-layout/menu.config.ts
@@ -24,9 +24,6 @@ export interface AppMenuItem {
    * aparecer.
    */
   screen?: string;
-
-  /** @deprecated Sai no passo 6. Quem decide agora é o `screen`. */
-  roles?: string[];
   badge?: string | number;
   items?: AppMenuItem[];
 }
@@ -51,55 +48,50 @@ export const APP_MENU: AppMenuItem[] = [
     label: 'RH - Recursos Humanos',
     icon: 'pi pi-fw pi-users',
     items: [
-      { label: 'Painel RH', icon: 'pi pi-fw pi-th-large', routerLink: ['rh/hub'], screen: 'rh/hub', roles: ['ADMIN', 'RH'] },
+      { label: 'Painel RH', icon: 'pi pi-fw pi-th-large', routerLink: ['rh/hub'], screen: 'rh/hub' },
       {
         label: 'Aprovações',
         icon: 'pi pi-fw pi-check-circle',
-        roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], screen: 'rh/vacation-requests', roles: ['ADMIN', 'RH'] },
-          { label: 'Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], screen: 'rh/reimbursements', roles: ['ADMIN', 'RH'] },
-          { label: 'Atestados', icon: 'pi pi-fw pi-file-check', routerLink: ['rh/medical-certificates'], screen: 'rh/medical-certificates', roles: ['ADMIN', 'RH'] },
+          { label: 'Férias', icon: 'pi pi-fw pi-sun', routerLink: ['rh/vacation-requests'], screen: 'rh/vacation-requests' },
+          { label: 'Reembolsos', icon: 'pi pi-fw pi-wallet', routerLink: ['rh/reimbursements'], screen: 'rh/reimbursements' },
+          { label: 'Atestados', icon: 'pi pi-fw pi-file-check', routerLink: ['rh/medical-certificates'], screen: 'rh/medical-certificates' },
         ],
       },
       {
         label: 'Pessoas',
         icon: 'pi pi-fw pi-user',
-        roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], screen: 'rh/employees', roles: ['ADMIN', 'RH'] },
-          { label: 'Visão de Equipe', icon: 'pi pi-fw pi-users', routerLink: ['rh/team-overview'], screen: 'rh/team-overview', roles: ['ADMIN', 'RH'] },
-          { label: 'Calendário', icon: 'pi pi-fw pi-calendar', routerLink: ['rh/calendar'], screen: 'rh/calendar', roles: ['ADMIN', 'RH'] },
+          { label: 'Funcionários', icon: 'pi pi-fw pi-user', routerLink: ['rh/employees'], screen: 'rh/employees' },
+          { label: 'Visão de Equipe', icon: 'pi pi-fw pi-users', routerLink: ['rh/team-overview'], screen: 'rh/team-overview' },
+          { label: 'Calendário', icon: 'pi pi-fw pi-calendar', routerLink: ['rh/calendar'], screen: 'rh/calendar' },
         ],
       },
       {
         label: 'Organização',
         icon: 'pi pi-fw pi-sitemap',
-        roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Estrutura', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], screen: 'rh/organizational-structure', roles: ['ADMIN', 'RH'] },
-          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], screen: 'rh/career-structure', roles: ['ADMIN', 'RH'] },
-          { label: 'Equipamentos', icon: 'pi pi-fw pi-desktop', routerLink: ['rh/equipment-assignments'], screen: 'rh/equipment-assignments', roles: ['ADMIN', 'RH'] },
+          { label: 'Estrutura', icon: 'pi pi-fw pi-sitemap', routerLink: ['rh/organizational-structure'], screen: 'rh/organizational-structure' },
+          { label: 'Cargos & Níveis', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/career-structure'], screen: 'rh/career-structure' },
+          { label: 'Equipamentos', icon: 'pi pi-fw pi-desktop', routerLink: ['rh/equipment-assignments'], screen: 'rh/equipment-assignments' },
         ],
       },
       {
         label: 'Ferramentas',
         icon: 'pi pi-fw pi-wrench',
-        roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Calculadoras', icon: 'pi pi-fw pi-calculator', routerLink: ['rh/calculators'], screen: 'rh/calculators', roles: ['ADMIN', 'RH'] },
-          { label: 'Holerit', icon: 'pi pi-fw pi-file', routerLink: ['rh/holerit'], screen: 'rh/holerit', roles: ['ADMIN', 'RH'] },
-          { label: 'Coletar Holerite', icon: 'pi pi-fw pi-file-arrow-up', routerLink: ['rh/holerit/extractor'], screen: 'rh/holerit/extractor', roles: ['ADMIN', 'RH'] },
+          { label: 'Calculadoras', icon: 'pi pi-fw pi-calculator', routerLink: ['rh/calculators'], screen: 'rh/calculators' },
+          { label: 'Holerit', icon: 'pi pi-fw pi-file', routerLink: ['rh/holerit'], screen: 'rh/holerit' },
+          { label: 'Coletar Holerite', icon: 'pi pi-fw pi-file-arrow-up', routerLink: ['rh/holerit/extractor'], screen: 'rh/holerit/extractor' },
         ],
       },
       {
         label: 'Comunicação',
         icon: 'pi pi-fw pi-megaphone',
-        roles: ['ADMIN', 'RH'],
         items: [
-          { label: 'Mural de Avisos', icon: 'pi pi-fw pi-megaphone', routerLink: ['rh/announcements'], screen: 'rh/announcements', roles: ['ADMIN', 'RH'] },
-          { label: 'Notificações', icon: 'pi pi-fw pi-bell', routerLink: ['rh/notifications'], screen: 'rh/notifications', roles: ['ADMIN', 'RH'] },
-          { label: 'Portal de Vagas', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/painel-de-vagas'], screen: 'rh/painel-de-vagas', roles: ['ADMIN', 'RH'] },
+          { label: 'Mural de Avisos', icon: 'pi pi-fw pi-megaphone', routerLink: ['rh/announcements'], screen: 'rh/announcements' },
+          { label: 'Notificações', icon: 'pi pi-fw pi-bell', routerLink: ['rh/notifications'], screen: 'rh/notifications' },
+          { label: 'Portal de Vagas', icon: 'pi pi-fw pi-briefcase', routerLink: ['rh/painel-de-vagas'], screen: 'rh/painel-de-vagas' },
         ],
       },
     ],
@@ -108,43 +100,43 @@ export const APP_MENU: AppMenuItem[] = [
     label: 'Financeiro',
     icon: 'pi pi-fw pi-money-bill',
     items: [
-      { label: 'Gerar Recibos Locação', icon: 'pi pi-fw pi-file-export', routerLink: ['finance/rent-receipt-generator'], screen: 'finance/rent-receipt-generator', roles: ['ADMIN', 'FINANCEIRO'] },
+      { label: 'Gerar Recibos Locação', icon: 'pi pi-fw pi-file-export', routerLink: ['finance/rent-receipt-generator'], screen: 'finance/rent-receipt-generator' },
     ],
   },
   {
     label: 'Empresa',
     icon: 'pi pi-fw pi-building',
     items: [
-      { label: 'Clientes', icon: 'pi pi-fw pi-user', routerLink: ['company/customers'], screen: 'company/customers', roles: ['ADMIN', 'RH', 'MARKETING'] },
-      { label: 'Coletar Dados NFe', icon: 'pi pi-fw pi-file', routerLink: ['company/nfe-collector'], screen: 'company/nfe-collector', roles: ['ADMIN', 'RH', 'FINANCEIRO', 'COMPRADOR'] },
+      { label: 'Clientes', icon: 'pi pi-fw pi-user', routerLink: ['company/customers'], screen: 'company/customers' },
+      { label: 'Coletar Dados NFe', icon: 'pi pi-fw pi-file', routerLink: ['company/nfe-collector'], screen: 'company/nfe-collector' },
       { label: 'Remover Senha do Excel', icon: 'pi pi-fw pi-lock', routerLink: ['company/excel'], screen: 'company/excel' },
-      { label: 'Abastecimento', icon: 'pi pi-fw pi-gauge', routerLink: ['company/fuel-supply'], screen: 'company/fuel-supply', roles: ['ADMIN', 'COMPRADOR'] },
-      { label: 'Hub de Abastecimento', icon: 'pi pi-fw pi-chart-line', routerLink: ['company/fuel-hub'], screen: 'company/fuel-hub', roles: ['ADMIN', 'COMPRADOR'] },
-      { label: 'Guia de Utilização', icon: 'pi pi-fw pi-file-pdf', routerLink: ['company/guide'], screen: 'company/guide', roles: ['ADMIN', 'CONTRATOS'] },
-      { label: 'Equipamentos', icon: 'pi pi-fw pi-wrench', routerLink: ['company/equipments'], screen: 'company/equipments', roles: ['ADMIN', 'CONTRATOS', 'DESIGN'] },
+      { label: 'Abastecimento', icon: 'pi pi-fw pi-gauge', routerLink: ['company/fuel-supply'], screen: 'company/fuel-supply' },
+      { label: 'Hub de Abastecimento', icon: 'pi pi-fw pi-chart-line', routerLink: ['company/fuel-hub'], screen: 'company/fuel-hub' },
+      { label: 'Guia de Utilização', icon: 'pi pi-fw pi-file-pdf', routerLink: ['company/guide'], screen: 'company/guide' },
+      { label: 'Equipamentos', icon: 'pi pi-fw pi-wrench', routerLink: ['company/equipments'], screen: 'company/equipments' },
     ],
   },
   {
     label: 'Comunicação',
     icon: 'pi pi-fw pi-comments',
     items: [
-      { label: 'Newsletter', icon: 'pi pi-fw pi-envelope', routerLink: ['communication/newsletter'], screen: 'communication/newsletter', roles: ['ADMIN', 'MARKETING'] },
-      { label: 'Disparo de Emails', icon: 'pi pi-fw pi-send', routerLink: ['communication/email'], screen: 'communication/email', roles: ['ADMIN', 'MARKETING', 'RH', 'SUPPORT', 'DESIGN'] },
-      { label: 'Comunicação Protegida', icon: 'pi pi-fw pi-lock', routerLink: ['communication/secrets'], screen: 'communication/secrets', roles: ['ADMIN', 'MARKETING', 'RH', 'VENDEDOR'] },
-      { label: 'Assinatura de Email', icon: 'pi pi-fw pi-file', routerLink: ['communication/email-signature'], screen: 'communication/email-signature', roles: ['ADMIN', 'RH', 'MARKETING', 'DESIGN'] },
-      { label: 'Contato', icon: 'pi pi-fw pi-phone', routerLink: ['communication/contact'], screen: 'communication/contact', roles: ['ADMIN', 'SUPPORT'] },
+      { label: 'Newsletter', icon: 'pi pi-fw pi-envelope', routerLink: ['communication/newsletter'], screen: 'communication/newsletter' },
+      { label: 'Disparo de Emails', icon: 'pi pi-fw pi-send', routerLink: ['communication/email'], screen: 'communication/email' },
+      { label: 'Comunicação Protegida', icon: 'pi pi-fw pi-lock', routerLink: ['communication/secrets'], screen: 'communication/secrets' },
+      { label: 'Assinatura de Email', icon: 'pi pi-fw pi-file', routerLink: ['communication/email-signature'], screen: 'communication/email-signature' },
+      { label: 'Contato', icon: 'pi pi-fw pi-phone', routerLink: ['communication/contact'], screen: 'communication/contact' },
     ],
   },
   {
     label: 'Estoque',
     icon: 'pi pi-fw pi-box',
     items: [
-      { label: 'Hub das Máquinas', icon: 'pi pi-fw pi-th-large', routerLink: ['stock/hub'], screen: 'stock/hub', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
-      { label: 'Programação', icon: 'pi pi-fw pi-table', routerLink: ['stock/programacao'], screen: 'stock/programacao', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
-      { label: 'Hub do Estoque', icon: 'pi pi-fw pi-chart-bar', routerLink: ['stock/inventory-hub'], screen: 'stock/inventory-hub', roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Produtos', icon: 'pi pi-fw pi-box', routerLink: ['stock/products'], screen: 'stock/products', roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Movimentações', icon: 'pi pi-fw pi-arrow-right-arrow-left', routerLink: ['stock/movements'], screen: 'stock/movements', roles: ['ADMIN', 'ALMOXARIFADO'] },
-      { label: 'Alertas de saída', icon: 'pi pi-fw pi-bell', routerLink: ['stock/alerts'], screen: 'stock/alerts', roles: ['ADMIN', 'ALMOXARIFADO', 'CONTRATOS'] },
+      { label: 'Hub das Máquinas', icon: 'pi pi-fw pi-th-large', routerLink: ['stock/hub'], screen: 'stock/hub' },
+      { label: 'Programação', icon: 'pi pi-fw pi-table', routerLink: ['stock/programacao'], screen: 'stock/programacao' },
+      { label: 'Hub do Estoque', icon: 'pi pi-fw pi-chart-bar', routerLink: ['stock/inventory-hub'], screen: 'stock/inventory-hub' },
+      { label: 'Produtos', icon: 'pi pi-fw pi-box', routerLink: ['stock/products'], screen: 'stock/products' },
+      { label: 'Movimentações', icon: 'pi pi-fw pi-arrow-right-arrow-left', routerLink: ['stock/movements'], screen: 'stock/movements' },
+      { label: 'Alertas de saída', icon: 'pi pi-fw pi-bell', routerLink: ['stock/alerts'], screen: 'stock/alerts' },
     ],
   },
   {
@@ -152,19 +144,19 @@ export const APP_MENU: AppMenuItem[] = [
     icon: 'pi pi-fw pi-wrench',
     items: [
       { label: 'PDF', icon: 'pi pi-fw pi-file-pdf', routerLink: ['tools/pdf'], screen: 'tools/pdf' },
-      { label: 'Certificados em lote', icon: 'pi pi-fw pi-verified', routerLink: ['tools/certificados'], screen: 'tools/certificados', roles: ['ADMIN'] },
+      { label: 'Certificados em lote', icon: 'pi pi-fw pi-verified', routerLink: ['tools/certificados'], screen: 'tools/certificados' },
     ],
   },
   {
     label: 'Configurações',
     icon: 'pi pi-fw pi-cog',
     items: [
-      { label: 'Produtos do site', icon: 'pi pi-fw pi-tags', routerLink: ['settings/products/website'], screen: 'settings/products/website', roles: ['ADMIN', 'DESIGN'] },
-      { label: 'Faq', icon: 'pi pi-fw pi-question-circle', routerLink: ['faq/manager'], screen: 'faq/manager', roles: ['ADMIN'] },
-      { label: 'Perfil', icon: 'pi pi-fw pi-id-card', routerLink: ['profile-manager'], screen: 'profile-manager', roles: ['ADMIN'] },
-      { label: 'Admin', icon: 'pi pi-fw pi-shield', routerLink: ['settings/admin'], screen: 'settings/admin', roles: ['ADMIN'] },
-      { label: 'Modelos de permissão', icon: 'pi pi-fw pi-bookmark', routerLink: ['settings/permissions/templates'], screen: 'settings/permissions/templates', roles: ['ADMIN'] },
-      { label: 'Permissões por usuário', icon: 'pi pi-fw pi-lock', routerLink: ['settings/permissions/users'], screen: 'settings/permissions/users', roles: ['ADMIN'] },
+      { label: 'Produtos do site', icon: 'pi pi-fw pi-tags', routerLink: ['settings/products/website'], screen: 'settings/products/website' },
+      { label: 'Faq', icon: 'pi pi-fw pi-question-circle', routerLink: ['faq/manager'], screen: 'faq/manager' },
+      { label: 'Perfil', icon: 'pi pi-fw pi-id-card', routerLink: ['profile-manager'], screen: 'profile-manager' },
+      { label: 'Admin', icon: 'pi pi-fw pi-shield', routerLink: ['settings/admin'], screen: 'settings/admin' },
+      { label: 'Modelos de permissão', icon: 'pi pi-fw pi-bookmark', routerLink: ['settings/permissions/templates'], screen: 'settings/permissions/templates' },
+      { label: 'Permissões por usuário', icon: 'pi pi-fw pi-lock', routerLink: ['settings/permissions/users'], screen: 'settings/permissions/users' },
     ],
   },
   {

--- a/src/app/layouts/auth-layout/nav-drawer/nav-drawer.component.html
+++ b/src/app/layouts/auth-layout/nav-drawer/nav-drawer.component.html
@@ -17,9 +17,9 @@
     <p class="drawer__section">Navegação</p>
 
     <ul class="drawer__list">
-      @for (node of nodes; track node.id) {
+      @for (node of nodes(); track node.id) {
         <li>
-          <ng-container *ngTemplateOutlet="nodeTpl; context: { $implicit: node, siblings: nodes, depth: 0 }" />
+          <ng-container *ngTemplateOutlet="nodeTpl; context: { $implicit: node, siblings: nodes(), depth: 0 }" />
         </li>
       }
     </ul>

--- a/src/app/layouts/auth-layout/nav-drawer/nav-drawer.component.ts
+++ b/src/app/layouts/auth-layout/nav-drawer/nav-drawer.component.ts
@@ -9,8 +9,7 @@ import {
   input,
   output,
   signal,
-  viewChild,
-} from '@angular/core';
+  viewChild, computed } from '@angular/core';
 import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 
 import { AuthService } from '../../../infrastructure/services/auth.service';
@@ -53,8 +52,15 @@ export class NavDrawerComponent {
 
   readonly auth = inject(AuthService);
 
-  /** Papéis não mudam sem recarregar a página, então basta montar uma vez. */
-  readonly nodes: DrawerNode[] = this.toNodes(this.menuService.menu());
+  /**
+   * `computed` e não campo: as permissões chegam por HTTP **depois** do login.
+   *
+   * Isto era um campo, com o comentário "papéis não mudam sem recarregar a
+   * página, então basta montar uma vez" — verdade com roles, que vêm no token.
+   * Com permissão vindo de requisição, o menu montava vazio e nunca mais
+   * recalculava.
+   */
+  readonly nodes = computed<DrawerNode[]>(() => this.toNodes(this.menuService.menu()));
 
   readonly expanded = signal<ReadonlySet<string>>(new Set<string>());
 
@@ -168,7 +174,7 @@ export class NavDrawerComponent {
       return false;
     };
 
-    walk(this.nodes, []);
+    walk(this.nodes(), []);
     this.expanded.set(branch);
   }
 


### PR DESCRIPTION
- **feat(permissoes): o front decide por tela e acao**
- **fix(permissoes): menu vazio para todo mundo, inclusive admin**
- **feat(permissoes): as telas de configuracao**
- **fix(permissoes): dialogo de aplicar modelo abria vazio**
- **fix(permissoes): dialogos e campos passam a usar o tema**
- **feat(permissoes): desfazer a aplicacao de um modelo, e some a metafora**
- **fix(perfil): a tela deixa de ficar em branco quando nao carrega**
- **refactor(permissoes): passo 6, parte 1 — data.roles sai das rotas e do menu**
- **refactor(permissoes): o multiselect de roles sai da tela de Admin**
- **feat(permissoes): a grade do desenvolvedor abre em leitura**
- **feat(documentos): sai o "Em breve", entra o controle de acesso**
- **fix(ferias): "definir saldo" marcado com campo vazio fazia o oposto**
