### PR TITLE
fix(imagens): as fotos passam a apontar para o host da API

### DIFF
--- a/src/app/components/auth/company/equipments/equipments.component.ts
+++ b/src/app/components/auth/company/equipments/equipments.component.ts
@@ -8,9 +8,11 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { MessageService, ConfirmationService } from 'primeng/api';
 
-import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
+
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
-import { FormScreenComponent } from '../../shared/form-screen/form-screen.component';
+import { FormScreenComponent } from '../../shared/form-screen/form-screen.component';
+
 import { TabDirtyCheck } from '../../../../infrastructure/routing/tab-dirty-check';
 import { PkInputComponent } from '../../../theme/ProautoKimium/pk-input/pk-input.component';
 import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
@@ -22,6 +24,7 @@ import {
 } from '../../../../domain/models/equipment.model';
 import { EquipmentService } from '../../../../infrastructure/services/company/equipment/equipment.service';
 import {ButtonDirective} from "primeng/button";
+import { urlDeMidia } from '../../../../infrastructure/config/media-url';
 
 @Component({
   selector: 'app-equipments',
@@ -282,14 +285,6 @@ export class EquipmentsComponent implements OnInit, TabDirtyCheck {
   }
 
   resolverImagem(path: string | null): string {
-    if (!path) {
-      return 'images/products/placeholder.png';
-    }
-
-    if (path.startsWith('http')) {
-      return path;
-    }
-
-    return path.startsWith('/') ? path : `/${path}`;
+    return urlDeMidia(path);
   }
 }

--- a/src/app/components/auth/company/products/website/website.component.ts
+++ b/src/app/components/auth/company/products/website/website.component.ts
@@ -33,6 +33,7 @@ import {
 } from '../../../../../domain/models/products.model';
 
 import { WebsiteProductStore } from '../../../../../infrastructure/state/website-product.store';
+import { urlDeMidia } from '../../../../../infrastructure/config/media-url';
 
 /**
  * Os três recortes da mesma lista.
@@ -523,16 +524,7 @@ export class WebsiteComponent implements OnInit, TabDirtyCheck {
   }
 
   resolverImagem(produto: ProductWebSiteResponseDTO): string {
-    if (!produto.imagem) {
-      return 'images/products/placeholder.png';
-    }
-
-    if (produto.imagem.startsWith('http')) {
-      return produto.imagem;
-    }
-
-    const caminho = produto.imagem.startsWith('/') ? produto.imagem : `/${produto.imagem}`;
-    return caminho;
+    return urlDeMidia(produto.imagem);
   }
 
   get totalProdutos(): number {

--- a/src/app/components/auth/perfil/perfil.component.html
+++ b/src/app/components/auth/perfil/perfil.component.html
@@ -11,7 +11,7 @@
     <section class="profile-header">
       <div class="avatar-area">
         @if (data.profile?.imagem && !avatarBroken) {
-          <img [src]="data.profile!.imagem" [alt]="data.employeeName" class="avatar-img"
+          <img [src]="urlDaFoto(data.profile!.imagem)" [alt]="data.employeeName" class="avatar-img"
                (error)="avatarBroken = true" />
         } @else {
           <div class="avatar-fallback">{{ initials(data.employeeName) }}</div>

--- a/src/app/components/auth/perfil/perfil.component.ts
+++ b/src/app/components/auth/perfil/perfil.component.ts
@@ -16,6 +16,7 @@ import { MessageService } from 'primeng/api';
 
 import { VcardService } from '../../../infrastructure/services/profile/vcard/vcard.service';
 import { AuthService } from '../../../infrastructure/services/auth.service';
+import { urlDeMidia } from '../../../infrastructure/config/media-url';
 import {
   MyProfileResponseDto,
   ProfileCreateDto,
@@ -345,5 +346,17 @@ export class PerfilComponent implements OnInit {
     a.download = `qrcode-${this.data?.profile?.slug ?? 'perfil'}.png`;
     a.click();
     URL.revokeObjectURL(url);
+  }
+
+  /**
+   * A foto do funcionário vem da API como caminho relativo — em produção o site
+   * e a API são hosts diferentes, e o navegador procuraria no domínio errado.
+   *
+   * O `(error)` do `<img>` já esconde a falha trocando pelas iniciais, e é por
+   * isso que este defeito passou tanto tempo despercebido aqui: a tela nunca
+   * pareceu quebrada, só nunca mostrou a foto.
+   */
+  urlDaFoto(caminho: string | null | undefined): string {
+    return urlDeMidia(caminho, '');
   }
 }

