### PR TITLE
test(front): os 63 testes que falhavam desde sempre

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,10 +1,18 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 
+import { provideServiceWorker } from '@angular/service-worker';
+import { providersDeTeste } from '../testing/test-setup';
+
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: providersDeTeste([
+        // O AppComponent escuta atualização do service worker. Desligado no
+        // teste: o que se verifica aqui é que a casca monta.
+        provideServiceWorker('ngsw-worker.js', { enabled: false }),
+      ]),
     }).compileComponents();
   });
 
@@ -20,10 +28,21 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('proauto-kimium');
   });
 
-  it('should render title', () => {
+  /**
+   * A casca do app é só o `<router-outlet>`.
+   *
+   * Este teste procurava um `<h1>Hello, proauto-kimium</h1>` — o template que o
+   * CLI gera e que foi apagado no primeiro dia do projeto. Ele nunca passou:
+   * afirmava algo que nunca foi verdade aqui.
+   *
+   * O que vale verificar é que a casca monta e tem onde pendurar as rotas. Sem
+   * o outlet, nenhuma tela aparece e o erro não diz por quê.
+   */
+  it('monta a casca com o router-outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
+
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, proauto-kimium');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/src/app/components/auth/admin-center/admin-center.component.spec.ts
+++ b/src/app/components/auth/admin-center/admin-center.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdminCenterComponent } from './admin-center.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('AdminCenterComponent', () => {
   let component: AdminCenterComponent;
   let fixture: ComponentFixture<AdminCenterComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminCenterComponent]
+      imports: [AdminCenterComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/auth/auth-home/auth-home.component.spec.ts
+++ b/src/app/components/auth/auth-home/auth-home.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AuthHomeComponent } from './auth-home.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('AuthHomeComponent', () => {
   let component: AuthHomeComponent;
   let fixture: ComponentFixture<AuthHomeComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AuthHomeComponent]
+      imports: [AuthHomeComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/auth/communication/email/email.component.spec.ts
+++ b/src/app/components/auth/communication/email/email.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EmailComponent } from './email.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('EmailComponent', () => {
   let component: EmailComponent;
   let fixture: ComponentFixture<EmailComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EmailComponent]
+      imports: [EmailComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/communication/newsletter/newsletter.component.spec.ts
+++ b/src/app/components/auth/communication/newsletter/newsletter.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NewsletterComponent } from './newsletter.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('NewsletterComponent', () => {
   let component: NewsletterComponent;
   let fixture: ComponentFixture<NewsletterComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NewsletterComponent]
+      imports: [NewsletterComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/communication/secrets/secrets.component.spec.ts
+++ b/src/app/components/auth/communication/secrets/secrets.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SecretsComponent } from './secrets.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('SecretsComponent', () => {
   let component: SecretsComponent;
   let fixture: ComponentFixture<SecretsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SecretsComponent]
+      imports: [SecretsComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/company/products/website/website.component.spec.ts
+++ b/src/app/components/auth/company/products/website/website.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { WebsiteComponent } from './website.component';
 
+import { providersDeTeste } from '../../../../../../testing/test-setup';
+
 describe('WebsiteComponent', () => {
   let component: WebsiteComponent;
   let fixture: ComponentFixture<WebsiteComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [WebsiteComponent]
+      imports: [WebsiteComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/company/vehicle/fuel-supply/fuel-supply.component.spec.ts
+++ b/src/app/components/auth/company/vehicle/fuel-supply/fuel-supply.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FuelSupplyComponent } from './fuel-supply.component';
 
+import { providersDeTeste } from '../../../../../../testing/test-setup';
+
 describe('FuelSupplyComponent', () => {
   let component: FuelSupplyComponent;
   let fixture: ComponentFixture<FuelSupplyComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FuelSupplyComponent]
+      imports: [FuelSupplyComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/documents/email-signature/email-signature.component.spec.ts
+++ b/src/app/components/auth/documents/email-signature/email-signature.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EmailSignatureComponent } from './email-signature.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('EmailSignatureComponent', () => {
   let component: EmailSignatureComponent;
   let fixture: ComponentFixture<EmailSignatureComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EmailSignatureComponent]
+      imports: [EmailSignatureComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/documents/excel-credentials/excel-credentials.component.spec.ts
+++ b/src/app/components/auth/documents/excel-credentials/excel-credentials.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ExcelCredentialsComponent } from './excel-credentials.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('ExcelCredentialsComponent', () => {
   let component: ExcelCredentialsComponent;
   let fixture: ComponentFixture<ExcelCredentialsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ExcelCredentialsComponent]
+      imports: [ExcelCredentialsComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/documents/holerit-spliter/holerit-spliter.component.spec.ts
+++ b/src/app/components/auth/documents/holerit-spliter/holerit-spliter.component.spec.ts
@@ -2,13 +2,21 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HoleritSpliterComponent } from './holerit-spliter.component';
 
+import { MessageService } from 'primeng/api';
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('HoleritSpliterComponent', () => {
   let component: HoleritSpliterComponent;
   let fixture: ComponentFixture<HoleritSpliterComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HoleritSpliterComponent]
+      imports: [HoleritSpliterComponent],
+      providers: providersDeTeste([
+        // Ele injeta MessageService e NÃO o declara: quem provê é o
+        // holerite-hub, que o hospeda. Montado sozinho, precisa do seu.
+        MessageService,
+      ])
     })
     .compileComponents();
     

--- a/src/app/components/auth/documents/nfe-data-collector/nfe-data-collector.component.spec.ts
+++ b/src/app/components/auth/documents/nfe-data-collector/nfe-data-collector.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NfeDataCollectorComponent } from './nfe-data-collector.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('NfeDataCollectorComponent', () => {
   let component: NfeDataCollectorComponent;
   let fixture: ComponentFixture<NfeDataCollectorComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [NfeDataCollectorComponent]
