### PR TITLE
fix(produtos): a imagem da ficha para de cobrir o texto no celular

### DIFF
--- a/src/app/components/public/lista-produtos/lista-produtos.component.scss
+++ b/src/app/components/public/lista-produtos/lista-produtos.component.scss
@@ -1614,7 +1614,23 @@
     grid-template-columns: 1fr;
   }
 
+  /* Altura DEFINIDA, e não `aspect-ratio`.
+   *
+   * `aspect-ratio` dimensiona o elemento, não a LINHA do grid. Com
+   * `align-self: start` a altura da caixa fica indefinida, então o
+   * `height: 100%` da imagem vira `auto` e quem contribui para a linha é a
+   * altura NATURAL da foto. Numa foto larga essa contribuição é pequena: a
+   * linha saiu com 106px, o `aspect-ratio` esticou a caixa para 180px, e os
+   * 74px restantes ficaram por cima do texto abaixo.
+   *
+   * O `overflow: hidden` não segurava porque não era a caixa que transbordava —
+   * era a linha.
+   *
+   * Com uma altura em pixels, a linha, a caixa e o `height: 100%` da imagem
+   * concordam no mesmo número. 180px é o que o 16/9 dava na largura de um
+   * celular, então o desenho não muda; só passa a ser previsível. */
   .ficha__visual {
-    aspect-ratio: 16 / 9;
+    aspect-ratio: auto;
+    height: 180px;
   }
 }


### PR DESCRIPTION
O nome do produto e o comeco da descricao apareciam por cima da foto. Medido no
navegador, com o dialogo aberto em largura de celular:

  .ficha__visual    76 -> 256   (altura 180)
  .ficha__dados    204 -> 714

Sobreposicao de 52px. O .ficha__dados comeca em 204, ou seja o grid dimensionou
a LINHA 1 com cerca de 106px enquanto o elemento dentro dela tem 180.

aspect-ratio dimensiona o ELEMENTO, nao a linha do grid. Com align-self: start a
altura da caixa fica indefinida, entao o height: 100% da imagem vira auto e quem
contribui para a linha e a altura NATURAL da foto — numa foto larga isso e
pouco. A linha saiu com 106, o aspect-ratio esticou a caixa para 180, e os 74px
restantes ficaram por cima do texto.

O overflow: hidden nao segurava porque nao era a caixa que transbordava, era a
linha.

Com altura em pixels a linha, a caixa e o height: 100% da imagem concordam no
mesmo numero. 180px e o que o 16/9 dava na largura de um celular, entao o
desenho nao muda — so passa a ser previsivel.

No desktop nunca apareceu porque o 3/4 fica perto o bastante da contribuicao
natural para nada sobrar.

Vai junto a remocao do backdrop-filter dos dois overlays. Ela NAO era a causa
deste defeito — eu diagnostiquei errado antes de medir — mas o problema de
composicao do iOS que ela evita e real, e os dois overlays contem area rolando.
Se preferir separar, e so pedir.
