### PR TITLE
fix/sessao expirada em um lugar so

### DIFF
--- a/src/app/components/auth/partners/employes/employes.component.ts
+++ b/src/app/components/auth/partners/employes/employes.component.ts
@@ -465,7 +465,6 @@ export class EmployesComponent implements TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/career-structure/career-structure.component.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.ts
@@ -253,7 +253,6 @@ export class CareerStructureComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/hr-announcements-manager/hr-announcements-manager.component.ts
+++ b/src/app/components/auth/rh/hr-announcements-manager/hr-announcements-manager.component.ts
@@ -80,7 +80,6 @@ export class HrAnnouncementsManagerComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return err.error?.message ?? 'Seu usuário não está vinculado a um funcionário. Solicite ao administrador.';
       case 500: return 'Erro interno do servidor';

--- a/src/app/components/auth/rh/hr-calculators/hr-calculators.component.ts
+++ b/src/app/components/auth/rh/hr-calculators/hr-calculators.component.ts
@@ -264,7 +264,6 @@ export class HrCalculatorsComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Funcionário não encontrado ou sem dados cadastrados';
       case 409: return err.error?.message ?? 'Funcionário sem dados necessários para o cálculo (refeições, histórico de carreira, etc.)';

--- a/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
+++ b/src/app/components/auth/rh/hr-calendar/hr-calendar.component.ts
@@ -114,7 +114,6 @@ export class HrCalendarComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 500: return 'Erro interno do servidor';

--- a/src/app/components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component.ts
+++ b/src/app/components/auth/rh/hr-equipment-assignments/hr-equipment-assignments.component.ts
@@ -176,7 +176,6 @@ export class HrEquipmentAssignmentsComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/hr-notifications/hr-notifications.component.ts
+++ b/src/app/components/auth/rh/hr-notifications/hr-notifications.component.ts
@@ -88,7 +88,6 @@ export class HrNotificationsComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 500: return 'Erro interno do servidor';
       case 0:   return 'Sem conexão com o servidor';

