### PR TITLE
fix(produtos): tira o desfoque dos overlays que rolam por dentro

### DIFF
--- a/src/app/components/public/lista-produtos/lista-produtos.component.scss
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.scss
@@ -1002,8 +1002,16 @@
   position: fixed;
   inset: 0;
   z-index: 1400;
-  background: rgba(15, 23, 42, 0.52);
-  backdrop-filter: blur(4px);
+
+  /* Mais escuro para compensar o desfoque que saiu: o que o blur fazia era
+     separar o modal da página atrás, e opacidade faz o mesmo sem envolver o
+     compositor. */
+  background: rgba(15, 23, 42, 0.66);
+  /* Sem desfoque, pelo mesmo motivo da ficha: este overlay é `fixed` e o
+     `.modal-box` dentro dele rola (`max-height: 88vh; overflow-y: auto`). No
+     Safari do iOS, `backdrop-filter` numa camada fixa que contém área rolando
+     deixa o conteúdo pintado em posições velhas — texto por cima de texto.
+     Aqui daria no formulário de orçamento, que é mais alto que a tela. */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1384,12 +1392,25 @@
   z-index: 1;
 }
 
+/* Sem `backdrop-filter`, e a razão é um defeito do Safari do iOS.
+ *
+ * Um elemento `position: fixed` com `backdrop-filter` que contém uma área
+ * rolando não é repintado direito pelo compositor do WebKit: o texto do miolo
+ * fica desenhado em posições velhas, por cima do que já estava na tela. Na
+ * ficha isso aparecia como o nome do produto e o começo da descrição pintados
+ * em cima da foto.
+ *
+ * Nunca deu no computador — o bug é do iOS, e nem do build de produção era. Foi
+ * confundido com "só acontece em produção" porque é lá que o celular entra.
+ *
+ * O fundo ficou mais escuro para compensar o desfoque que saiu: o que o blur
+ * fazia era separar o diálogo da grade atrás, e opacidade faz o mesmo sem
+ * envolver o compositor. */
 .ficha-backdrop {
   position: fixed;
   inset: 0;
   z-index: 1200;
-  background: rgba(23, 29, 48, 0.55);
-  backdrop-filter: blur(3px);
+  background: rgba(23, 29, 48, 0.68);
   display: grid;
   place-items: center;
   padding: 20px;


### PR DESCRIPTION
O nome do produto e o comeco da descricao apareciam pintados em cima da foto na
ficha tecnica. Nao e layout: conferi o CSS servido em producao e ele esta certo
— no celular a ficha e uma coluna so, a caixa da imagem e 16/9 com overflow
hidden, e a medida da imagem no print bate com 16/9.

E um defeito de composicao do Safari do iOS. Uma camada `position: fixed` com
backdrop-filter que contem area rolando nao e repintada direito pelo WebKit: o
conteudo do miolo fica desenhado em posicoes velhas, por cima do que ja estava
na tela.

Nao era "so em producao" — e so no iOS. Passou por producao porque e la que o
celular entra; no computador nunca deu, e nem o build de producao tinha a ver.

Dois overlays tinham o mesmo desenho, e o segundo ainda nao tinha sido notado: o
.modal-overlay do orcamento e fixed com blur e contem o .modal-box com
max-height 88vh e overflow-y auto. O formulario e mais alto que a tela do
celular, entao daria exatamente o mesmo. Consertar so um deixaria o outro para
reaparecer amanha.

Os dois fundos ficaram mais escuros para compensar: o que o blur fazia era
separar o dialogo da pagina atras, e opacidade faz o mesmo sem envolver o
compositor.

O backdrop-filter continua na topbar e no card-cta — nenhum dos dois contem area
rolando, e nao correm o risco.

Sem teste: e artefato de renderizacao de um navegador especifico, e nenhuma
asercao de unidade alcanca. Precisa de olho no iPhone.