+      imports: [NfeDataCollectorComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/faq-manager/faq-manager.component.spec.ts
+++ b/src/app/components/auth/faq-manager/faq-manager.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FaqManagerComponent } from './faq-manager.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('FaqManagerComponent', () => {
   let component: FaqManagerComponent;
   let fixture: ComponentFixture<FaqManagerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FaqManagerComponent]
+      imports: [FaqManagerComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/finance/rent-receipt-generator/rent-receipt-generator.component.spec.ts
+++ b/src/app/components/auth/finance/rent-receipt-generator/rent-receipt-generator.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { RentReceiptGeneratorComponent } from './rent-receipt-generator.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('RentReceiptGeneratorComponent', () => {
   let component: RentReceiptGeneratorComponent;
   let fixture: ComponentFixture<RentReceiptGeneratorComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RentReceiptGeneratorComponent]
+      imports: [RentReceiptGeneratorComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/guide/guide.component.spec.ts
+++ b/src/app/components/auth/guide/guide.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GuideComponent } from './guide.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('GuideComponent', () => {
   let component: GuideComponent;
   let fixture: ComponentFixture<GuideComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GuideComponent]
+      imports: [GuideComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/partners/customer/customer.component.spec.ts
+++ b/src/app/components/auth/partners/customer/customer.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CustomerComponent } from './customer.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('CustomerComponent', () => {
   let component: CustomerComponent;
   let fixture: ComponentFixture<CustomerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CustomerComponent]
+      imports: [CustomerComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/auth/partners/employes/employes.component.spec.ts
+++ b/src/app/components/auth/partners/employes/employes.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { EmployesComponent } from './employes.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('EmployesComponent', () => {
   let component: EmployesComponent;
   let fixture: ComponentFixture<EmployesComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [EmployesComponent]
+      imports: [EmployesComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/auth/profile/profile-manager/profile-manager.component.spec.ts
+++ b/src/app/components/auth/profile/profile-manager/profile-manager.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProfileManagerComponent } from './profile-manager.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('ProfileManagerComponent', () => {
   let component: ProfileManagerComponent;
   let fixture: ComponentFixture<ProfileManagerComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProfileManagerComponent]
+      imports: [ProfileManagerComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/rh/candidaturas/candidaturas.component.spec.ts
+++ b/src/app/components/auth/rh/candidaturas/candidaturas.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CandidaturasComponent } from './candidaturas.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('CandidaturasComponent', () => {
   let component: CandidaturasComponent;
   let fixture: ComponentFixture<CandidaturasComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CandidaturasComponent]
+      imports: [CandidaturasComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/rh/painel-de-vagas/painel-de-vagas.component.spec.ts
+++ b/src/app/components/auth/rh/painel-de-vagas/painel-de-vagas.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PainelDeVagasComponent } from './painel-de-vagas.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('PainelDeVagasComponent', () => {
   let component: PainelDeVagasComponent;
   let fixture: ComponentFixture<PainelDeVagasComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PainelDeVagasComponent]
