### PR TITLE
feat(estoque): cada status de maquina ganha cor e icone proprios

### DIFF
--- a/src/app/components/auth/stock/hub/machine-hub.component.scss
+++ b/src/app/components/auth/stock/hub/machine-hub.component.scss
@@ -170,6 +170,11 @@
     &--warning { background: var(--app-warning); }
     &--danger  { background: var(--app-danger); }
     &--action  { background: var(--app-action); }
+    // Os dois papéis novos do vocabulário de status. Sem eles, a barra de
+    // Reservada e a de Liberar equipamentos cairiam no `background` padrão e
+    // ficariam cinza — a colisão de cor voltaria por outra porta.
+    &--info    { background: var(--app-info); }
+    &--work    { background: var(--app-work); }
     &--neutral { background: var(--app-text-subtle); }
   }
 

--- a/src/app/components/auth/stock/programacao/programacao.component.html
+++ b/src/app/components/auth/stock/programacao/programacao.component.html
@@ -188,7 +188,7 @@
                   engano que a escolha obrigatória existe para impedir.
                 -->
                 @if (row.status) {
-                  <span [class]="statusClass(row.status)">{{ statusLabel(row.status) }}</span>
+                  <span [class]="statusClass(row.status)"><i [class]="statusIcon(row.status)" aria-hidden="true"></i>{{ statusLabel(row.status) }}</span>
                 } @else {
                   <span class="status-pick">Escolher status</span>
                 }

