### PR TITLE
feat(hub): botao de atualizar no Hub das Maquinas

### DIFF
--- a/src/app/components/auth/stock/hub/machine-hub.component.html
+++ b/src/app/components/auth/stock/hub/machine-hub.component.html
@@ -5,6 +5,22 @@
     title="Hub das Máquinas"
     subtitle="Situação do parque e o que sai nos próximos dias"
     size="lg">
+
+    <!--
+      O Hub não recarrega sozinho: ele lê os stores uma vez, no `ngOnInit`.
+      Quem deixa a tela aberta enquanto outra pessoa mexe na Programação fica
+      olhando um número velho, e nada na tela diz isso.
+
+      `[pkLoading]` também desabilita o botão, então o clique repetido não
+      dispara quatro requisições por cima das quatro que ainda estão voltando.
+    -->
+    <div actions>
+      <pk-button pkType="refresh"
+                 pkLabel="Atualizar"
+                 pkSize="sm"
+                 [pkLoading]="loading() || loadingDivergences()"
+                 (clicked)="refresh()" />
+    </div>
   </app-page-header>
   <!--
     O alerta de atraso saiu daqui: ele virou a primeira linha de "Precisa de

--- a/src/app/components/auth/stock/hub/machine-hub.component.spec.ts
+++ b/src/app/components/auth/stock/hub/machine-hub.component.spec.ts
@@ -479,4 +479,34 @@ describe('MachineHubComponent · carga por consultor', () => {
     expect(component.isAligning(lavadora)).toBeFalse();
     expect(component.isAligning(capo)).toBeFalse();
   });
+
+  // ─── O botão de atualizar ─────────────────────────────────────────────────
+
+  /**
+   * **O Hub não recarrega sozinho.**
+   *
+   * Ele lê os stores uma vez, no `ngOnInit`. Quem deixa a tela aberta enquanto
+   * outra pessoa mexe na Programação fica olhando um número velho — e nada na
+   * tela diz isso.
+   */
+  it('o botão de atualizar recarrega as duas listas', () => {
+    spyOn(registerStore, 'refresh');
+
+    component.refresh();
+
+    expect(registerStore.refresh).toHaveBeenCalled();
+  });
+
+  /**
+   * E ele existe na tela.
+   *
+   * O método `refresh()` já estava escrito antes deste botão, e não era
+   * chamado de lugar nenhum: código vivo sem caminho até ele. Este teste é o
+   * que impede a ligação de se perder de novo.
+   */
+  it('o botão está no cabeçalho da tela', () => {
+    const botao = fixture.nativeElement.querySelector('[actions] pk-button');
+
+    expect(botao).not.toBeNull();
+  });
 });

--- a/src/app/components/auth/stock/hub/machine-hub.component.ts
+++ b/src/app/components/auth/stock/hub/machine-hub.component.ts
@@ -30,6 +30,7 @@ import {
   CalendarTone,
   PkCalendarComponent,
 } from '../../../theme/ProautoKimium/pk-calendar/pk-calendar.component';
+import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
 
 interface Slice {
   label: string;
@@ -102,7 +103,7 @@ interface Parada {
   standalone: true,
   imports: [
     CommonModule, RouterLink, PageHeaderComponent, PkDialogComponent, PkCalendarComponent,
-    ConfirmDialogModule, Toast,
+    PkButtonComponent, ConfirmDialogModule, Toast,
   ],
   providers: [ConfirmationService, MessageService],
   templateUrl: './machine-hub.component.html',


### PR DESCRIPTION
O metodo refresh() ja existia e nao era chamado de lugar nenhum — codigo vivo
sem caminho ate ele. Faltava so o botao.

O Hub le os stores uma vez, no ngOnInit. Quem deixa a tela aberta enquanto
outra pessoa mexe na Programacao fica olhando numero velho, e nada na tela diz
isso.

[pkLoading] tambem desabilita o botao: sem ele, o clique repetido dispara
quatro requisicoes por cima das quatro que ainda estao voltando.

E o slot [actions] do page-header, que existia e nunca tinha sido usado por
nenhuma tela — esta e a primeira.