+      imports: [PainelDeVagasComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/auth/support/contacts/contacts.component.spec.ts
+++ b/src/app/components/auth/support/contacts/contacts.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ContactsComponent } from './contacts.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('ContactsComponent', () => {
   let component: ContactsComponent;
   let fixture: ComponentFixture<ContactsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ContactsComponent]
+      imports: [ContactsComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/layout/footer/footer.component.spec.ts
+++ b/src/app/components/layout/footer/footer.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FooterComponent } from './footer.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('FooterComponent', () => {
   let component: FooterComponent;
   let fixture: ComponentFixture<FooterComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FooterComponent]
+      imports: [FooterComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/layout/header/header.component.spec.ts
+++ b/src/app/components/layout/header/header.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeaderComponent } from './header.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HeaderComponent]
+      imports: [HeaderComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/client-login/client-login.component.spec.ts
+++ b/src/app/components/public/client-login/client-login.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClientLoginComponent } from './client-login.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ClientLoginComponent', () => {
   let component: ClientLoginComponent;
   let fixture: ComponentFixture<ClientLoginComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ClientLoginComponent]
+      imports: [ClientLoginComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/public/faq/faq.component.spec.ts
+++ b/src/app/components/public/faq/faq.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FaqComponent } from './faq.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('FaqComponent', () => {
   let component: FaqComponent;
   let fixture: ComponentFixture<FaqComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FaqComponent]
+      imports: [FaqComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/first-access/first-access.component.spec.ts
+++ b/src/app/components/public/first-access/first-access.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FirstAccessComponent } from './first-access.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('FirstAccessComponent', () => {
   let component: FirstAccessComponent;
   let fixture: ComponentFixture<FirstAccessComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FirstAccessComponent]
+      imports: [FirstAccessComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/public/forgot-password/forgot-password.component.spec.ts
+++ b/src/app/components/public/forgot-password/forgot-password.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ForgotPasswordComponent } from './forgot-password.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ForgotPasswordComponent', () => {
   let component: ForgotPasswordComponent;
   let fixture: ComponentFixture<ForgotPasswordComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ForgotPasswordComponent]
+      imports: [ForgotPasswordComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/public/home/components/hero/hero.component.spec.ts
+++ b/src/app/components/public/home/components/hero/hero.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeroComponent } from './hero.component';
 
+import { providersDeTeste } from '../../../../../../testing/test-setup';
+
 describe('HeroComponent', () => {
   let component: HeroComponent;
   let fixture: ComponentFixture<HeroComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HeroComponent]
+      imports: [HeroComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/home/home.component.spec.ts
+++ b/src/app/components/public/home/home.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HomeComponent } from './home.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent]
+      imports: [HomeComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/lista-produtos/lista-produtos.component.spec.ts
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ListaProdutosComponent } from './lista-produtos.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ListaProdutosComponent', () => {
   let component: ListaProdutosComponent;
   let fixture: ComponentFixture<ListaProdutosComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ListaProdutosComponent]
+      imports: [ListaProdutosComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/login/login.component.spec.ts
+++ b/src/app/components/public/login/login.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LoginComponent } from './login.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('LoginComponent', () => {
   let component: LoginComponent;
   let fixture: ComponentFixture<LoginComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [LoginComponent]
+      imports: [LoginComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/profile/vcard/vcard.component.spec.ts
+++ b/src/app/components/public/profile/vcard/vcard.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { VcardComponent } from './vcard.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('VcardComponent', () => {
   let component: VcardComponent;
   let fixture: ComponentFixture<VcardComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [VcardComponent]
+      imports: [VcardComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/public/sales-certificates/sales-certificates.component.spec.ts
+++ b/src/app/components/public/sales-certificates/sales-certificates.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SalesCertificatesComponent } from './sales-certificates.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('SalesCertificatesComponent', () => {
   let component: SalesCertificatesComponent;
   let fixture: ComponentFixture<SalesCertificatesComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SalesCertificatesComponent]
+      imports: [SalesCertificatesComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/public/trabalhe-conosco/trabalhe-conosco.component.spec.ts
+++ b/src/app/components/public/trabalhe-conosco/trabalhe-conosco.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TrabalheConoscoComponent } from './trabalhe-conosco.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('TrabalheConoscoComponent', () => {
   let component: TrabalheConoscoComponent;
   let fixture: ComponentFixture<TrabalheConoscoComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TrabalheConoscoComponent]