--- a/src/app/components/auth/stock/programacao/programacao.component.ts
+++ b/src/app/components/auth/stock/programacao/programacao.component.ts
@@ -16,6 +16,7 @@ import { Tooltip } from 'primeng/tooltip';
 
 import {
   MACHINE_STATUS_LABEL,
+  MACHINE_STATUS_ICON,
   MACHINE_STATUS_SEVERITY,
   MachineStatus,
   IN_STOCK_STATUSES,
@@ -504,6 +505,18 @@ export class ProgramacaoComponent implements OnInit {
 
   statusClass(status: MachineStatus): string {
     return `status-chip status-chip--${MACHINE_STATUS_SEVERITY[status] ?? 'neutral'}`;
+  }
+
+  /**
+   * O ícone do chip.
+   *
+   * Existe para o status não depender só da cor: em escala de cinza, ou para
+   * quem não distingue vermelho de verde, os seis chips ficariam parecidos
+   * demais. O `?? ''` cobre um status que a API passe a mandar antes de a tela
+   * conhecer — sem ícone é melhor que com o ícone errado.
+   */
+  statusIcon(status: MachineStatus): string {
+    return MACHINE_STATUS_ICON[status] ?? '';
   }
 
   stamp(value: string | null | undefined): string {

--- a/src/app/components/theme/ProautoKimium/pk-calendar/pk-calendar.component.scss
+++ b/src/app/components/theme/ProautoKimium/pk-calendar/pk-calendar.component.scss
@@ -176,7 +176,11 @@
   &--success { background: var(--app-success); }
   &--warning { background: var(--app-warning); }
   &--danger  { background: var(--app-danger); }
-  &--info    { background: var(--app-action); }
+  // Passou a apontar para `--app-info` quando o papel virou token próprio: o
+  // ponto e o chip do mesmo status precisam ser da mesma cor, senão o Hub
+  // contradiz a grade. Antes usava `--app-action`, que é a cor de clicar.
+  &--info    { background: var(--app-info); }
+  &--work    { background: var(--app-work); }
   &--neutral { background: var(--app-text-muted); }
   &--muted   { background: var(--app-text-subtle); }
 

--- a/src/app/domain/models/prostock/machine.model.spec.ts
+++ b/src/app/domain/models/prostock/machine.model.spec.ts
@@ -1,0 +1,101 @@
+import {
+  IN_STOCK_STATUSES,
+  MACHINE_STATUS_ICON,
+  MACHINE_STATUS_LABEL,
+  MACHINE_STATUS_SEVERITY,
+  MachineStatus,
+  OPEN_STATUSES,
+} from './machine.model';
+
+/**
+ * O vocabulário de status das máquinas.
+ *
+ * Não há componente aqui, e é de propósito: são tabelas de constantes, e o que
+ * elas erram não aparece em teste de tela. Um status sem cor própria desenha
+ * perfeitamente — só desenha **igual ao vizinho**, e ninguém percebe até alguém
+ * ler a grade errado por meses.
+ */
+describe('machine.model — vocabulário de status', () => {
+  const TODOS = Object.values(MachineStatus);
+
+  /**
+   * **O teste que existe por causa do defeito real.**
+   *
+   * Havia seis status e quatro papéis de cor, então três pares saíam idênticos:
+   * Entregue igual a Reservada, Reforma igual a Liberar equipamentos. Na tela,
+   * uma máquina que já foi embora era indistinguível de uma que está prometida.
+   *
+   * O compilador nunca reclamaria: repetir valor num `Record` é legal. Só uma
+   * afirmação sobre o CONJUNTO pega isso — e é o tipo de defeito que volta na
+   * primeira vez que alguém acrescentar um status sem pensar na cor.
+   */
+  it('cada status tem um papel de cor só dele', () => {
+    const papeis = TODOS.map(status => MACHINE_STATUS_SEVERITY[status]);
+
+    expect(new Set(papeis).size).toBe(TODOS.length);
+  });
+
+  /**
+   * O par do de cima, e ele importa tanto quanto.
+   *
+   * Sem ícone, os seis chips viram três tons em escala de cinza — é o que
+   * acontece com daltonismo vermelho-verde e em impressão preto e branco. Um
+   * ícone repetido devolve a ambiguidade que a cor acabou de resolver.
+   */
+  it('cada status tem um ícone só dele', () => {
+    const icones = TODOS.map(status => MACHINE_STATUS_ICON[status]);
+
+    expect(new Set(icones).size).toBe(TODOS.length);
+    expect(icones.every(icone => icone.startsWith('pi pi-'))).toBeTrue();
+  });
+
+  /**
+   * As três tabelas andam juntas. Acrescentar um status e esquecer uma delas
+   * dá `undefined` em runtime — chip sem texto, ou classe `status-chip--`
+   * pendurada em nada, que é exatamente o vazio que o tema reserva.
+   */
+  it('rótulo, cor e ícone cobrem todos os status', () => {
+    for (const status of TODOS) {
+      expect(MACHINE_STATUS_LABEL[status]).toBeTruthy();
+      expect(MACHINE_STATUS_SEVERITY[status]).toBeTruthy();
+      expect(MACHINE_STATUS_ICON[status]).toBeTruthy();
+    }
+  });
+
+  /**
+   * O papel tem que existir no `chips.scss`. A lista está escrita à mão aqui de
+   * propósito: é o contrato com o CSS, e o CSS não é tipado.
+   *
+   * Sem isto, `status-chip--roxo` compila, renderiza, e cai no vazio — o chip
+   * fica sem fundo e sem cor, e a tela não acusa nada.
+   */
+  it('todo papel usado existe como classe no tema', () => {
+    const noTema = ['success', 'info', 'warning', 'work', 'danger', 'neutral'];
+
+    for (const status of TODOS) {
+      expect(noTema).toContain(MACHINE_STATUS_SEVERITY[status]);
+    }
+  });
+
+  // ─── As listas de status, que decidem estoque ─────────────────────────────
+
+  /**
+   * `IN_STOCK_STATUSES` não é "≠ ENTREGUE".
+   *
+   * Aguardando aquisição e Liberar equipamentos estão abertas e **não** estão
+   * no galpão. Confundir as duas listas ofereceria para entregar uma máquina
+   * que ainda não chegou.
+   */
+  it('estar em aberto não é estar em estoque', () => {
+    expect(OPEN_STATUSES).toContain(MachineStatus.AGUARDANDO_AQUISICAO);
+    expect(IN_STOCK_STATUSES).not.toContain(MachineStatus.AGUARDANDO_AQUISICAO);
+
+    expect(OPEN_STATUSES).toContain(MachineStatus.LIBERAR_EQUIPAMENTOS);
+    expect(IN_STOCK_STATUSES).not.toContain(MachineStatus.LIBERAR_EQUIPAMENTOS);
+  });
+
+  /** Em reforma a máquina está fisicamente lá, mesmo sem poder ser vendida. */
+  it('reforma conta como estoque', () => {
+    expect(IN_STOCK_STATUSES).toContain(MachineStatus.REFORMA);
+  });
+});

--- a/src/app/domain/models/prostock/machine.model.ts
+++ b/src/app/domain/models/prostock/machine.model.ts
@@ -48,17 +48,55 @@ export const MACHINE_STATUS_LABEL: Record<MachineStatus, string> = {
   [MachineStatus.REFORMA]: 'Reforma',
 };
 
+export type StatusSeverity = 'success' | 'info' | 'warning' | 'work' | 'danger' | 'neutral';
+
 /**
- * Cor por PAPEL: disponível é bom, entregue é assunto encerrado, aguardando
- * aquisição está travado esperando terceiro, o resto pede ação nossa.
+ * Cor por PAPEL — **um papel por status, sem repetição**.
+ *
+ * Eram quatro papéis para seis status, e três pares saíam idênticos na tela:
+ * Entregue igual a Reservada, Reforma igual a Liberar equipamentos. Quem lia a
+ * grade não distinguia uma máquina que já foi de uma que está prometida.
+ *
+ * O critério é o que o status pede de quem olha:
+ *
+ * - `success` — está aqui e pode ser vendida. A única assim.
+ * - `info` — está aqui, mas com dono. Não é problema nem conclusão.
+ * - `warning` — está aqui e alguém trabalha nela agora.
+ * - `work` — trava interna, esperando ação NOSSA para liberar.
+ * - `danger` — nem foi comprada. É a única que promete o que não existe.
+ * - `neutral` — assunto encerrado; o que não pede nada recua na tela.
+ *
+ * Repetir papel aqui é o defeito de origem, e ele volta em silêncio: o
+ * compilador aceita, a tela desenha, e só quem usa percebe — meses depois.
  */
-export const MACHINE_STATUS_SEVERITY: Record<MachineStatus, 'success' | 'warning' | 'danger' | 'neutral'> = {
+export const MACHINE_STATUS_SEVERITY: Record<MachineStatus, StatusSeverity> = {
   [MachineStatus.DISPONIVEL]: 'success',
-  [MachineStatus.ENTREGUE]: 'neutral',
-  [MachineStatus.RESERVADA]: 'neutral',
-  [MachineStatus.AGUARDANDO_AQUISICAO]: 'danger',
-  [MachineStatus.LIBERAR_EQUIPAMENTOS]: 'warning',
+  [MachineStatus.RESERVADA]: 'info',
   [MachineStatus.REFORMA]: 'warning',
+  [MachineStatus.LIBERAR_EQUIPAMENTOS]: 'work',
+  [MachineStatus.AGUARDANDO_AQUISICAO]: 'danger',
+  [MachineStatus.ENTREGUE]: 'neutral',
+};
+
+/**
+ * O ícone que acompanha a cor.
+ *
+ * **Não é enfeite: é o que faz o status sobreviver sem cor.** Seis cores viram
+ * três tons em escala de cinza, que é o que acontece com daltonismo
+ * vermelho-verde — cerca de 8% dos homens — e em qualquer impressão em preto e
+ * branco. Com o ícone, a informação não depende de enxergar a diferença entre
+ * âmbar e violeta.
+ *
+ * A classe `.status-chip` já reservava espaço para ele em `chips.scss`; nenhuma
+ * tela usava.
+ */
+export const MACHINE_STATUS_ICON: Record<MachineStatus, string> = {
+  [MachineStatus.DISPONIVEL]: 'pi pi-check-circle',
+  [MachineStatus.RESERVADA]: 'pi pi-bookmark-fill',
+  [MachineStatus.REFORMA]: 'pi pi-wrench',
+  [MachineStatus.LIBERAR_EQUIPAMENTOS]: 'pi pi-flag',
+  [MachineStatus.AGUARDANDO_AQUISICAO]: 'pi pi-shopping-cart',
+  [MachineStatus.ENTREGUE]: 'pi pi-truck',
 };
 
 /**

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -57,6 +57,22 @@
   --app-success-soft: rgba(87, 193, 171, 0.16);
   --app-warning:      #b7791f;
   --app-warning-soft: rgba(246, 173, 85, 0.20);
+
+  // `info` e `work` nasceram da programação de máquinas, onde seis status
+  // dividiam quatro papéis e três pares saíam com a mesma cor — Entregue igual
+  // a Reservada, Reforma igual a Liberar equipamentos.
+  //
+  // São PAPÉIS e não cores: `info` é o que está resolvido mas ainda não é
+  // conclusão (uma máquina reservada não é problema nem fim de assunto);
+  // `work` é o que espera ação NOSSA, distinto de `warning`, que é algo em
+  // andamento, e de `danger`, que é bloqueio de terceiro.
+  //
+  // O azul é deliberadamente diferente de `--app-action`: ação é o que se
+  // clica, e um chip de status não se clica.
+  --app-info:         #2c6fb5;
+  --app-info-soft:    rgba(44, 111, 181, 0.13);
+  --app-work:         #7a5bbd;
+  --app-work-soft:    rgba(122, 91, 189, 0.14);
   --app-danger:       #{v.$danger};
   --app-danger-soft:  rgba(229, 62, 62, 0.12);
 
@@ -129,6 +145,13 @@
   --app-success-soft: rgba(87, 193, 171, 0.18);
   --app-warning:      #e0a44a;
   --app-warning-soft: rgba(224, 164, 74, 0.18);
+
+  // Azul e violeta escurecem mal sobre fundo azul-noite: no escuro entram mais
+  // claros que no claro, para manter contraste com a superfície.
+  --app-info:         #6ba7e8;
+  --app-info-soft:    rgba(107, 167, 232, 0.16);
+  --app-work:         #a98ce0;
+  --app-work-soft:    rgba(169, 140, 224, 0.16);
   --app-danger:       #f87171;
   --app-danger-soft:  rgba(248, 113, 113, 0.16);
 

--- a/src/styles/chips.scss
+++ b/src/styles/chips.scss
@@ -43,6 +43,19 @@
     color: var(--app-danger);
   }
 
+  // Reservado, prometido, em andamento — resolvido, mas não encerrado.
+  &--info {
+    background: var(--app-info-soft);
+    color: var(--app-info);
+  }
+
+  // Espera ação NOSSA. Diferente de `warning`, que é algo já em andamento, e de
+  // `danger`, que é bloqueio de terceiro.
+  &--work {
+    background: var(--app-work-soft);
+    color: var(--app-work);
+  }
+
   &--neutral {
     background: var(--app-surface-3);
     color: var(--app-text-muted);


### PR DESCRIPTION
Eram seis status para quatro papeis de cor, e tres pares saiam identicos na
tela: Entregue igual a Reservada, Reforma igual a Liberar equipamentos. Quem lia
a grade nao distinguia uma maquina que ja foi de uma que esta prometida.

Dois papeis novos no tema, e sao PAPEIS e nao cores. `info` e o que esta
resolvido mas nao encerrado — uma maquina reservada nao e problema nem fim de
assunto. `work` e o que espera acao NOSSA, distinto de `warning`, que e algo ja
em andamento, e de `danger`, que e bloqueio de terceiro.

O azul de `info` e deliberadamente diferente de `--app-action`: acao e o que se
clica, e chip de status nao se clica.

O icone nao e enfeite. Seis cores viram tres tons em escala de cinza, que e o
que acontece com daltonismo vermelho-verde e em qualquer impressao preto e
branco — com o icone a informacao para de depender de distinguir ambar de
violeta. A classe .status-chip ja reservava espaco para um e nenhuma tela usava.

O papel novo teve que entrar em tres lugares alem do chip: a barra do Hub e o
ponto do calendario tambem sao pintados por severidade, e sem os modificadores
`--info` e `--work` cairiam no padrao cinza — a colisao voltaria por outra
porta. O ponto `cal__dot--info` passou de `--app-action` para `--app-info` pelo
mesmo motivo: ponto e chip do mesmo status precisam ser da mesma cor, ou o Hub
contradiz a grade.

O teste mora no modelo e nao na tela, porque o defeito nao aparece em teste de
componente: um status sem cor propria desenha perfeitamente, so desenha igual ao
vizinho. Afirmar sobre o CONJUNTO — seis papeis distintos, seis icones
distintos — e o unico jeito de pegar. Conferido devolvendo cada defeito: com
Reservada de volta em neutral, uma falha; com dois status dividindo icone,
outra.