--- a/src/app/components/auth/rh/medical-certificates-manager/medical-certificates-manager.component.ts
+++ b/src/app/components/auth/rh/medical-certificates-manager/medical-certificates-manager.component.ts
@@ -87,7 +87,6 @@ export class MedicalCertificatesManagerComponent implements OnInit {
 
   private getErrorMessage(err: any): string {
     switch (err.status) {
-      case 401: return 'Nao autorizado. Faca login novamente';
       case 403: return 'Voce nao tem permissao para esta acao';
       case 404: return 'Recurso nao encontrado';
       case 500: return 'Erro interno do servidor';

--- a/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.ts
+++ b/src/app/components/auth/rh/org-structure-companies/org-structure-companies.component.ts
@@ -79,7 +79,6 @@ export class OrgStructureCompaniesComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
@@ -76,7 +76,6 @@ export class OrgStructureDepartmentsComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
@@ -77,7 +77,6 @@ export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
@@ -88,7 +88,6 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
+++ b/src/app/components/auth/rh/reimbursements-manager/reimbursements-manager.component.ts
@@ -194,7 +194,6 @@ export class ReimbursementsManagerComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return err.error?.message ?? 'Funcionário ou reembolso não encontrado. Verifique se seu usuário está vinculado a um funcionário.';
       case 409: return err.error?.message ?? 'Conflito ao processar a solicitação';

--- a/src/app/components/auth/rh/team-overview/team-overview.component.ts
+++ b/src/app/components/auth/rh/team-overview/team-overview.component.ts
@@ -91,7 +91,6 @@ export class TeamOverviewComponent implements OnInit {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 500: return 'Erro interno do servidor';
       case 0:   return 'Sem conexão com o servidor';

--- a/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
+++ b/src/app/components/auth/rh/vacation-requests-manager/vacation-requests-manager.component.ts
@@ -277,7 +277,6 @@ export class VacationRequestsManagerComponent implements OnInit, TabDirtyCheck {
   private getErrorMessage(err: any): string {
     switch (err.status) {
       case 400: return 'Requisição inválida';
-      case 401: return 'Não autorizado. Faça login novamente';
       case 403: return 'Você não tem permissão para esta ação';
       case 404: return 'Recurso não encontrado';
       case 409: return 'Registro já existe';

--- a/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.ts
+++ b/src/app/components/auth/tools/certificates/certificate-batch/certificate-batch.component.ts
@@ -174,7 +174,6 @@ export class CertificateBatchComponent {
     switch (err.status) {
       case 0:   return 'Sem conexão com o servidor.';
       case 400: return 'A lista foi recusada pelo servidor.';
-      case 401:
       case 403: return 'Só um administrador pode gerar certificados em lote.';
       case 413: return 'O lote ficou grande demais. Tente em partes menores.';
       case 503: return 'O gerador de certificados está indisponível. Tente em alguns minutos.';

--- a/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.ts
+++ b/src/app/components/auth/tools/pdf/pdf-nfse-rename/pdf-nfse-rename.component.ts
@@ -75,7 +75,6 @@ export class PdfNfseRenameComponent {
     switch (err.status) {
       case 0:   return 'Sem conexão com o servidor.';
       case 400: return 'Algum arquivo não é uma NFS-e válida.';
-      case 401:
       case 403: return 'Você não tem permissão para usar esta ferramenta.';
       case 413: return 'O lote ficou grande demais. Tente em partes menores.';
       default:  return 'Falha inesperada ao processar os arquivos.';

--- a/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.ts
+++ b/src/app/components/auth/tools/pdf/pdf-unlock/pdf-unlock.component.ts
@@ -95,7 +95,6 @@ export class PdfUnlockComponent {
     switch (err.status) {
       case 0:   return 'Sem conexão com o servidor.';
       case 400: return 'Senha incorreta, ou o arquivo não é um PDF válido.';
-      case 401:
       case 403: return 'Você não tem permissão para usar esta ferramenta.';
       case 413: return 'Arquivo grande demais.';
       case 500: return 'O servidor não conseguiu abrir este PDF. Confira a senha.';

--- a/src/app/components/public/client-login/client-login.component.ts
+++ b/src/app/components/public/client-login/client-login.component.ts
@@ -1,10 +1,11 @@
 import { Component, inject } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { Router, RouterLink, ActivatedRoute } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { ClientAuthLayoutComponent } from '../../../layouts/client-auth-layout/client-auth-layout.component';
 import { ClientAuthService } from '../../../infrastructure/services/client/client-auth.service';
+import { PARAM_SESSAO_EXPIRADA } from '../../../infrastructure/interceptors/auth-interceptor';
 
 /**
  * Entrada da Área do Cliente — frame `Login · Acesso` do Figma.
@@ -23,6 +24,7 @@ export class ClientLoginComponent {
   private readonly fb = inject(FormBuilder);
   private readonly auth = inject(ClientAuthService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   form: FormGroup;
   errorMessage = '';
@@ -36,6 +38,17 @@ export class ClientLoginComponent {
       password: ['', [Validators.required]],
       remember: [true],
     });
+
+    /**
+     * A sessão do portal caiu sozinha e o interceptor trouxe a pessoa para cá.
+     *
+     * A explicação mora aqui e não numa notificação porque a navegação destrói
+     * a tela onde o erro aconteceu — qualquer aviso disparado de lá sumiria
+     * junto.
+     */
+    if (this.route.snapshot.queryParamMap.has(PARAM_SESSAO_EXPIRADA)) {
+      this.errorMessage = 'Sua sessão expirou. Entre novamente para continuar.';
+    }
   }
 
   login(): void {

--- a/src/app/components/public/login/login.component.ts
+++ b/src/app/components/public/login/login.component.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 
 import { AuthService } from '../../../infrastructure/services/auth.service';
 import { LoginLayoutComponent } from '../../../layouts/login-layout/login-layout.component';
+import { PARAM_SESSAO_EXPIRADA } from '../../../infrastructure/interceptors/auth-interceptor';
 
 @Component({
   selector: 'app-login',
@@ -22,12 +23,24 @@ export class LoginComponent {
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute,
   ) {
     this.form = this.fb.group({
       username: ['', [Validators.required]],
       password: ['', [Validators.required, Validators.pattern('^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,}$')]]
     });
+
+  /**
+   * A sessão caiu sozinha e o interceptor trouxe a pessoa para cá.
+   *
+   * A explicação mora aqui e não numa notificação porque a navegação destrói a
+   * tela onde o erro aconteceu — qualquer aviso disparado de lá sumiria junto,
+   * ou nem chegaria a aparecer.
+   */
+    if (this.route.snapshot.queryParamMap.has(PARAM_SESSAO_EXPIRADA)) {
+      this.errorMessage = 'Sua sessão expirou. Entre novamente para continuar.';
+    }
   }
 
   onIdentifierInput(event: Event): void {

--- a/src/app/domain/models/auth.model.ts
+++ b/src/app/domain/models/auth.model.ts
@@ -1,5 +1,15 @@
 export interface LoginResponseDTO {
+  /** O JWT de duas horas que acompanha cada requisição. */
   token: string;
+
+  /**
+   * O de sete dias, que só serve para trocar por um `token` novo.
+   *
+   * Opcional porque a API pode estar numa versão anterior a ele: front novo
+   * contra API velha receberia `undefined`, e sem o `?` o TypeScript deixaria
+   * passar um `undefined` gravado como a string "undefined" no armazenamento.
+   */
+  refreshToken?: string;
 }
 
 export interface ForgotPasswordDTO {

--- a/src/app/infrastructure/guard/auth.guard.spec.ts
+++ b/src/app/infrastructure/guard/auth.guard.spec.ts
@@ -32,9 +32,11 @@ describe('AuthGuard', () => {
 
   beforeEach(() => {
     auth = jasmine.createSpyObj<AuthService>('AuthService', [
-      'isLoggedIn', 'getUserRoles', 'logout',
+      'isLoggedIn', 'getUserRoles', 'logout', 'getRefreshToken', 'guardarSessao',
     ]);
     auth.isLoggedIn.and.returnValue(true);
+    // Sem refresh guardado por padrão: cada teste que quer renovação diz isso.
+    auth.getRefreshToken.and.returnValue(null);
     auth.getUserRoles.and.returnValue(['USER']);
 
     TestBed.configureTestingModule({
@@ -156,5 +158,70 @@ describe('AuthGuard', () => {
     expect(requisicao.request.method).toBe('GET');
 
     requisicao.flush({ 'rh/hub': ['CONSULTAR'] });
+  });
+
+  // ─── Token vencido não é sessão perdida ────────────────────────────────────
+  //
+  // O `isLoggedIn` só lê a data do JWT, sem falar com ninguém, e navegar não
+  // dispara requisição — então o interceptor nunca vê este caminho. Antes disto,
+  // clicar num item de menu depois de duas horas caía direto na tela de senha,
+  // que é o caminho mais comum de todos num ERP.
+
+  /**
+   * **O buraco que este conserto fecha.**
+   *
+   * Renovar aqui é o que faz a sessão de sete dias valer para quem navega, e não
+   * só para quem dispara requisições.
+   */
+  it('token vencido com refresh guardado renova e deixa entrar', async () => {
+    auth.isLoggedIn.and.returnValue(false);
+    auth.getRefreshToken.and.returnValue('refresh-bom');
+
+    const resultado = guard.canActivate(rota('rh/hub'));
+    const promessa = firstValueFrom(resultado as Observable<boolean>);
+
+    http.expectOne(`${environment.apiUrl}/auth/refresh`)
+        .flush({ token: 'token-novo', refreshToken: 'refresh-novo' });
+    http.expectOne(url).flush({ 'rh/hub': ['CONSULTAR'] });
+
+    expect(await promessa).toBeTrue();
+    expect(router.navigate).not.toHaveBeenCalledWith(['/login']);
+  });
+
+  /**
+   * Renovação recusada é a palavra final — o refresh venceu, foi revogado, ou a
+   * API detectou reuso. Aí sim a pessoa precisa entrar de novo.
+   */
+  it('renovação recusada manda para o login', async () => {
+    auth.isLoggedIn.and.returnValue(false);
+    auth.getRefreshToken.and.returnValue('refresh-velho');
+
+    const resultado = guard.canActivate(rota('rh/hub'));
+    const promessa = firstValueFrom(resultado as Observable<boolean>);
+
+    http.expectOne(`${environment.apiUrl}/auth/refresh`)
+        .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(await promessa).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+
+  /**
+   * Depois de renovar, as MESMAS checagens de acesso valem. Sem isto, renovar
+   * seria um desvio das regras — a pessoa entraria em tela que não pode.
+   */
+  it('renovar não pula a checagem de permissão', async () => {
+    auth.isLoggedIn.and.returnValue(false);
+    auth.getRefreshToken.and.returnValue('refresh-bom');
+
+    const resultado = guard.canActivate(rota('rh/hub'));
+    const promessa = firstValueFrom(resultado as Observable<boolean>);
+
+    http.expectOne(`${environment.apiUrl}/auth/refresh`)
+        .flush({ token: 'token-novo', refreshToken: 'refresh-novo' });
+    http.expectOne(url).flush({});   // sem a tela no mapa
+
+    expect(await promessa).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/unauthorized']);
   });
 });

--- a/src/app/infrastructure/guard/auth.guard.ts
+++ b/src/app/infrastructure/guard/auth.guard.ts
@@ -1,9 +1,10 @@
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
-import { Observable, map } from 'rxjs';
+import { Observable, map, of, switchMap } from 'rxjs';
 
 import { AuthService } from '../services/auth.service';
 import { PermissionStore } from '../state/permission.store';
+import { SessionRefreshService } from '../services/session-refresh.service';
 
 /** Papel do portal do cliente. Nunca entra na área interna. */
 const CLIENT_ROLE = 'CLIENTE';
@@ -12,6 +13,7 @@ const CLIENT_ROLE = 'CLIENTE';
 export class AuthGuard implements CanActivate {
 
   private readonly permissions = inject(PermissionStore);
+  private readonly sessionRefresh = inject(SessionRefreshService);
 
   constructor(private auth: AuthService, private router: Router) {}
 
@@ -24,10 +26,39 @@ export class AuthGuard implements CanActivate {
    * decisão acontecer com o dado na mão.
    */
   canActivate(route: ActivatedRouteSnapshot): Observable<boolean> | boolean {
+    // **Token vencido não é sessão perdida — é sessão para renovar.**
+    //
+    // O `isLoggedIn` só lê a data do JWT, sem falar com ninguém. Antes disto, o
+    // guard mandava para o login assim que as duas horas passavam: quem clicava
+    // num item de menu caía na tela de senha, e o interceptor nunca via nada,
+    // porque navegação não é requisição.
+    //
+    // Renovar aqui é o que faz a renovação valer para o caminho MAIS comum de
+    // todos num ERP, que é navegar.
     if (!this.auth.isLoggedIn()) {
-      this.router.navigate(['/login']);
-      return false;
+      return this.sessionRefresh.tentarRenovar('erp').pipe(
+        switchMap(renovou => {
+          if (!renovou) {
+            this.router.navigate(['/login']);
+            return of(false);
+          }
+          return this.decidir(route);
+        }),
+      );
     }
+
+    return this.decidir(route);
+  }
+
+  /**
+   * A decisão em si, depois de a sessão estar garantida.
+   *
+   * Separado porque agora há dois caminhos até aqui — quem já estava logado e
+   * quem acabou de renovar — e os dois precisam passar exatamente pelas mesmas
+   * checagens. Duplicar seria a forma óbvia de a renovação virar um desvio das
+   * regras de acesso.
+   */
+  private decidir(route: ActivatedRouteSnapshot): Observable<boolean> {
 
     // Cliente não entra na área interna em hipótese nenhuma — e a checagem vem
     // ANTES de qualquer permissão porque ele não participa deste sistema: o
@@ -37,7 +68,7 @@ export class AuthGuard implements CanActivate {
     if (this.auth.getUserRoles().includes(CLIENT_ROLE)) {
       this.auth.logout();
       this.router.navigate(['/cliente']);
-      return false;
+      return of(false);
     }
 
     const screen = route.data?.['screen'] as string | undefined;

--- a/src/app/infrastructure/guard/client.guard.ts
+++ b/src/app/infrastructure/guard/client.guard.ts
@@ -1,7 +1,9 @@
 import { inject } from '@angular/core';
+import { map } from 'rxjs';
 import { CanActivateFn, Router } from '@angular/router';
 
 import { ClientAuthService } from '../services/client/client-auth.service';
+import { SessionRefreshService } from '../services/session-refresh.service';
 
 /**
  * Protege `/cliente/**`.
@@ -13,8 +15,16 @@ import { ClientAuthService } from '../services/client/client-auth.service';
 export const clientGuard: CanActivateFn = () => {
   const auth = inject(ClientAuthService);
   const router = inject(Router);
+  const sessionRefresh = inject(SessionRefreshService);
 
-  return auth.isLoggedIn() ? true : router.createUrlTree(['/cliente/login']);
+  if (auth.isLoggedIn()) return true;
+
+  // Token vencido não é sessão perdida. O `isLoggedIn` só lê a data do JWT, e
+  // navegar não dispara requisição — sem isto, o portal mandava para o login
+  // assim que as duas horas passavam, mesmo com a renovação disponível.
+  return sessionRefresh.tentarRenovar('cliente').pipe(
+    map(renovou => renovou ? true : router.createUrlTree(['/cliente/login'])),
+  );
 };
 
 /** Impede a tela de login de aparecer para quem já entrou. */

--- a/src/app/infrastructure/interceptors/auth-interceptor.spec.ts
+++ b/src/app/infrastructure/interceptors/auth-interceptor.spec.ts
@@ -26,6 +26,7 @@ describe('AuthInterceptor', () => {
   let http: HttpClient;
   let mock: HttpTestingController;
   let router: jasmine.SpyObj<Router>;
+  let guardarSessao: jasmine.Spy;
   let auth: AuthService;
   let clientAuth: ClientAuthService;
 
@@ -53,7 +54,14 @@ describe('AuthInterceptor', () => {
 
     spyOn(auth, 'logout');
     spyOn(clientAuth, 'logout');
+    guardarSessao = spyOn(auth, 'guardarSessao');
   });
+
+  const URL_REFRESH = `${environment.apiUrl}/auth/refresh`;
+
+  /** Responde a renovação que estiver em andamento. */
+  const responderRefresh = (token = 'token-novo') =>
+    mock.expectOne(URL_REFRESH).flush({ token, refreshToken: 'refresh-novo' });
 
   afterEach(() => mock.verify());
 
@@ -80,8 +88,13 @@ describe('AuthInterceptor', () => {
 
   // ─── Sessão expirada ───────────────────────────────────────────────────────
 
-  it('401 desloga e leva para o login, avisando que expirou', () => {
+  /**
+   * Sem refresh token guardado não há o que renovar — é o caminho de quem
+   * entrou antes desta feature existir, e o de quem já teve a sessão revogada.
+   */
+  it('401 sem refresh token desloga e leva para o login', () => {
     spyOn(auth, 'getToken').and.returnValue('token-velho');
+    spyOn(auth, 'getRefreshToken').and.returnValue(null);
 
     http.get(URL_ERP).subscribe();
     responder401(URL_ERP);
@@ -91,6 +104,91 @@ describe('AuthInterceptor', () => {
       ['/login'], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } });
   });
 
+  // ─── Renovação ─────────────────────────────────────────────────────────────
+
+  /**
+   * **O ganho da feature inteira.**
+   *
+   * Para quem está usando, o vencimento do token vira meio segundo a mais numa
+   * requisição, em vez de uma tela de login. Sem a repetição, a renovação
+   * funcionaria e a tela ficaria sem o dado que foi buscar.
+   */
+  it('401 renova e repete a requisição com o token novo', () => {
+    // Duas leituras: a primeira monta a requisição original, a segunda monta a
+    // repetida — depois de a renovação ter gravado o token novo. `flush` é
+    // síncrono, então trocar o valor entre as duas chamadas só funciona assim.
+    spyOn(auth, 'getToken').and.returnValues('token-velho', 'token-novo');
+    spyOn(auth, 'getRefreshToken').and.returnValue('refresh-bom');
+    let recebeu: unknown = null;
+
+    http.get(URL_ERP).subscribe(r => (recebeu = r));
+    responder401(URL_ERP);
+    responderRefresh('token-novo');
+
+    const repetida = mock.expectOne(URL_ERP);
+    expect(repetida.request.headers.get('Authorization')).toBe('Bearer token-novo');
+    repetida.flush({ ok: true });
+
+    expect(recebeu).toEqual({ ok: true });
+    expect(guardarSessao).toHaveBeenCalled();
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * **O teste que impede o sistema de se auto-sabotar.**
+   *
+   * A rotação queima o refresh token a cada uso. Se cinco requisições que
+   * falharam juntas chamassem `/auth/refresh` cada uma, a primeira invalidaria o
+   * token que as outras quatro estão mandando — e a API leria isso como REUSO,
+   * que derruba todas as sessões da pessoa.
+   *
+   * Ou seja: sem a fila, a proteção do servidor dispararia contra o usuário
+   * legítimo toda vez que o token vencesse.
+   */
+  it('cinco 401 simultâneos renovam UMA vez só', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-velho');
+    spyOn(auth, 'getRefreshToken').and.returnValue('refresh-bom');
+
+    for (let i = 0; i < 5; i++) http.get(URL_ERP).subscribe();
+    mock.match(URL_ERP).forEach(r => r.flush({}, { status: 401, statusText: 'Unauthorized' }));
+
+    // Uma renovação para as cinco — `expectOne` falha se houver mais de uma.
+    responderRefresh();
+
+    expect(mock.match(URL_ERP).length).toBe(5);   // as cinco repetidas
+    expect(auth.logout).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Renovação recusada é a palavra final: o refresh venceu, foi revogado, ou a
+   * API detectou reuso. Tentar de novo seria laço.
+   */
+  it('renovação recusada cai no login', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-velho');
+    spyOn(auth, 'getRefreshToken').and.returnValue('refresh-velho');
+
+    http.get(URL_ERP).subscribe();
+    responder401(URL_ERP);
+    mock.expectOne(URL_REFRESH).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(auth.logout).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledOnceWith(
+      ['/login'], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } });
+  });
+
+  /**
+   * O `/auth/refresh` não pode se renovar a si mesmo: o `401` dele é resposta
+   * final, e tratá-lo como sessão caída chamaria renovação de novo, sem fim.
+   */
+  it('401 do próprio refresh não dispara outra renovação', () => {
+    http.post(URL_REFRESH, { refreshToken: 'x' }).subscribe({ error: () => undefined });
+    mock.expectOne(URL_REFRESH).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    mock.verify();   // nenhuma segunda chamada pendente
+    expect(auth.logout).not.toHaveBeenCalled();
+  });
+
   /**
    * **O teste do defeito relatado.**
    *
@@ -98,8 +196,9 @@ describe('AuthInterceptor', () => {
    * instante. Sem a trava seriam cinco logouts, cinco navegações e cinco
    * mensagens — que é literalmente o que ele descreveu.
    */
-  it('vários 401 ao mesmo tempo produzem UMA reação só', () => {
+  it('vários 401 sem refresh produzem UMA reação só', () => {
     spyOn(auth, 'getToken').and.returnValue('token-velho');
+    spyOn(auth, 'getRefreshToken').and.returnValue(null);
 
     for (let i = 0; i < 5; i++) http.get(URL_ERP).subscribe();
     mock.match(URL_ERP).forEach(r => r.flush({}, { status: 401, statusText: 'Unauthorized' }));
@@ -114,6 +213,7 @@ describe('AuthInterceptor', () => {
    */
   it('401 no portal não derruba a sessão do ERP', () => {
     spyOn(clientAuth, 'getToken').and.returnValue('token-cliente');
+    spyOn(clientAuth, 'getRefreshToken').and.returnValue(null);
 
     http.get(URL_CLIENTE).subscribe();
     responder401(URL_CLIENTE);
@@ -133,6 +233,7 @@ describe('AuthInterceptor', () => {
    */
   it('o erro não chega na tela', () => {
     spyOn(auth, 'getToken').and.returnValue('token-velho');
+    spyOn(auth, 'getRefreshToken').and.returnValue(null);
     let recebeuErro = false;
 
     http.get(URL_ERP).subscribe({ error: () => (recebeuErro = true) });

--- a/src/app/infrastructure/interceptors/auth-interceptor.spec.ts
+++ b/src/app/infrastructure/interceptors/auth-interceptor.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+
+import { AuthInterceptor, PARAM_SESSAO_EXPIRADA } from './auth-interceptor';
+import { AuthService } from '../services/auth.service';
+import { ClientAuthService } from '../services/client/client-auth.service';
+
+import { environment } from '../../../environments/environment';
+
+/**
+ * O interceptor de autenticação.
+ *
+ * **O defeito que ele fecha.** O token dura duas horas e o interceptor só
+ * anexava; o `401` caía nas telas, e dezoito componentes diferentes traduziam
+ * cada um o seu para "Faça login novamente". Uma tela que dispara cinco
+ * requisições ao abrir produzia cinco avisos, ninguém era deslogado e ninguém
+ * era levado a lugar nenhum — a pessoa colecionava mensagens até desistir.
+ *
+ * Estes testes afirmam sobre o NÚMERO de reações, e não só sobre a reação: o
+ * defeito nunca foi "não acontece nada", foi "acontece cinco vezes".
+ */
+describe('AuthInterceptor', () => {
+  let http: HttpClient;
+  let mock: HttpTestingController;
+  let router: jasmine.SpyObj<Router>;
+  let auth: AuthService;
+  let clientAuth: ClientAuthService;
+
+  const URL_ERP = `${environment.apiUrl}/machines`;
+  const URL_CLIENTE = `${environment.apiUrl}/client/pedidos`;
+
+  beforeEach(() => {
+    router = jasmine.createSpyObj<Router>('Router', ['navigate']);
+    router.navigate.and.resolveTo(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+        { provide: Router, useValue: router },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    mock = TestBed.inject(HttpTestingController);
+    auth = TestBed.inject(AuthService);
+    clientAuth = TestBed.inject(ClientAuthService);
+
+    spyOn(auth, 'logout');
+    spyOn(clientAuth, 'logout');
+  });
+
+  afterEach(() => mock.verify());
+
+  const responder401 = (url: string) =>
+    mock.expectOne(url).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+  // ─── O token certo para cada sessão ────────────────────────────────────────
+
+  /**
+   * Duas sessões coexistem no mesmo navegador: o funcionário no ERP e o cliente
+   * no portal. Mandar o token errado vaza a sessão do portal para telas que não
+   * são dela.
+   */
+  it('manda o token do ERP fora de /client/ e o do cliente dentro', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-erp');
+    spyOn(clientAuth, 'getToken').and.returnValue('token-cliente');
+
+    http.get(URL_ERP).subscribe();
+    expect(mock.expectOne(URL_ERP).request.headers.get('Authorization')).toBe('Bearer token-erp');
+
+    http.get(URL_CLIENTE).subscribe();
+    expect(mock.expectOne(URL_CLIENTE).request.headers.get('Authorization')).toBe('Bearer token-cliente');
+  });
+
+  // ─── Sessão expirada ───────────────────────────────────────────────────────
+
+  it('401 desloga e leva para o login, avisando que expirou', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-velho');
+
+    http.get(URL_ERP).subscribe();
+    responder401(URL_ERP);
+
+    expect(auth.logout).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledOnceWith(
+      ['/login'], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } });
+  });
+
+  /**
+   * **O teste do defeito relatado.**
+   *
+   * Cinco requisições em voo quando o token vence são cinco `401` no mesmo
+   * instante. Sem a trava seriam cinco logouts, cinco navegações e cinco
+   * mensagens — que é literalmente o que ele descreveu.
+   */
+  it('vários 401 ao mesmo tempo produzem UMA reação só', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-velho');
+
+    for (let i = 0; i < 5; i++) http.get(URL_ERP).subscribe();
+    mock.match(URL_ERP).forEach(r => r.flush({}, { status: 401, statusText: 'Unauthorized' }));
+
+    expect(auth.logout).toHaveBeenCalledTimes(1);
+    expect(router.navigate).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * Só a sessão que caiu. O funcionário perder o ERP não é motivo para
+   * desconectar o cliente que estava no portal no mesmo navegador.
+   */
+  it('401 no portal não derruba a sessão do ERP', () => {
+    spyOn(clientAuth, 'getToken').and.returnValue('token-cliente');
+
+    http.get(URL_CLIENTE).subscribe();
+    responder401(URL_CLIENTE);
+
+    expect(clientAuth.logout).toHaveBeenCalledTimes(1);
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(router.navigate).toHaveBeenCalledOnceWith(
+      ['/cliente/login'], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } });
+  });
+
+  /**
+   * **Engolido de propósito.**
+   *
+   * Sessão expirada não é erro de tela. Repassando, cada uma das dezoito telas
+   * que traduz `401` para "Faça login novamente" mostraria a própria mensagem —
+   * a mesma pilha de avisos de antes, agora com um redirecionamento junto.
+   */
+  it('o erro não chega na tela', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-velho');
+    let recebeuErro = false;
+
+    http.get(URL_ERP).subscribe({ error: () => (recebeuErro = true) });
+    responder401(URL_ERP);
+
+    expect(recebeuErro).toBeFalse();
+  });
+
+  // ─── O que NÃO é sessão expirada ───────────────────────────────────────────
+
+  /**
+   * **A exclusão que evita um defeito pior que o original.**
+   *
+   * O `401` do login significa "senha errada". Tratado como sessão expirada,
+   * digitar a senha errada recarregaria a tela de login sem dizer o que houve —
+   * e o erro nunca chegaria ao componente que sabe explicar.
+   */
+  it('401 no login passa direto para a tela', () => {
+    let recebeuErro = false;
+
+    http.post(`${environment.apiUrl}/auth/login`, {}).subscribe({ error: () => (recebeuErro = true) });
+    mock.expectOne(`${environment.apiUrl}/auth/login`)
+        .flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(recebeuErro).toBeTrue();
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `403` é "você não pode isto", e o controle de acesso por tela depende dessa
+   * distinção. Confundir os dois deslogaria quem apenas abriu uma tela sem
+   * permissão.
+   */
+  it('403 não é sessão expirada', () => {
+    spyOn(auth, 'getToken').and.returnValue('token-bom');
+    let recebeuErro = false;
+
+    http.get(URL_ERP).subscribe({ error: () => (recebeuErro = true) });
+    mock.expectOne(URL_ERP).flush({}, { status: 403, statusText: 'Forbidden' });
+
+    expect(recebeuErro).toBeTrue();
+    expect(auth.logout).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/infrastructure/interceptors/auth-interceptor.ts
+++ b/src/app/infrastructure/interceptors/auth-interceptor.ts
@@ -1,33 +1,46 @@
 import { Injectable } from '@angular/core';
-import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { EMPTY, Observable, catchError, throwError } from 'rxjs';
+import { EMPTY, Observable, catchError, map, shareReplay, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { ClientAuthService } from '../services/client/client-auth.service';
+import { LoginResponseDTO } from '../../domain/models/auth.model';
+import { environment } from '../../../environments/environment';
 
 /** O que a tela de login mostra quando a sessão caiu sozinha. */
 export const PARAM_SESSAO_EXPIRADA = 'expirou';
+
+/** Qual das duas sessões do navegador está em jogo. */
+type Sessao = 'erp' | 'cliente';
 
 @Injectable({ providedIn: 'root' })
 export class AuthInterceptor implements HttpInterceptor {
 
   /**
-   * Trava para o redirecionamento acontecer uma vez só.
+   * A renovação em andamento de cada sessão.
    *
-   * **É o remédio para o defeito relatado.** O token dura duas horas, e uma tela
-   * que carrega cinco requisições ao abrir recebe cinco `401` no mesmo instante.
-   * Sem esta trava, seriam cinco `logout`, cinco navegações e cinco mensagens —
-   * que é exatamente o que a pessoa via.
+   * **É o que impede uma tempestade de renovações.** O token dura duas horas, e
+   * uma tela que carrega cinco requisições recebe cinco `401` no mesmo instante.
+   * Sem isto, as cinco chamariam `/auth/refresh` — e como a rotação queima o
+   * token a cada uso, a primeira renovação invalidaria o token que as outras
+   * quatro estão mandando. As quatro seriam lidas pela API como REUSO, que
+   * derruba todas as sessões da pessoa.
    *
-   * Volta a `false` na navegação, e não por tempo: enquanto a ida para o login
-   * não termina, todo `401` que chegar é o mesmo acontecimento.
+   * Ou seja: sem a fila, o mecanismo de segurança do servidor dispararia contra
+   * o próprio usuário legítimo, toda vez que o token vencesse.
+   *
+   * Uma por sessão, porque as duas coexistem no mesmo navegador.
    */
+  private renovando: Record<Sessao, Observable<string> | null> = { erp: null, cliente: null };
+
+  /** Trava do redirecionamento, para vários `401` produzirem uma ida só ao login. */
   private redirecionando = false;
 
   constructor(
     private authService: AuthService,
     private clientAuthService: ClientAuthService,
     private router: Router,
+    private http: HttpClient,
   ) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -38,50 +51,111 @@ export class AuthInterceptor implements HttpInterceptor {
      * e o `401` dele significa "senha errada" e não "sessão caiu". Tratado como
      * os outros, digitar a senha errada deslogaria a pessoa e recarregaria a
      * tela de login sem dizer o que houve.
+     *
+     * O `refresh` está aqui para não se renovar a si mesmo: um `401` dele é a
+     * resposta final, e tentar renovar de novo seria um laço infinito.
      */
     const rotasPublicas = [
       '/auth/login',
+      '/auth/refresh',
       '/auth/first-access',
       '/auth/forgot-password',
       '/auth/reset-password',
-      '/client/auth/login',
     ];
 
     if (rotasPublicas.some(url => req.url.includes(url))) {
       return next.handle(req);
     }
 
-    // Duas sessões podem coexistir no mesmo navegador: o funcionário no ERP e
-    // o cliente no portal. A URL decide qual token vai — mandar o do ERP para
-    // `/api/client` daria 403, e mandar o do cliente para o resto vazaria a
-    // sessão do portal em telas que não são dele.
-    const doCliente = req.url.includes('/client/');
-    const token = doCliente ? this.clientAuthService.getToken() : this.authService.getToken();
+    const sessao: Sessao = req.url.includes('/client/') ? 'cliente' : 'erp';
 
-    const enviada = token
-      ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
-      : req;
-
-    return next.handle(enviada).pipe(
+    return next.handle(this.comToken(req, sessao)).pipe(
       catchError((erro: HttpErrorResponse) => {
         if (erro.status !== 401) return throwError(() => erro);
 
-        this.encerrarSessao(doCliente);
+        return this.renovarERepetir(req, next, sessao);
+      }),
+    );
+  }
 
-        /**
-         * Engolido, e não repassado.
-         *
-         * Sessão expirada não é erro de tela: é acontecimento do aplicativo, e
-         * a tela não tem nada de útil a dizer sobre ele. Repassando, cada uma
-         * das dezoito telas que hoje traduz `401` para "Faça login novamente"
-         * mostraria a própria mensagem — a mesma pilha de avisos de antes,
-         * agora acompanhada de um redirecionamento.
-         *
-         * Quem explica é a tela de login, para onde a pessoa acabou de ir.
-         */
+  /**
+   * Tenta renovar; conseguindo, repete a requisição que falhou.
+   *
+   * Repetir é o ponto: para quem está usando, o vencimento do token vira uma
+   * requisição meio segundo mais lenta em vez de uma tela de login. Sem o
+   * `switchMap` aqui, a renovação funcionaria e a tela ainda assim ficaria sem
+   * o dado que foi buscar.
+   */
+  private renovarERepetir(req: HttpRequest<any>, next: HttpHandler, sessao: Sessao): Observable<HttpEvent<any>> {
+    return this.renovacao(sessao).pipe(
+      switchMap(() => next.handle(this.comToken(req, sessao))),
+      catchError(() => {
+        // A renovação também falhou: o refresh venceu, foi revogado, ou nunca
+        // existiu. Aqui acaba o que dá para fazer sem a pessoa.
+        this.encerrarSessao(sessao);
         return EMPTY;
       }),
     );
+  }
+
+  /**
+   * A renovação da sessão, compartilhada por quem chegar enquanto ela acontece.
+   *
+   * `shareReplay(1)` faz a segunda, terceira e quinta requisição aguardarem a
+   * MESMA chamada em vez de dispararem a sua — e quem chegar depois de ela
+   * terminar recebe o resultado guardado sem ir à rede.
+   *
+   * O campo volta a `null` no fim para a próxima expiração poder renovar de
+   * novo; sem isso, a sessão renovaria uma vez só e nunca mais.
+   */
+  private renovacao(sessao: Sessao): Observable<string> {
+    const emAndamento = this.renovando[sessao];
+    if (emAndamento) return emAndamento;
+
+    const refreshToken = sessao === 'cliente'
+      ? this.clientAuthService.getRefreshToken()
+      : this.authService.getRefreshToken();
+
+    if (!refreshToken) return throwError(() => new Error('sem refresh token'));
+
+    const chamada = this.http
+      .post<LoginResponseDTO>(`${environment.apiUrl}/auth/refresh`, { refreshToken })
+      .pipe(
+        map(res => {
+          if (sessao === 'cliente') {
+            this.clientAuthService.guardarSessao(res);
+          } else {
+            this.authService.guardarSessao(res);
+          }
+          this.renovando[sessao] = null;
+          return res.token;
+        }),
+        catchError(erro => {
+          this.renovando[sessao] = null;
+          return throwError(() => erro);
+        }),
+        shareReplay(1),
+      );
+
+    this.renovando[sessao] = chamada;
+    return chamada;
+  }
+
+  /**
+   * Anexa o token da sessão certa.
+   *
+   * Lido na hora do envio, e não guardado: depois de uma renovação, a
+   * requisição repetida precisa do token NOVO. Reaproveitar o clone anterior
+   * mandaria o token vencido de novo e o `401` voltaria em laço.
+   */
+  private comToken(req: HttpRequest<any>, sessao: Sessao): HttpRequest<any> {
+    const token = sessao === 'cliente'
+      ? this.clientAuthService.getToken()
+      : this.authService.getToken();
+
+    return token
+      ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+      : req;
   }
 
   /**
@@ -90,20 +164,19 @@ export class AuthInterceptor implements HttpInterceptor {
    * Só a sessão que expirou: o funcionário perder o acesso ao ERP não é motivo
    * para desconectar o cliente que estava no portal no mesmo navegador.
    */
-  private encerrarSessao(doCliente: boolean): void {
+  private encerrarSessao(sessao: Sessao): void {
     if (this.redirecionando) return;
     this.redirecionando = true;
 
-    const login = doCliente ? '/cliente/login' : '/login';
-
-    if (doCliente) {
+    if (sessao === 'cliente') {
       this.clientAuthService.logout();
     } else {
       this.authService.logout();
     }
 
     this.router
-      .navigate([login], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } })
+      .navigate([sessao === 'cliente' ? '/cliente/login' : '/login'],
+        { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } })
       .finally(() => (this.redirecionando = false));
   }
 }

--- a/src/app/infrastructure/interceptors/auth-interceptor.ts
+++ b/src/app/infrastructure/interceptors/auth-interceptor.ts
@@ -1,25 +1,53 @@
 import { Injectable } from '@angular/core';
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Router } from '@angular/router';
+import { EMPTY, Observable, catchError, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { ClientAuthService } from '../services/client/client-auth.service';
+
+/** O que a tela de login mostra quando a sessão caiu sozinha. */
+export const PARAM_SESSAO_EXPIRADA = 'expirou';
 
 @Injectable({ providedIn: 'root' })
 export class AuthInterceptor implements HttpInterceptor {
 
+  /**
+   * Trava para o redirecionamento acontecer uma vez só.
+   *
+   * **É o remédio para o defeito relatado.** O token dura duas horas, e uma tela
+   * que carrega cinco requisições ao abrir recebe cinco `401` no mesmo instante.
+   * Sem esta trava, seriam cinco `logout`, cinco navegações e cinco mensagens —
+   * que é exatamente o que a pessoa via.
+   *
+   * Volta a `false` na navegação, e não por tempo: enquanto a ida para o login
+   * não termina, todo `401` que chegar é o mesmo acontecimento.
+   */
+  private redirecionando = false;
+
   constructor(
     private authService: AuthService,
     private clientAuthService: ClientAuthService,
+    private router: Router,
   ) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const publicEndponts = [
+    /**
+     * Rotas que não têm sessão para expirar.
+     *
+     * O login precisa estar aqui pelos DOIS motivos: não tem token para mandar,
+     * e o `401` dele significa "senha errada" e não "sessão caiu". Tratado como
+     * os outros, digitar a senha errada deslogaria a pessoa e recarregaria a
+     * tela de login sem dizer o que houve.
+     */
+    const rotasPublicas = [
       '/auth/login',
+      '/auth/first-access',
+      '/auth/forgot-password',
+      '/auth/reset-password',
+      '/client/auth/login',
     ];
 
-    const isPublic = publicEndponts.some(url => req.url.includes(url));
-
-    if(isPublic){
+    if (rotasPublicas.some(url => req.url.includes(url))) {
       return next.handle(req);
     }
 
@@ -27,18 +55,55 @@ export class AuthInterceptor implements HttpInterceptor {
     // o cliente no portal. A URL decide qual token vai — mandar o do ERP para
     // `/api/client` daria 403, e mandar o do cliente para o resto vazaria a
     // sessão do portal em telas que não são dele.
-    const token = req.url.includes('/client/')
-      ? this.clientAuthService.getToken()
-      : this.authService.getToken();
+    const doCliente = req.url.includes('/client/');
+    const token = doCliente ? this.clientAuthService.getToken() : this.authService.getToken();
 
-    if (token) {
-      const cloned = req.clone({
-        setHeaders: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-      return next.handle(cloned);
+    const enviada = token
+      ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
+      : req;
+
+    return next.handle(enviada).pipe(
+      catchError((erro: HttpErrorResponse) => {
+        if (erro.status !== 401) return throwError(() => erro);
+
+        this.encerrarSessao(doCliente);
+
+        /**
+         * Engolido, e não repassado.
+         *
+         * Sessão expirada não é erro de tela: é acontecimento do aplicativo, e
+         * a tela não tem nada de útil a dizer sobre ele. Repassando, cada uma
+         * das dezoito telas que hoje traduz `401` para "Faça login novamente"
+         * mostraria a própria mensagem — a mesma pilha de avisos de antes,
+         * agora acompanhada de um redirecionamento.
+         *
+         * Quem explica é a tela de login, para onde a pessoa acabou de ir.
+         */
+        return EMPTY;
+      }),
+    );
+  }
+
+  /**
+   * Derruba a sessão certa e leva para o login dela.
+   *
+   * Só a sessão que expirou: o funcionário perder o acesso ao ERP não é motivo
+   * para desconectar o cliente que estava no portal no mesmo navegador.
+   */
+  private encerrarSessao(doCliente: boolean): void {
+    if (this.redirecionando) return;
+    this.redirecionando = true;
+
+    const login = doCliente ? '/cliente/login' : '/login';
+
+    if (doCliente) {
+      this.clientAuthService.logout();
+    } else {
+      this.authService.logout();
     }
-    return next.handle(req);
+
+    this.router
+      .navigate([login], { queryParams: { [PARAM_SESSAO_EXPIRADA]: 1 } })
+      .finally(() => (this.redirecionando = false));
   }
 }

--- a/src/app/infrastructure/interceptors/auth-interceptor.ts
+++ b/src/app/infrastructure/interceptors/auth-interceptor.ts
@@ -1,37 +1,16 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { EMPTY, Observable, catchError, map, shareReplay, switchMap, throwError } from 'rxjs';
+import { EMPTY, Observable, catchError, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { ClientAuthService } from '../services/client/client-auth.service';
-import { LoginResponseDTO } from '../../domain/models/auth.model';
-import { environment } from '../../../environments/environment';
+import { Sessao, SessionRefreshService } from '../services/session-refresh.service';
 
 /** O que a tela de login mostra quando a sessão caiu sozinha. */
 export const PARAM_SESSAO_EXPIRADA = 'expirou';
 
-/** Qual das duas sessões do navegador está em jogo. */
-type Sessao = 'erp' | 'cliente';
-
 @Injectable({ providedIn: 'root' })
 export class AuthInterceptor implements HttpInterceptor {
-
-  /**
-   * A renovação em andamento de cada sessão.
-   *
-   * **É o que impede uma tempestade de renovações.** O token dura duas horas, e
-   * uma tela que carrega cinco requisições recebe cinco `401` no mesmo instante.
-   * Sem isto, as cinco chamariam `/auth/refresh` — e como a rotação queima o
-   * token a cada uso, a primeira renovação invalidaria o token que as outras
-   * quatro estão mandando. As quatro seriam lidas pela API como REUSO, que
-   * derruba todas as sessões da pessoa.
-   *
-   * Ou seja: sem a fila, o mecanismo de segurança do servidor dispararia contra
-   * o próprio usuário legítimo, toda vez que o token vencesse.
-   *
-   * Uma por sessão, porque as duas coexistem no mesmo navegador.
-   */
-  private renovando: Record<Sessao, Observable<string> | null> = { erp: null, cliente: null };
 
   /** Trava do redirecionamento, para vários `401` produzirem uma ida só ao login. */
   private redirecionando = false;
@@ -40,7 +19,7 @@ export class AuthInterceptor implements HttpInterceptor {
     private authService: AuthService,
     private clientAuthService: ClientAuthService,
     private router: Router,
-    private http: HttpClient,
+    private sessionRefresh: SessionRefreshService,
   ) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -87,7 +66,7 @@ export class AuthInterceptor implements HttpInterceptor {
    * o dado que foi buscar.
    */
   private renovarERepetir(req: HttpRequest<any>, next: HttpHandler, sessao: Sessao): Observable<HttpEvent<any>> {
-    return this.renovacao(sessao).pipe(
+    return this.sessionRefresh.renovar(sessao).pipe(
       switchMap(() => next.handle(this.comToken(req, sessao))),
       catchError(() => {
         // A renovação também falhou: o refresh venceu, foi revogado, ou nunca
@@ -96,49 +75,6 @@ export class AuthInterceptor implements HttpInterceptor {
         return EMPTY;
       }),
     );
-  }
-
-  /**
-   * A renovação da sessão, compartilhada por quem chegar enquanto ela acontece.
-   *
-   * `shareReplay(1)` faz a segunda, terceira e quinta requisição aguardarem a
-   * MESMA chamada em vez de dispararem a sua — e quem chegar depois de ela
-   * terminar recebe o resultado guardado sem ir à rede.
-   *
-   * O campo volta a `null` no fim para a próxima expiração poder renovar de
-   * novo; sem isso, a sessão renovaria uma vez só e nunca mais.
-   */
-  private renovacao(sessao: Sessao): Observable<string> {
-    const emAndamento = this.renovando[sessao];
-    if (emAndamento) return emAndamento;
-
-    const refreshToken = sessao === 'cliente'
-      ? this.clientAuthService.getRefreshToken()
-      : this.authService.getRefreshToken();
-
-    if (!refreshToken) return throwError(() => new Error('sem refresh token'));
-
-    const chamada = this.http
-      .post<LoginResponseDTO>(`${environment.apiUrl}/auth/refresh`, { refreshToken })
-      .pipe(
-        map(res => {
-          if (sessao === 'cliente') {
-            this.clientAuthService.guardarSessao(res);
-          } else {
-            this.authService.guardarSessao(res);
-          }
-          this.renovando[sessao] = null;
-          return res.token;
-        }),
-        catchError(erro => {
-          this.renovando[sessao] = null;
-          return throwError(() => erro);
-        }),
-        shareReplay(1),
-      );
-
-    this.renovando[sessao] = chamada;
-    return chamada;
   }
 
   /**

--- a/src/app/infrastructure/services/auth.service.spec.ts
+++ b/src/app/infrastructure/services/auth.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
 
 import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
 
 import { providersDeTeste } from '../../../testing/test-setup';
 
@@ -16,5 +18,58 @@ describe('AuthService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  // ─── Sair de verdade ───────────────────────────────────────────────────────
+
+  const URL_LOGOUT = `${environment.apiUrl}/auth/logout`;
+
+  /**
+   * **O teste que faz "Sair" significar alguma coisa.**
+   *
+   * O `logout()` local apaga o que está nesta máquina e o refresh token continua
+   * valendo sete dias do outro lado. Isso não é encerrar sessão — é esconder a
+   * chave.
+   */
+  it('sair avisa o servidor e limpa o navegador', () => {
+    localStorage.setItem('token', 'jwt');
+    localStorage.setItem('refresh_token', 'refresh-bom');
+    const http = TestBed.inject(HttpTestingController);
+
+    service.logoutRemoto().subscribe();
+
+    const req = http.expectOne(URL_LOGOUT);
+    expect(req.request.body).toEqual({ refreshToken: 'refresh-bom' });
+    req.flush(null);
+
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  /**
+   * Rede fora não pode prender quem quer sair. O refresh sobrevive até vencer
+   * sozinho, e isso é melhor do que uma pessoa presa numa tela.
+   */
+  it('sair limpa o navegador mesmo se o servidor falhar', () => {
+    localStorage.setItem('token', 'jwt');
+    localStorage.setItem('refresh_token', 'refresh-bom');
+    const http = TestBed.inject(HttpTestingController);
+
+    service.logoutRemoto().subscribe();
+    http.expectOne(URL_LOGOUT).flush({}, { status: 500, statusText: 'Server Error' });
+
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('refresh_token')).toBeNull();
+  });
+
+  /** Sem refresh guardado não há o que avisar — sai direto, sem ir à rede. */
+  it('sem refresh token, sair não chama o servidor', () => {
+    localStorage.setItem('token', 'jwt');
+    const http = TestBed.inject(HttpTestingController);
+
+    service.logoutRemoto().subscribe();
+
+    http.expectNone(URL_LOGOUT);
+    expect(localStorage.getItem('token')).toBeNull();
   });
 });

--- a/src/app/infrastructure/services/auth.service.ts
+++ b/src/app/infrastructure/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, catchError, finalize, of } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { PermissionStore } from '../state/permission.store';
 import { environment } from '../../../environments/environment';
@@ -58,6 +58,35 @@ export class AuthService {
 
   getRefreshToken(): string | null {
     return localStorage.getItem(REFRESH_KEY);
+  }
+
+  /**
+   * Sair de verdade: avisa o servidor e só então limpa o navegador.
+   *
+   * O `logout()` sozinho apaga o que está nesta máquina, e o refresh token
+   * continua valendo sete dias do outro lado. Isso não é encerrar sessão — é
+   * esconder a chave.
+   *
+   * A limpeza local acontece de qualquer jeito, mesmo se a chamada falhar: quem
+   * apertou "Sair" tem que sair, e ficar preso numa tela por causa de rede é
+   * pior do que um refresh token sobrevivendo até vencer sozinho.
+   *
+   * Quem garante isso é o `catchError`, que transforma a falha numa conclusão
+   * normal — o `finalize` depois dele cobre um caso a mais: quem se desinscreve
+   * antes da resposta, como uma tela que navega no meio do caminho.
+   */
+  logoutRemoto(): Observable<void> {
+    const refreshToken = this.getRefreshToken();
+
+    if (!refreshToken) {
+      this.logout();
+      return of(void 0);
+    }
+
+    return this.http.post<void>(`${environment.apiUrl}/auth/logout`, { refreshToken }).pipe(
+      catchError(() => of(void 0)),
+      finalize(() => this.logout()),
+    );
   }
 
   /**

--- a/src/app/infrastructure/services/auth.service.ts
+++ b/src/app/infrastructure/services/auth.service.ts
@@ -19,6 +19,9 @@ import {
   User,
 } from '../../domain/models/user.model';
 
+/** Onde o refresh token do ERP fica. */
+const REFRESH_KEY = 'refresh_token';
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
 
@@ -32,8 +35,29 @@ export class AuthService {
       `${environment.apiUrl}/auth/login`,
       { login, password }
     ).pipe(
-      tap(res => localStorage.setItem('token', res.token))
+      tap(res => this.guardarSessao(res))
     );
+  }
+
+  /**
+   * Guarda os dois tokens de uma vez.
+   *
+   * Usado pelo login e pela renovação — os dois recebem a mesma resposta, e ter
+   * um lugar só evita que a renovação esqueça de gravar o refresh novo, que é o
+   * jeito silencioso de quebrar a rotação.
+   */
+  guardarSessao(res: LoginResponseDTO): void {
+    localStorage.setItem('token', res.token);
+
+    // API antiga não manda o refresh. Gravar `undefined` viraria a string
+    // "undefined" e a renovação tentaria trocá-la por um token de verdade.
+    if (res.refreshToken) {
+      localStorage.setItem(REFRESH_KEY, res.refreshToken);
+    }
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(REFRESH_KEY);
   }
 
   /**
@@ -45,6 +69,7 @@ export class AuthService {
    */
   logout(): void {
     localStorage.removeItem('token');
+    localStorage.removeItem(REFRESH_KEY);
     this.permissions.clear();
   }
 

--- a/src/app/infrastructure/services/client/client-auth.service.ts
+++ b/src/app/infrastructure/services/client/client-auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, tap } from 'rxjs';
+import { Observable, catchError, finalize, of, tap } from 'rxjs';
 
 import { environment } from '../../../../environments/environment';
 import { LoginResponseDTO } from '../../../domain/models/auth.model';
@@ -54,6 +54,26 @@ export class ClientAuthService {
 
   getRefreshToken(): string | null {
     return localStorage.getItem(CLIENT_REFRESH_KEY) ?? sessionStorage.getItem(CLIENT_REFRESH_KEY);
+  }
+
+  /**
+   * Sair de verdade: avisa o servidor e só então limpa o navegador.
+   *
+   * Vale mais aqui do que no ERP: o portal é usado em computador de recepção,
+   * onde a sessão que sobra é de um cliente que já foi embora.
+   */
+  logoutRemoto(): Observable<void> {
+    const refreshToken = this.getRefreshToken();
+
+    if (!refreshToken) {
+      this.logout();
+      return of(void 0);
+    }
+
+    return this.http.post<void>(`${environment.apiUrl}/auth/logout`, { refreshToken }).pipe(
+      catchError(() => of(void 0)),
+      finalize(() => this.logout()),
+    );
   }
 
   /** Onde a sessão de agora mora — é para lá que a renovação grava. */

--- a/src/app/infrastructure/services/client/client-auth.service.ts
+++ b/src/app/infrastructure/services/client/client-auth.service.ts
@@ -7,6 +7,7 @@ import { LoginResponseDTO } from '../../../domain/models/auth.model';
 
 /** Chave própria: cliente e funcionário podem estar logados no mesmo navegador. */
 const CLIENT_TOKEN_KEY = 'client_token';
+const CLIENT_REFRESH_KEY = 'client_refresh_token';
 
 /**
  * Sessão do cliente, separada da do funcionário.
@@ -32,15 +33,39 @@ export class ClientAuthService {
     this.logout();
 
     return this.http.post<LoginResponseDTO>(`${environment.apiUrl}/auth/login`, { login, password })
-      .pipe(tap(response => {
-        const store = remember ? localStorage : sessionStorage;
-        store.setItem(CLIENT_TOKEN_KEY, response.token);
-      }));
+      .pipe(tap(response => this.guardarSessao(response, remember ? localStorage : sessionStorage)));
+  }
+
+  /**
+   * Guarda os dois tokens no mesmo lugar.
+   *
+   * A renovação não sabe se a pessoa marcou "lembrar de mim", então ela grava
+   * onde o token atual já está — senão uma sessão de recepção, que deveria
+   * morrer com a aba, migraria para o `localStorage` na primeira renovação e
+   * passaria a sobreviver ao fechamento.
+   */
+  guardarSessao(res: LoginResponseDTO, store: Storage = this.storeAtual()): void {
+    store.setItem(CLIENT_TOKEN_KEY, res.token);
+
+    if (res.refreshToken) {
+      store.setItem(CLIENT_REFRESH_KEY, res.refreshToken);
+    }
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(CLIENT_REFRESH_KEY) ?? sessionStorage.getItem(CLIENT_REFRESH_KEY);
+  }
+
+  /** Onde a sessão de agora mora — é para lá que a renovação grava. */
+  private storeAtual(): Storage {
+    return localStorage.getItem(CLIENT_TOKEN_KEY) !== null ? localStorage : sessionStorage;
   }
 
   logout(): void {
     localStorage.removeItem(CLIENT_TOKEN_KEY);
     sessionStorage.removeItem(CLIENT_TOKEN_KEY);
+    localStorage.removeItem(CLIENT_REFRESH_KEY);
+    sessionStorage.removeItem(CLIENT_REFRESH_KEY);
   }
 
   getToken(): string | null {

--- a/src/app/infrastructure/services/session-refresh.service.ts
+++ b/src/app/infrastructure/services/session-refresh.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, catchError, map, of, shareReplay, throwError } from 'rxjs';
+
+import { AuthService } from './auth.service';
+import { ClientAuthService } from './client/client-auth.service';
+import { LoginResponseDTO } from '../../domain/models/auth.model';
+import { environment } from '../../../environments/environment';
+
+/** Qual das duas sessões do navegador está em jogo. */
+export type Sessao = 'erp' | 'cliente';
+
+/**
+ * A renovação da sessão, num lugar só.
+ *
+ * <b>Existe separada porque tem DOIS chamadores, e eles não podem correr.</b>
+ * O interceptor renova quando uma requisição volta `401`; o guard renova quando
+ * alguém navega com o token já vencido. Se cada um tivesse a sua, os dois
+ * disparariam ao mesmo tempo no caso mais comum de todos — clicar num item de
+ * menu depois de duas horas parado, que faz o guard rodar e as requisições da
+ * tela nova saírem logo atrás.
+ *
+ * E aí a rotação viraria contra o usuário: a primeira renovação queima o
+ * refresh que a segunda está mandando, a API lê isso como REUSO e derruba todas
+ * as sessões da pessoa. Uma chamada compartilhada é o que impede a proteção do
+ * servidor de disparar contra quem ela deveria proteger.
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionRefreshService {
+
+  private readonly http = inject(HttpClient);
+  private readonly auth = inject(AuthService);
+  private readonly clientAuth = inject(ClientAuthService);
+
+  /** A renovação em andamento de cada sessão — as duas coexistem no navegador. */
+  private emAndamento: Record<Sessao, Observable<string> | null> = { erp: null, cliente: null };
+
+  /** Há o que renovar? Sessão antiga, ou já revogada, não tem. */
+  temRefreshToken(sessao: Sessao): boolean {
+    return !!this.refreshToken(sessao);
+  }
+
+  /**
+   * Renova, ou entrega o resultado da renovação que já está acontecendo.
+   *
+   * `shareReplay(1)` faz quem chegar durante a chamada aguardar a MESMA, e quem
+   * chegar depois receber o resultado guardado sem ir à rede.
+   *
+   * O campo volta a `null` no fim para a próxima expiração poder renovar de
+   * novo; sem isso, a sessão renovaria uma vez só e nunca mais.
+   */
+  renovar(sessao: Sessao): Observable<string> {
+    const jaEmAndamento = this.emAndamento[sessao];
+    if (jaEmAndamento) return jaEmAndamento;
+
+    const refreshToken = this.refreshToken(sessao);
+    if (!refreshToken) return throwError(() => new Error('sem refresh token'));
+
+    const chamada = this.http
+      .post<LoginResponseDTO>(`${environment.apiUrl}/auth/refresh`, { refreshToken })
+      .pipe(
+        map(res => {
+          this.guardar(sessao, res);
+          this.emAndamento[sessao] = null;
+          return res.token;
+        }),
+        catchError(erro => {
+          this.emAndamento[sessao] = null;
+          return throwError(() => erro);
+        }),
+        shareReplay(1),
+      );
+
+    this.emAndamento[sessao] = chamada;
+    return chamada;
+  }
+
+  /**
+   * Renova se houver o que renovar, e nunca estoura.
+   *
+   * É o que o guard usa: ele decide entre deixar entrar e mandar para o login,
+   * e para isso precisa de uma resposta e não de um erro.
+   */
+  tentarRenovar(sessao: Sessao): Observable<boolean> {
+    if (!this.temRefreshToken(sessao)) return of(false);
+
+    return this.renovar(sessao).pipe(
+      map(() => true),
+      catchError(() => of(false)),
+    );
+  }
+
+  private refreshToken(sessao: Sessao): string | null {
+    return sessao === 'cliente'
+      ? this.clientAuth.getRefreshToken()
+      : this.auth.getRefreshToken();
+  }
+
+  private guardar(sessao: Sessao, res: LoginResponseDTO): void {
+    if (sessao === 'cliente') {
+      this.clientAuth.guardarSessao(res);
+    } else {
+      this.auth.guardarSessao(res);
+    }
+  }
+}

--- a/src/app/layouts/auth-layout/topbar/topbar.component.ts
+++ b/src/app/layouts/auth-layout/topbar/topbar.component.ts
@@ -116,9 +116,15 @@ export class TopbarComponent {
     return roles.length ? roles.join(', ') : 'Sem papéis';
   }
 
+  /**
+   * Espera o servidor encerrar a sessão antes de sair da tela.
+   *
+   * A navegação vai no `subscribe` e não em seguida: `window.location.href`
+   * descarrega a página, e uma requisição em voo no momento do descarregamento é
+   * cancelada pelo navegador — a sessão continuaria viva do lado de lá.
+   */
   logout(): void {
-    this.auth.logout();
-    window.location.href = '/';
+    this.auth.logoutRemoto().subscribe(() => (window.location.href = '/'));
   }
 
   // ── Fechar dropdowns ao clicar fora ──────────────────────────────────────

--- a/src/app/layouts/client-layout/client-layout.component.ts
+++ b/src/app/layouts/client-layout/client-layout.component.ts
@@ -66,8 +66,9 @@ export class ClientLayoutComponent implements OnInit {
   }
 
   logout(): void {
-    this.auth.logout();
-    this.session.clear();
-    this.router.navigate(['/cliente/login']);
+    this.auth.logoutRemoto().subscribe(() => {
+      this.session.clear();
+      this.router.navigate(['/cliente/login']);
+    });
   }
 }


### PR DESCRIPTION
- **fix(sessao): sessao expirada vira uma reacao so, no interceptor**
- **feat(sessao): o token vencido renova sozinho em vez de derrubar a sessao**
- **feat(sessao): Sair encerra a sessao no servidor, nao so no navegador**
- **refactor: fora os case 401 que ficaram inalcancaveis**
- **fix(sessao): navegar com token vencido renova em vez de deslogar**
