### PR TITLE
feat(orcamento): pede CPF ou CNPJ antes de mandar pelo WhatsApp

### DIFF
--- a/src/app/components/public/lista-produtos/lista-produtos.component.html
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.html
@@ -325,6 +325,30 @@
               }
             </div>
 
+            <div class="form-group" [class.is-invalid]="orcamento.isInvalid('documento')">
+              <label for="documento">CPF ou CNPJ</label>
+              <!--
+                Sem `formControlName`: o valor visível é a máscara e o guardado
+                são só os dígitos, como já acontece no telefone logo acima.
+
+                `inputmode="numeric"` abre o teclado de números no celular sem
+                virar `type="number"` — que traria setinhas de incremento e
+                comeria o zero à esquerda.
+              -->
+              <input
+                id="documento"
+                type="text"
+                inputmode="numeric"
+                autocomplete="off"
+                maxlength="18"
+                placeholder="000.000.000-00 ou 00.000.000/0000-00"
+                (input)="onDocumentoInput($event)"
+              />
+              @if (orcamento.isInvalid('documento')) {
+                <span class="field-error">Informe um CPF ou CNPJ válido.</span>
+              }
+            </div>
+
             <div class="form-group" [class.is-invalid]="orcamento.isInvalid('segmento')">
               <label for="segmento">Segmento</label>
               <input id="segmento" type="text" formControlName="segmento" placeholder="Seu segmento, ex: Alimentos, Restaurantes, Automotivo..." />

--- a/src/app/components/public/lista-produtos/lista-produtos.component.ts
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.ts
@@ -9,6 +9,7 @@ import {OrcamentoDrawerComponent} from "./components/orcamento-drawer/orcamento-
 import {FormsModule, ReactiveFormsModule} from "@angular/forms";
 import {ProductWebSitePublicResponseDTO} from "../../../domain/models/products.model";
 import { urlDeMidia } from '../../../infrastructure/config/media-url';
+import { apenasDigitos, formatarDocumento } from '../../../infrastructure/validators/documento-br';
 
 export interface ProdutoPorDepartamento {
   nome: string;
@@ -129,5 +130,24 @@ export class ListaProdutosComponent implements OnInit {
 
     input.value = masked;
     this.orcamento.form.get('telefone')?.setValue(digits, { emitEvent: false });
+  }
+
+  /**
+   * Máscara de CPF/CNPJ, no mesmo desenho da do telefone.
+   *
+   * O visível é formatado e o guardado são só os dígitos: o formulário nunca vê
+   * ponto nem barra, então o validador não precisa limpar nada e a mensagem
+   * decide o formato na hora de escrever.
+   *
+   * `setValue` com `emitEvent: false` para a máscara não disparar a validação a
+   * cada tecla — quem digita um CPF veria "documento inválido" nos dez
+   * primeiros dígitos, e o erro certo só aparece quando o campo perde o foco.
+   */
+  onDocumentoInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const digits = apenasDigitos(input.value);
+
+    input.value = formatarDocumento(digits);
+    this.orcamento.form.get('documento')?.setValue(digits, { emitEvent: false });
   }
 }