+      imports: [TrabalheConoscoComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/public/view-secrets/view-secrets.component.spec.ts
+++ b/src/app/components/public/view-secrets/view-secrets.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ViewSecretsComponent } from './view-secrets.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ViewSecretsComponent', () => {
   let component: ViewSecretsComponent;
   let fixture: ComponentFixture<ViewSecretsComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ViewSecretsComponent]
+      imports: [ViewSecretsComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/components/shared/contact/contact.component.spec.ts
+++ b/src/app/components/shared/contact/contact.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ContactComponent } from './contact.component';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ContactComponent', () => {
   let component: ContactComponent;
   let fixture: ComponentFixture<ContactComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ContactComponent]
+      imports: [ContactComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/components/theme/ProautoKimium/pk-file-upload/pk-file-upload.component.spec.ts
+++ b/src/app/components/theme/ProautoKimium/pk-file-upload/pk-file-upload.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PkFileUploadComponent } from './pk-file-upload.component';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('PkFileUploadComponent', () => {
   let component: PkFileUploadComponent;
   let fixture: ComponentFixture<PkFileUploadComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PkFileUploadComponent]
+      imports: [PkFileUploadComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
 

--- a/src/app/infrastructure/services/auth.service.spec.ts
+++ b/src/app/infrastructure/services/auth.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { AuthService } from './auth.service';
 
+import { providersDeTeste } from '../../../testing/test-setup';
+
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(AuthService);
   });
 

--- a/src/app/infrastructure/services/certificate/certificate.service.spec.ts
+++ b/src/app/infrastructure/services/certificate/certificate.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { CertificateService } from './certificate.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('CertificateService', () => {
   let service: CertificateService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(CertificateService);
   });
 

--- a/src/app/infrastructure/services/communication/secrets/secrets.service.spec.ts
+++ b/src/app/infrastructure/services/communication/secrets/secrets.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { SecretsService } from './secrets.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('SecretsService', () => {
   let service: SecretsService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(SecretsService);
   });
 

--- a/src/app/infrastructure/services/company/inventory/inventory-product.service.spec.ts
+++ b/src/app/infrastructure/services/company/inventory/inventory-product.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { InventoryProductService } from './inventory-product.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('InventoryProductService', () => {
   let service: InventoryProductService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(InventoryProductService);
   });
 

--- a/src/app/infrastructure/services/company/products/website/website.service.spec.ts
+++ b/src/app/infrastructure/services/company/products/website/website.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { WebsiteService } from './website.service';
 
+import { providersDeTeste } from '../../../../../../testing/test-setup';
+
 describe('WebsiteService', () => {
   let service: WebsiteService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(WebsiteService);
   });
 

--- a/src/app/infrastructure/services/company/vehicle/fuelSupply/fuel-suppy.service.spec.ts
+++ b/src/app/infrastructure/services/company/vehicle/fuelSupply/fuel-suppy.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { FuelSuppyService } from './fuel-suppy.service';
 
+import { providersDeTeste } from '../../../../../../testing/test-setup';
+
 describe('FuelSuppyService', () => {
   let service: FuelSuppyService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(FuelSuppyService);
   });
 

--- a/src/app/infrastructure/services/contact/contact.service.spec.ts
+++ b/src/app/infrastructure/services/contact/contact.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { ContactService } from './contact.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ContactService', () => {
   let service: ContactService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(ContactService);
   });
 

--- a/src/app/infrastructure/services/email/email.service.spec.ts
+++ b/src/app/infrastructure/services/email/email.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { EmailService } from './email.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('EmailService', () => {
   let service: EmailService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(EmailService);
   });
 

--- a/src/app/infrastructure/services/emailSignature/email-signature.service.spec.ts
+++ b/src/app/infrastructure/services/emailSignature/email-signature.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { EmailSignatureService } from './email-signature.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('EmailSignatureService', () => {
   let service: EmailSignatureService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(EmailSignatureService);
   });
 

--- a/src/app/infrastructure/services/excel/excel.service.spec.ts
+++ b/src/app/infrastructure/services/excel/excel.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { ExcelService } from './excel.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('ExcelService', () => {
   let service: ExcelService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(ExcelService);
   });
 