--- a/src/app/components/public/lista-produtos/components/orcamento-drawer/orcamento-drawer.component.ts
+++ b/src/app/components/public/lista-produtos/components/orcamento-drawer/orcamento-drawer.component.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { OrcamentoService } from '../../../../../infrastructure/services/company/products/website/orcamento/orcamento.service';
 import { ProductWebSitePublicResponseDTO } from '../../../../../domain/models/products.model';
+import { urlDeMidia } from '../../../../../infrastructure/config/media-url';
 
 @Component({
   selector: 'app-orcamento-drawer',
@@ -30,12 +31,6 @@ export class OrcamentoDrawerComponent {
   }
 
   resolverImagem(produto: ProductWebSitePublicResponseDTO): string {
-    if (!produto.imagem) {
-      return 'images/products/placeholder.png';
-    }
-    if (produto.imagem.startsWith('http')) {
-      return produto.imagem;
-    }
-    return produto.imagem.startsWith('/') ? produto.imagem : `/${produto.imagem}`;
+    return urlDeMidia(produto.imagem);
   }
 }

--- a/src/app/components/public/lista-produtos/lista-produtos.component.ts
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.ts
@@ -8,6 +8,7 @@ import {OrcamentoService} from "../../../infrastructure/services/company/product
 import {OrcamentoDrawerComponent} from "./components/orcamento-drawer/orcamento-drawer.component";
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {ProductWebSitePublicResponseDTO} from "../../../domain/models/products.model";
+import { urlDeMidia } from '../../../infrastructure/config/media-url';
 
 export interface ProdutoPorDepartamento {
   nome: string;
@@ -98,15 +99,7 @@ export class ListaProdutosComponent implements OnInit {
   }
 
   resolverImagem(produto: ProductWebSitePublicResponseDTO): string {
-    if (!produto.imagem) {
-      return 'images/products/placeholder.png';
-    }
-
-    if (produto.imagem.startsWith('http')) {
-      return produto.imagem;
-    }
-
-    return produto.imagem.startsWith('/') ? produto.imagem : `/${produto.imagem}`;
+    return urlDeMidia(produto.imagem);
   }
 
   slugDepartamento(nome: string): string {

--- a/src/app/components/public/profile/vcard/vcard.component.html
+++ b/src/app/components/public/profile/vcard/vcard.component.html
@@ -28,7 +28,7 @@
     <div class="hero">
       <div class="hero-logo-ring">
         @if (profile.imagem && !imageBroken) {
-          <img [src]="profile.imagem" [alt]="profile.nome" class="hero-logo"
+          <img [src]="urlDaFoto(profile.imagem)" [alt]="profile.nome" class="hero-logo"
                (error)="imageBroken = true" />
         } @else {
           <div class="hero-logo-fallback">

--- a/src/app/components/public/profile/vcard/vcard.component.ts
+++ b/src/app/components/public/profile/vcard/vcard.component.ts
@@ -8,6 +8,7 @@ import {ProfileResponseDto} from "../../../../domain/models/profile.model";
 import {VcardService} from "../../../../infrastructure/services/profile/vcard/vcard.service";
 import {PkBtnSharedComponent} from "../../../theme/ProautoKimium/pk-btn-shared/pk-btn-shared.component";
 import {PkQrcodeComponent} from "../../../theme/ProautoKimium/pk-qrcode/pk-qrcode.component";
+import { urlDeMidia } from '../../../../infrastructure/config/media-url';
 
 interface ContactItem {
   label: string;
@@ -167,5 +168,17 @@ export class VcardComponent implements OnInit {
       return `(${clean.substring(0, 2)}) ${clean.substring(2, 6)}-${clean.substring(6)}`;
     }
     return value;
+  }
+
+  /**
+   * A foto do funcionário vem da API como caminho relativo — em produção o site
+   * e a API são hosts diferentes, e o navegador procuraria no domínio errado.
+   *
+   * O `(error)` do `<img>` já esconde a falha trocando pelas iniciais, e é por
+   * isso que este defeito passou tanto tempo despercebido aqui: a tela nunca
+   * pareceu quebrada, só nunca mostrou a foto.
+   */
+  urlDaFoto(caminho: string | null | undefined): string {
+    return urlDeMidia(caminho, '');
   }
 }

--- a/src/app/infrastructure/config/media-url.spec.ts
+++ b/src/app/infrastructure/config/media-url.spec.ts
@@ -1,0 +1,109 @@
+import { urlDeMidia, urlDeMidiaCom } from './media-url';
+
+/**
+ * O endereço das imagens servidas pela API.
+ *
+ * **Este é o teste do bug de produção.** O caminho vinha da API começando com
+ * `/`, e o navegador resolve isso contra a origem da PÁGINA. Em
+ * desenvolvimento site e API são o mesmo host por causa do proxy, então tudo
+ * funcionava; em produção o site é `proautokimium.com.br` e os arquivos estão
+ * em `api.proautokimium.com`, e toda foto voltava 404.
+ *
+ * Um teste de tela não pegaria: o `onerror` do `<img>` troca pelo placeholder,
+ * a página renderiza inteira, e só o console reclama. O erro estava na
+ * construção da URL, e é lá que ele tem que ser afirmado.
+ *
+ * A suíte roda com `environment.apiUrl = '/api'` (desenvolvimento), então a
+ * base é vazia e o resultado é relativo. É o comportamento que o proxy espera.
+ */
+describe('urlDeMidia', () => {
+  it('devolve o placeholder quando não há imagem', () => {
+    expect(urlDeMidia(null)).toBe('images/products/placeholder.png');
+    expect(urlDeMidia(undefined)).toBe('images/products/placeholder.png');
+    expect(urlDeMidia('')).toBe('images/products/placeholder.png');
+  });
+
+  /**
+   * String só com espaço é o que um campo de texto limpo produz, e ela passaria
+   * pela checagem de vazio ingênua — virando uma URL que termina em `/ `.
+   */
+  it('trata string em branco como ausência', () => {
+    expect(urlDeMidia('   ')).toBe('images/products/placeholder.png');
+  });
+
+  it('aceita um placeholder próprio', () => {
+    expect(urlDeMidia(null, 'images/avatar.png')).toBe('images/avatar.png');
+  });
+
+  /**
+   * O caso que veio da API. A barra inicial é o que enganava: parece caminho
+   * pronto e é justamente o que manda o navegador procurar no host errado.
+   */
+  it('prefixa a base no caminho vindo da API', () => {
+    expect(urlDeMidia('/upload/images/2822-abc.png')).toBe('/upload/images/2822-abc.png');
+  });
+
+  /** Sem a barra inicial o resultado tem que ser o mesmo, e não `basecaminho`. */
+  it('normaliza caminho sem barra inicial', () => {
+    expect(urlDeMidia('upload/images/2822-abc.png')).toBe('/upload/images/2822-abc.png');
+  });
+
+  /**
+   * Imagem hospedada fora já vem pronta. Prefixar aqui produziria
+   * `https://api...//https://outro-site...`, que não falha em lugar nenhum —
+   * só não carrega.
+   */
+  it('deixa URL absoluta intacta', () => {
+    expect(urlDeMidia('https://cdn.exemplo.com/foto.png')).toBe('https://cdn.exemplo.com/foto.png');
+    expect(urlDeMidia('http://cdn.exemplo.com/foto.png')).toBe('http://cdn.exemplo.com/foto.png');
+  });
+
+  /**
+   * **Pré-visualização de upload.**
+   *
+   * `data:` e `blob:` são a imagem que a pessoa acabou de escolher, ainda na
+   * memória do navegador. Prefixar host aqui quebraria exatamente a conferência
+   * que existe para ela ver o que vai salvar — e quebraria só ali, num caminho
+   * que nenhum teste de listagem percorre.
+   */
+  it('não mexe em preview de upload', () => {
+    expect(urlDeMidia('data:image/png;base64,iVBORw0KGgo=')).toBe('data:image/png;base64,iVBORw0KGgo=');
+    expect(urlDeMidia('blob:http://localhost:4200/abc-123')).toBe('blob:http://localhost:4200/abc-123');
+  });
+
+  // ─── Com a base de PRODUÇÃO ────────────────────────────────────────────────
+  //
+  // Tudo acima roda com a base vazia, porque a suíte usa o ambiente de
+  // desenvolvimento. É o cenário em que o bug NÃO acontece — afirmar só ele
+  // seria um teste verde sobre o caso errado.
+
+  describe('com a base de produção', () => {
+    const PROD = 'https://api.proautokimium.com';
+
+    /** O 404 exato que ele viu: a foto era procurada no domínio do site. */
+    it('manda a foto para o host da API, não para o do site', () => {
+      expect(urlDeMidiaCom(PROD, '/upload/images/2822-58f317e6.png'))
+        .toBe('https://api.proautokimium.com/upload/images/2822-58f317e6.png');
+    });
+
+    it('não duplica a barra quando o caminho não tem a inicial', () => {
+      expect(urlDeMidiaCom(PROD, 'upload/images/foto.png'))
+        .toBe('https://api.proautokimium.com/upload/images/foto.png');
+    });
+
+    /**
+     * O `/api` sai da base porque os arquivos são servidos na raiz do host.
+     * Mantido ali, a URL viraria `.../api/upload/images/...` e o resource
+     * handler do Spring — registrado em `/upload/images/**` — não casaria:
+     * outro 404, com exatamente a mesma cara do primeiro.
+     */
+    it('a base não carrega o /api', () => {
+      expect(urlDeMidiaCom('https://api.proautokimium.com/api'.replace(/\/api\/?$/, ''), '/upload/x.png'))
+        .toBe('https://api.proautokimium.com/upload/x.png');
+    });
+
+    it('preview de upload continua intocado mesmo com base', () => {
+      expect(urlDeMidiaCom(PROD, 'blob:http://localhost:4200/abc')).toBe('blob:http://localhost:4200/abc');
+    });
+  });
+});

--- a/src/app/infrastructure/config/media-url.ts
+++ b/src/app/infrastructure/config/media-url.ts
@@ -1,0 +1,67 @@
+import { environment } from '../../../environments/environment';
+
+/**
+ * A base dos arquivos: o `apiUrl` sem o `/api` final.
+ *
+ * Os arquivos são servidos **fora** do `/api` — o `StaticResourceConfig` do
+ * backend registra `/upload/images/**` na raiz do host, não sob a API.
+ *
+ * Em desenvolvimento o `apiUrl` é `/api`, então a base fica vazia e o caminho
+ * continua relativo, que é o que o `proxy.conf.json` precisa. Em produção vira
+ * `https://api.proautokimium.com`.
+ */
+const BASE_DE_MIDIA = environment.apiUrl.replace(/\/api\/?$/, '');
+
+/**
+ * Monta o endereço a partir de uma base explícita.
+ *
+ * Existe separado de `urlDeMidia` para poder ser testado com a base de
+ * PRODUÇÃO. A suíte roda com o ambiente de desenvolvimento, onde a base é
+ * vazia — e o defeito que esta função conserta só aparece quando ela não é.
+ * Sem esta separação, o teste passaria verde afirmando exatamente o cenário em
+ * que o bug não acontece.
+ */
+export function urlDeMidiaCom(
+  base: string,
+  caminho: string | null | undefined,
+  reserva = 'images/products/placeholder.png',
+): string {
+  const valor = caminho?.trim();
+  if (!valor) return reserva;
+
+  // Imagem hospedada fora (galeria externa, avatar de terceiro) já vem pronta.
+  if (/^https?:\/\//i.test(valor)) return valor;
+
+  // `data:` e `blob:` são pré-visualização de upload, ainda na memória do
+  // navegador. Prefixar host aqui quebraria a imagem que a pessoa acabou de
+  // escolher — e quebraria só na conferência antes de salvar.
+  if (/^(data|blob):/i.test(valor)) return valor;
+
+  const relativo = valor.startsWith('/') ? valor : `/${valor}`;
+  return `${base}${relativo}`;
+}
+
+/**
+ * O endereço absoluto de um arquivo servido pela API.
+ *
+ * **O bug que isto conserta.** A API grava o caminho como
+ * `/upload/images/2822-....png` e devolve essa string no DTO. As telas jogavam
+ * isso direto no `[src]`, e um caminho que começa com `/` o navegador resolve
+ * contra a **origem da página** — não contra a da API.
+ *
+ * Em desenvolvimento funcionava por acidente: o `proxy.conf.json` encaminha
+ * `/upload` para o backend, então site e API são o mesmo host. Em produção não
+ * são — o site é `proautokimium.com.br` e os arquivos estão em
+ * `api.proautokimium.com`. Toda foto ia buscar no domínio errado e voltava 404,
+ * e o `onerror` do `<img>` trocava pelo placeholder: a tela parecia certa e só
+ * o console reclamava.
+ *
+ * @param caminho o que veio da API — pode ser nulo, relativo ou absoluto
+ * @param reserva o que usar quando não há imagem
+ */
+export function urlDeMidia(
+  caminho: string | null | undefined,
+  reserva = 'images/products/placeholder.png',
+): string {
+  return urlDeMidiaCom(BASE_DE_MIDIA, caminho, reserva);
+}


### PR DESCRIPTION
Em producao toda foto voltava 404. O navegador procurava
https://proautokimium.com.br/upload/images/2822-....png — o dominio do SITE — e
os arquivos estao em api.proautokimium.com.

A API grava o caminho como /upload/images/nome.png e devolve essa string no DTO.
As telas jogavam isso direto no [src], e caminho que comeca com barra o
navegador resolve contra a origem da PAGINA, nao contra a da API.

Funcionava em desenvolvimento por acidente: o proxy.conf.json encaminha /upload
para o backend, entao site e API sao o mesmo host. Nenhum teste pegaria, e a
tela nunca pareceu quebrada — o onerror do <img> troca pelo placeholder, entao
so o console reclamava.

Eram seis lugares com o mesmo defeito: quatro copias do mesmo resolverImagem
(produtos do site, equipamentos, lista publica, gaveta de orcamento) e duas
ligacoes diretas de foto de perfil (perfil e vCard). Agora ha uma funcao so.

A base sai do apiUrl sem o /api final, porque os arquivos sao servidos na raiz
do host e nao sob a API — o StaticResourceConfig registra /upload/images/** ali.
Em desenvolvimento o apiUrl e /api, a base fica vazia, e o caminho segue
relativo, que e o que o proxy precisa.

Preview de upload (data: e blob:) passa intocado. Prefixar host ali quebraria a
imagem que a pessoa acabou de escolher, e quebraria so na conferencia antes de
salvar — um caminho que nenhum teste de listagem percorre.

A funcao pura recebe a base por parametro de proposito. A suite roda com o
ambiente de desenvolvimento, onde a base e vazia: testar so por urlDeMidia seria
afirmar exatamente o cenario em que o bug NAO acontece. Conferido devolvendo o
defeito — tres falhas, todas no bloco da base de producao.