--- a/src/app/infrastructure/services/company/products/website/orcamento/orcamento.service.spec.ts
+++ b/src/app/infrastructure/services/company/products/website/orcamento/orcamento.service.spec.ts
@@ -15,4 +15,79 @@ describe('OrcamentoService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  // ─── CPF/CNPJ ──────────────────────────────────────────────────────────────
+
+  const CPF = '52998224725';
+
+  const preencher = (extra: Record<string, string> = {}) => {
+    service.form.patchValue({
+      nome: 'Transportadora Beta',
+      email: 'compras@beta.com.br',
+      telefone: '11999998888',
+      documento: CPF,
+      segmento: 'Transporte',
+      ...extra,
+    });
+  };
+
+  /**
+   * **O campo é obrigatório**, e é o pedido que originou tudo isto: o orçamento
+   * abre o WhatsApp do comercial, e do outro lado alguém precisa saber para quem
+   * está cotando.
+   */
+  it('o formulário não fica válido sem documento', () => {
+    preencher({ documento: '' });
+
+    expect(service.form.valid).toBeFalse();
+    expect(service.form.get('documento')!.hasError('required')).toBeTrue();
+  });
+
+  /**
+   * **Onze dígitos não são um CPF.**
+   *
+   * Sem conferir dígito verificador, o campo obrigatório só ensina a digitar
+   * `11111111111` para passar da tela — e o comercial recebe um cadastro que
+   * não existe.
+   */
+  it('documento com formato certo e dígito errado não passa', () => {
+    preencher({ documento: '11111111111' });
+
+    expect(service.form.valid).toBeFalse();
+    expect(service.form.get('documento')!.hasError('documentoBr')).toBeTrue();
+  });
+
+  it('CPF e CNPJ válidos passam', () => {
+    preencher({ documento: CPF });
+    expect(service.form.valid).toBeTrue();
+
+    preencher({ documento: '11222333000181' });
+    expect(service.form.valid).toBeTrue();
+  });
+
+  /**
+   * A mensagem leva o documento FORMATADO, embora o formulário guarde só os
+   * dígitos: quem lê é uma pessoa no WhatsApp, e catorze números seguidos não se
+   * conferem de olho.
+   */
+  it('o texto do WhatsApp mostra o documento com máscara', () => {
+    const texto = decodeURIComponent(
+      service.gerarTextoWhatsApp('Beta', '11999998888', 'a@b.com', 'Transporte', CPF)
+    );
+
+    expect(texto).toContain('*CPF/CNPJ:* 529.982.247-25');
+  });
+
+  /**
+   * O envio não pode acontecer com o formulário inválido — é o que impede um
+   * orçamento sem identificação de chegar ao comercial.
+   */
+  it('não abre o WhatsApp com o formulário incompleto', () => {
+    const abrir = spyOn(window, 'open').and.stub();
+    preencher({ documento: '' });
+
+    service.enviarWhatsApp();
+
+    expect(abrir).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/infrastructure/services/company/products/website/orcamento/orcamento.service.ts
+++ b/src/app/infrastructure/services/company/products/website/orcamento/orcamento.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, signal, computed, inject } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { ProductWebSitePublicResponseDTO } from '../../../../../../domain/models/products.model';
+import { documentoBr, formatarDocumento } from '../../../../../validators/documento-br';
 
 export interface ItemOrcamento {
   produto: ProductWebSitePublicResponseDTO;
@@ -30,6 +31,15 @@ export class OrcamentoService {
     nome:      ['', [Validators.required, Validators.minLength(2)]],
     email:     ['', [Validators.required, Validators.email]],
     telefone:  ['', Validators.required],
+
+    // CPF ou CNPJ, num campo só: a contagem de dígitos decide qual dos dois é,
+    // e ninguém precisa escolher antes de digitar.
+    //
+    // O `documentoBr` confere dígito verificador, e não só o tamanho. O que sai
+    // daqui abre o WhatsApp do comercial e vira cadastro de cliente do outro
+    // lado — `111.111.111-11` tem onze dígitos e não é documento de ninguém.
+    documento: ['', [Validators.required, documentoBr]],
+
     segmento:  ['', Validators.required],
     mensagem:  [''],
   });
@@ -71,8 +81,8 @@ export class OrcamentoService {
       this.form.markAllAsTouched();
       return;
     }
-    const { nome, telefone, email, segmento} = this.form.value;
-    const texto = this.gerarTextoWhatsApp(nome!, telefone!, email!, segmento!);
+    const { nome, telefone, email, segmento, documento } = this.form.value;
+    const texto = this.gerarTextoWhatsApp(nome!, telefone!, email!, segmento!, documento!);
     window.open(`https://wa.me/${this.WHATSAPP_NUMBER}?text=${texto}`, '_blank');
     this.finalizarEnvio();
   }
@@ -82,7 +92,7 @@ export class OrcamentoService {
       this.form.markAllAsTouched();
       return;
     }
-    const { nome, email, telefone, mensagem, segmento } = this.form.value;
+    const { nome, email, telefone, mensagem, segmento, documento } = this.form.value;
 
     const linhasProdutos = this._itens()
       .map(i => `- ${i.produto.name} (${i.produto.systemCode}) — Qtd: ${i.quantidade}`)
@@ -90,7 +100,9 @@ export class OrcamentoService {
 
     const assunto = encodeURIComponent('Solicitação de Orçamento');
     const corpo = encodeURIComponent(
-      `Nome: ${nome}\nTelefone: ${telefone}\nE-mail: ${email}\nSegmento: ${segmento}\nMensagem: ${mensagem ?? ''}\n\nProdutos:\n`
+      `Nome: ${nome}\nTelefone: ${telefone}\nE-mail: ${email}\n` +
+      `CPF/CNPJ: ${formatarDocumento(documento ?? '')}\n` +
+      `Segmento: ${segmento}\nMensagem: ${mensagem ?? ''}\n\nProdutos:\n`
     ) + linhasProdutos;
 
     window.open(`mailto:seuemail@empresa.com.br?subject=${assunto}&body=${corpo}`, '_blank');
@@ -145,7 +157,7 @@ export class OrcamentoService {
 
   // ── WhatsApp ──────────────────────────────────────────────────────────────
 
-  gerarTextoWhatsApp(nome: string, telefone: string, email : string, segmento : string): string {
+  gerarTextoWhatsApp(nome: string, telefone: string, email : string, segmento : string, documento : string): string {
     const linhas = this._itens().map(i =>
       `• ${i.produto.name} (${i.produto.systemCode}) — Qtd: ${i.quantidade}`
     );
@@ -154,6 +166,9 @@ export class OrcamentoService {
       `*Nome:* ${nome}\n` +
       `*Telefone:* ${telefone}\n` +
       `*Email:* ${email}\n` +
+      // Formatado, e não os dígitos crus guardados no formulário: quem lê é uma
+      // pessoa no WhatsApp, e catorze números seguidos não se conferem de olho.
+      `*CPF/CNPJ:* ${formatarDocumento(documento)}\n` +
       `*Segmento:* ${segmento}\n\n` +
       `*Produtos:*\n${linhas.join('\n')}`
     );

--- a/src/app/infrastructure/validators/documento-br.spec.ts
+++ b/src/app/infrastructure/validators/documento-br.spec.ts
@@ -1,0 +1,121 @@
+import { FormControl } from '@angular/forms';
+
+import { cnpjValido, cpfValido, documentoBr, formatarDocumento } from './documento-br';
+
+/**
+ * CPF e CNPJ.
+ *
+ * O que estes testes protegem é a diferença entre **pedir o documento** e pedir
+ * onze números. Uma máscara sozinha aceita `111.111.111-11`, que tem o formato
+ * certo e não é documento de ninguém — e o que passa daqui vira o cadastro de um
+ * cliente do outro lado do WhatsApp.
+ *
+ * Os documentos usados aqui são inválidos de propósito como pessoas e válidos
+ * como aritmética: os dígitos verificadores fecham, e é só isso que o código
+ * conhece.
+ */
+describe('documento-br', () => {
+  const CPF_VALIDO = '52998224725';
+  const CNPJ_VALIDO = '11222333000181';
+
+  // ─── Máscara ───────────────────────────────────────────────────────────────
+
+  describe('formatarDocumento', () => {
+    it('formata CPF conforme a pessoa digita', () => {
+      expect(formatarDocumento('529')).toBe('529');
+      expect(formatarDocumento('5299')).toBe('529.9');
+      expect(formatarDocumento('529982')).toBe('529.982');
+      expect(formatarDocumento('5299822')).toBe('529.982.2');
+      expect(formatarDocumento(CPF_VALIDO)).toBe('529.982.247-25');
+    });
+
+    /**
+     * **A troca acontece no décimo segundo dígito.**
+     *
+     * É o que permite um campo só. A alternativa seria um seletor "CPF/CNPJ"
+     * antes dele — uma decisão a mais para quem só quer pedir um orçamento, e
+     * que a contagem resolve sozinha.
+     */
+    it('vira CNPJ ao passar de onze dígitos', () => {
+      expect(formatarDocumento('11222333000')).toBe('112.223.330-00');
+      expect(formatarDocumento('112223330001')).toBe('11.222.333/0001');
+      expect(formatarDocumento(CNPJ_VALIDO)).toBe('11.222.333/0001-81');
+    });
+
+    it('ignora o que não for dígito e para em catorze', () => {
+      expect(formatarDocumento('529.982.247-25')).toBe('529.982.247-25');
+      expect(formatarDocumento('abc529982247251234567')).toBe('52.998.224/7251-23');
+    });
+
+    it('vazio continua vazio', () => {
+      expect(formatarDocumento('')).toBe('');
+    });
+  });
+
+  // ─── Dígito verificador ────────────────────────────────────────────────────
+
+  describe('cpfValido', () => {
+    it('aceita um CPF com dígitos certos', () => {
+      expect(cpfValido(CPF_VALIDO)).toBeTrue();
+      expect(cpfValido('529.982.247-25')).toBeTrue();
+    });
+
+    /**
+     * **O caso que a máscara sozinha deixa passar**, e o que alguém digita para
+     * escapar do campo obrigatório.
+     */
+    it('recusa dígitos repetidos', () => {
+      expect(cpfValido('11111111111')).toBeFalse();
+      expect(cpfValido('00000000000')).toBeFalse();
+    });
+
+    /** Um dígito trocado quebra a conta — é o mesmo cálculo que pega erro de digitação. */
+    it('recusa um dígito verificador errado', () => {
+      expect(cpfValido('52998224724')).toBeFalse();
+    });
+
+    it('recusa tamanho errado', () => {
+      expect(cpfValido('5299822472')).toBeFalse();
+      expect(cpfValido('529982247251')).toBeFalse();
+    });
+  });
+
+  describe('cnpjValido', () => {
+    it('aceita um CNPJ com dígitos certos', () => {
+      expect(cnpjValido(CNPJ_VALIDO)).toBeTrue();
+      expect(cnpjValido('11.222.333/0001-81')).toBeTrue();
+    });
+
+    it('recusa dígitos repetidos', () => {
+      expect(cnpjValido('11111111111111')).toBeFalse();
+    });
+
+    it('recusa um dígito verificador errado', () => {
+      expect(cnpjValido('11222333000182')).toBeFalse();
+    });
+  });
+
+  // ─── O validador do formulário ─────────────────────────────────────────────
+
+  describe('documentoBr', () => {
+    it('aceita CPF e CNPJ', () => {
+      expect(documentoBr(new FormControl(CPF_VALIDO))).toBeNull();
+      expect(documentoBr(new FormControl(CNPJ_VALIDO))).toBeNull();
+    });
+
+    it('recusa o que não é nenhum dos dois', () => {
+      expect(documentoBr(new FormControl('11111111111'))).toEqual({ documentoBr: true });
+      expect(documentoBr(new FormControl('123'))).toEqual({ documentoBr: true });
+    });
+
+    /**
+     * Vazio devolve nulo de propósito: quem decide se o campo é obrigatório é o
+     * `Validators.required` ao lado. Misturados, o campo opcional passaria a
+     * reclamar de vazio no dia em que alguém tirasse o `required`.
+     */
+    it('vazio não é erro deste validador', () => {
+      expect(documentoBr(new FormControl(''))).toBeNull();
+      expect(documentoBr(new FormControl(null))).toBeNull();
+    });
+  });
+});

--- a/src/app/infrastructure/validators/documento-br.ts
+++ b/src/app/infrastructure/validators/documento-br.ts
@@ -1,0 +1,96 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+/**
+ * CPF e CNPJ: máscara e validação.
+ *
+ * **A máscara sozinha não basta.** `111.111.111-11` tem onze dígitos e o
+ * formato certo, e não é documento de ninguém. Num formulário que abre o
+ * WhatsApp do comercial, o que passa daqui vira o cadastro de um cliente — e
+ * conferir dígito verificador é a diferença entre pedir o documento e só pedir
+ * onze números.
+ *
+ * O dígito verificador é aritmética fechada: os dois últimos números saem dos
+ * anteriores. Errar um dígito ao digitar quase sempre quebra a conta, então o
+ * mesmo cálculo que barra invenção também pega tecla trocada.
+ */
+
+/** Só os dígitos, no limite do maior dos dois documentos. */
+export function apenasDigitos(valor: string): string {
+  return (valor ?? '').replace(/\D/g, '').slice(0, 14);
+}
+
+/**
+ * Formata conforme o tamanho: até onze dígitos é CPF, acima é CNPJ.
+ *
+ * A troca acontece no décimo segundo dígito, e é o que permite um campo só. A
+ * alternativa seria um seletor "CPF/CNPJ" antes do campo — uma decisão a mais
+ * para quem só quer pedir um orçamento, e que a contagem resolve sozinha.
+ */
+export function formatarDocumento(valor: string): string {
+  const d = apenasDigitos(valor);
+
+  if (d.length <= 11) {
+    // 000.000.000-00
+    return d
+      .replace(/^(\d{3})(\d)/, '$1.$2')
+      .replace(/^(\d{3})\.(\d{3})(\d)/, '$1.$2.$3')
+      .replace(/^(\d{3})\.(\d{3})\.(\d{3})(\d)/, '$1.$2.$3-$4');
+  }
+
+  // 00.000.000/0000-00
+  return d
+    .replace(/^(\d{2})(\d)/, '$1.$2')
+    .replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3')
+    .replace(/^(\d{2})\.(\d{3})\.(\d{3})(\d)/, '$1.$2.$3/$4')
+    .replace(/^(\d{2})\.(\d{3})\.(\d{3})\/(\d{4})(\d)/, '$1.$2.$3/$4-$5');
+}
+
+/**
+ * O dígito verificador, que é o mesmo cálculo nos dois documentos com pesos
+ * diferentes: soma ponderada, resto por 11, e resto menor que 2 vira zero.
+ */
+function digitoVerificador(digitos: string, pesos: number[]): number {
+  const soma = pesos.reduce((total, peso, i) => total + Number(digitos[i]) * peso, 0);
+  const resto = soma % 11;
+  return resto < 2 ? 0 : 11 - resto;
+}
+
+export function cpfValido(valor: string): boolean {
+  const d = apenasDigitos(valor);
+  if (d.length !== 11) return false;
+
+  // `111.111.111-11` e os outros repetidos passam na conta do dígito
+  // verificador — é uma sequência válida por acidente da aritmética, e é
+  // justamente o que alguém digita para escapar do campo.
+  if (/^(\d)\1{10}$/.test(d)) return false;
+
+  const primeiro = digitoVerificador(d, [10, 9, 8, 7, 6, 5, 4, 3, 2]);
+  const segundo = digitoVerificador(d, [11, 10, 9, 8, 7, 6, 5, 4, 3, 2]);
+
+  return primeiro === Number(d[9]) && segundo === Number(d[10]);
+}
+
+export function cnpjValido(valor: string): boolean {
+  const d = apenasDigitos(valor);
+  if (d.length !== 14) return false;
+  if (/^(\d)\1{13}$/.test(d)) return false;
+
+  const primeiro = digitoVerificador(d, [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+  const segundo = digitoVerificador(d, [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]);
+
+  return primeiro === Number(d[12]) && segundo === Number(d[13]);
+}
+
+/**
+ * Validador de formulário: aceita um CPF **ou** um CNPJ.
+ *
+ * Campo vazio devolve `null` de propósito. Quem decide se é obrigatório é o
+ * `Validators.required` ao lado — misturar as duas coisas faria o campo
+ * opcional reclamar de vazio no dia em que alguém tirasse o `required`.
+ */
+export function documentoBr(control: AbstractControl): ValidationErrors | null {
+  const d = apenasDigitos(control.value ?? '');
+  if (!d) return null;
+
+  return cpfValido(d) || cnpjValido(d) ? null : { documentoBr: true };
+}


### PR DESCRIPTION
O orcamento abre o WhatsApp do comercial, e do outro lado alguem precisa saber
para quem esta cotando. O campo entra obrigatorio, entre telefone e segmento.

Um campo so para os dois documentos: a contagem de digitos decide qual e, e a
troca acontece no decimo segundo. A alternativa seria um seletor "CPF/CNPJ"
antes do campo — uma decisao a mais para quem so quer pedir um orcamento, e que
a contagem resolve sozinha.

A mascara sozinha nao bastava. 111.111.111-11 tem onze digitos e o formato
certo, e nao e documento de ninguem — obrigar o campo sem conferir digito
verificador so ensinaria a digitar isso para passar da tela. O mesmo calculo que
barra invencao pega tecla trocada, porque os dois ultimos numeros saem dos
anteriores.

Digito repetido e recusado a parte: a sequencia passa na aritmetica por
acidente, e e justamente o que alguem digita para escapar.

O visivel e formatado e o guardado sao so os digitos, no mesmo desenho da
mascara de telefone que ja existia. Assim o validador nao precisa limpar nada, e
a mensagem decide o formato na hora de escrever — o WhatsApp e o e-mail levam o
documento COM mascara, porque quem le e uma pessoa e catorze numeros seguidos
nao se conferem de olho.

O setValue nao emite evento: sem isso quem digita um CPF veria "documento
invalido" nos dez primeiros digitos.

O validador devolve nulo para vazio de proposito. Quem decide obrigatoriedade e
o Validators.required ao lado — juntos, o campo passaria a reclamar de vazio no
dia em que alguem tirasse o required.

Conferido devolvendo os defeitos: validando so o tamanho, duas falhas; sem a
troca para CNPJ na mascara, outras duas.