--- a/src/app/infrastructure/services/faq/faq.service.spec.ts
+++ b/src/app/infrastructure/services/faq/faq.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { FaqService } from './faq.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('FaqService', () => {
   let service: FaqService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(FaqService);
   });
 

--- a/src/app/infrastructure/services/newsletter/newsletter.service.spec.ts
+++ b/src/app/infrastructure/services/newsletter/newsletter.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { NewsletterService } from './newsletter.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('NewsletterService', () => {
   let service: NewsletterService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(NewsletterService);
   });
 

--- a/src/app/infrastructure/services/nfe/nfe.service.spec.ts
+++ b/src/app/infrastructure/services/nfe/nfe.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { NfeService } from './nfe.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('NfeService', () => {
   let service: NfeService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(NfeService);
   });
 

--- a/src/app/infrastructure/services/partners/customer/customer.service.spec.ts
+++ b/src/app/infrastructure/services/partners/customer/customer.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { CustomerService } from './customer.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('CustomerService', () => {
   let service: CustomerService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(CustomerService);
   });
 

--- a/src/app/infrastructure/services/partners/employee/employee.service.spec.ts
+++ b/src/app/infrastructure/services/partners/employee/employee.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { EmployeeService } from './employee.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('EmployeeService', () => {
   let service: EmployeeService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(EmployeeService);
   });
 

--- a/src/app/infrastructure/services/partners/serviceLocations/service-locations.service.spec.ts
+++ b/src/app/infrastructure/services/partners/serviceLocations/service-locations.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { ServiceLocationsService } from './service-locations.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('ServiceLocationsService', () => {
   let service: ServiceLocationsService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(ServiceLocationsService);
   });
 

--- a/src/app/infrastructure/services/processoSeletivo/candidatura/candidatura.service.spec.ts
+++ b/src/app/infrastructure/services/processoSeletivo/candidatura/candidatura.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { CandidaturaService } from './candidatura.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('CandidaturaService', () => {
   let service: CandidaturaService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(CandidaturaService);
   });
 

--- a/src/app/infrastructure/services/processoSeletivo/vaga/vaga.service.spec.ts
+++ b/src/app/infrastructure/services/processoSeletivo/vaga/vaga.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { VagaService } from './vaga.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('VagaService', () => {
   let service: VagaService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(VagaService);
   });
 

--- a/src/app/infrastructure/services/profile/vcard/vcard.service.spec.ts
+++ b/src/app/infrastructure/services/profile/vcard/vcard.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { VcardService } from './vcard.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('VcardService', () => {
   let service: VcardService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(VcardService);
   });
 

--- a/src/app/infrastructure/services/rentReceiptService/rent-receipt.service.spec.ts
+++ b/src/app/infrastructure/services/rentReceiptService/rent-receipt.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { RentReceiptService } from './rent-receipt.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('RentReceiptServiceService', () => {
   let service: RentReceiptService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(RentReceiptService);
   });
 

--- a/src/app/infrastructure/services/vehicle/maintenance/maintenance.service.spec.ts
+++ b/src/app/infrastructure/services/vehicle/maintenance/maintenance.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { MaintenanceService } from './maintenance.service';
 
+import { providersDeTeste } from '../../../../../testing/test-setup';
+
 describe('MaintenanceService', () => {
   let service: MaintenanceService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(MaintenanceService);
   });
 

--- a/src/app/infrastructure/services/vehicle/vehicle.service.spec.ts
+++ b/src/app/infrastructure/services/vehicle/vehicle.service.spec.ts
@@ -2,11 +2,15 @@ import { TestBed } from '@angular/core/testing';
 
 import { VehicleService } from './vehicle.service';
 
+import { providersDeTeste } from '../../../../testing/test-setup';
+
 describe('VehicleService', () => {
   let service: VehicleService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: providersDeTeste(),
+    });
     service = TestBed.inject(VehicleService);
   });
 

--- a/src/app/layouts/auth-layout/auth-layout.component.spec.ts
+++ b/src/app/layouts/auth-layout/auth-layout.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AuthLayoutComponent } from './auth-layout.component';
 
+import { providersDeTeste } from '../../../testing/test-setup';
+
 describe('AuthLayoutComponent', () => {
   let component: AuthLayoutComponent;
   let fixture: ComponentFixture<AuthLayoutComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AuthLayoutComponent]
+      imports: [AuthLayoutComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/app/layouts/public-layout/public-layout.component.spec.ts
+++ b/src/app/layouts/public-layout/public-layout.component.spec.ts
@@ -2,13 +2,16 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PublicLayoutComponent } from './public-layout.component';
 
+import { providersDeTeste } from '../../../testing/test-setup';
+
 describe('PublicLayoutComponent', () => {
   let component: PublicLayoutComponent;
   let fixture: ComponentFixture<PublicLayoutComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PublicLayoutComponent]
+      imports: [PublicLayoutComponent],
+      providers: providersDeTeste()
     })
     .compileComponents();
     

--- a/src/testing/test-setup.ts
+++ b/src/testing/test-setup.ts
@@ -1,0 +1,46 @@
+import { EnvironmentProviders, Provider, provideZonelessChangeDetection } from '@angular/core';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { registerLocaleData } from '@angular/common';
+import localePt from '@angular/common/locales/pt';
+
+// Quem registra o pt-BR na aplicação é o `main.ts`, e teste nenhum roda o
+// `main.ts`. Sem isto, qualquer componente com `| date:'…':'pt-BR'` estoura em
+// NG0701 — e o erro fala de locale, não de configuração de teste, então quem
+// lê procura no lugar errado.
+registerLocaleData(localePt);
+
+/**
+ * O mínimo que um teste precisa para montar qualquer coisa deste app.
+ *
+ * Os stubs que o CLI gera vêm com `TestBed.configureTestingModule({})` vazio, e
+ * quase todo componente daqui injeta `HttpClient` direta ou indiretamente. O
+ * resultado eram **63 testes falhando desde sempre** com `NG0201` — e, pior que
+ * as 63 falhas, o ruído: um teste de verdade quebrava no meio delas e ninguém
+ * via.
+ *
+ * Estar num lugar só é o ponto. Colar a lista de providers em 63 arquivos
+ * garante que eles divirjam: daqui a três meses metade teria `provideRouter` e
+ * a outra metade não, e ninguém saberia qual está certo.
+ *
+ * **`provideHttpClientTesting` vem depois do `provideHttpClient`**, e a ordem
+ * não é estilo: o segundo substitui o backend real pelo de teste. Invertido,
+ * o teste faz requisição de verdade — que num CI sem rede vira timeout, e numa
+ * máquina com rede vira algo pior.
+ */
+export function providersDeTeste(
+  extras: (Provider | EnvironmentProviders)[] = [],
+): (Provider | EnvironmentProviders)[] {
+  return [
+    provideZonelessChangeDetection(),
+    provideNoopAnimations(),
+    provideHttpClient(),
+    provideHttpClientTesting(),
+    // Rotas vazias: quem precisa navegar de verdade declara as suas. O que isto
+    // resolve é o `ActivatedRoute` e o `Router` existirem.
+    provideRouter([]),
+    ...extras,
+  ];
+}


### PR DESCRIPTION
Eram os stubs que o CLI gera com TestBed vazio, e quase todo componente daqui
injeta HttpClient direta ou indiretamente: 51 morriam em NG0201 por isso, 9 por
ActivatedRoute e 3 por SwUpdate.

Pior que as 63 falhas era o ruido. `ng test` inteiro nao servia de portao — um
teste de verdade quebrava no meio delas e ninguem via. Foi assim durante meses.

Um preparo compartilhado em src/testing/test-setup.ts, e nao a lista colada em
63 arquivos: colada, eles divergem, e daqui a tres meses metade teria
provideRouter e a outra metade nao, sem ninguem saber qual esta certo.

O locale entrou nele tambem. Quem registra o pt-BR e o main.ts, e teste nenhum
roda o main.ts — sem isso, componente com `| date:…:'pt-BR'` estoura em NG0701,
e o erro fala de locale, nao de configuracao de teste.

Tres precisaram do proprio: o AppComponent quer SwUpdate, e o holerit-spliter
injeta MessageService SEM declarar — quem prove e o holerite-hub, que o
hospeda. Montado sozinho, ele nao existe.

E o "should render title" procurava `<h1>Hello, proauto-kimium</h1>`, o
template que o CLI gera e que foi apagado no primeiro dia. Nunca passou:
afirmava algo que nunca foi verdade. Virou o que vale verificar — a casca monta
com o router-outlet.

216 de 216.
