### PR TITLE
fix: pk-input mascarava numero como se fossem digitos digitados

### DIFF
--- a/src/app/components/theme/ProautoKimium/pk-input/pk-input.component.spec.ts
+++ b/src/app/components/theme/ProautoKimium/pk-input/pk-input.component.spec.ts
@@ -22,4 +22,66 @@ describe('PkInputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('máscara decimal', () => {
+
+    /** `pkDecimals` é signal input: só dá para setá-lo pela fixture. */
+    function comMascara(casas: number): void {
+      fixture.componentRef.setInput('pkDecimals', casas);
+      fixture.detectChanges();
+    }
+
+    it('escreve um número com as casas que ele tem, e não com os dígitos que aparenta', () => {
+      // O erro que isto tranca: a máscara olha só os dígitos, então o número
+      // 10 sairia '0,10' e 3,5 sairia '0,35' — uma e duas ordens de grandeza
+      // de diferença, num campo de preço.
+      comMascara(2);
+
+      component.writeValue(10);
+      expect(component.innerValue).toBe('10,00');
+
+      component.writeValue(3.5);
+      expect(component.innerValue).toBe('3,50');
+
+      component.writeValue(0.5);
+      expect(component.innerValue).toBe('0,50');
+    });
+
+    it('acerta também o preço de duas casas, que acertava por coincidência', () => {
+      // Sozinho, este teste passa com e sem o defeito. Está aqui porque é o
+      // valor que alguém escolheria para conferir a mão — e é justamente o que
+      // escondia o problema.
+      comMascara(2);
+      component.writeValue(3.79);
+      expect(component.innerValue).toBe('3,79');
+    });
+
+    it('mascara o texto que já vem escrito, sem mexer nele', () => {
+      // O caminho normal: o valor volta do próprio campo, já formatado.
+      comMascara(2);
+      component.writeValue('3,79');
+      expect(component.innerValue).toBe('3,79');
+    });
+
+    it('respeita as casas pedidas quando o número tem outras tantas', () => {
+      comMascara(1);
+      component.writeValue(8.5);
+      expect(component.innerValue).toBe('8,5');
+
+      component.writeValue(12);
+      expect(component.innerValue).toBe('12,0');
+    });
+
+    it('deixa o campo vazio para nulo, e não zerado', () => {
+      comMascara(2);
+      component.writeValue(null);
+      expect(component.innerValue).toBe('');
+    });
+
+    it('não mexe em campo sem máscara', () => {
+      // `pkDecimals` nulo é o padrão: nenhum dos campos que já existem muda.
+      component.writeValue('texto livre');
+      expect(component.innerValue).toBe('texto livre');
+    });
+  });
 });

--- a/src/app/components/theme/ProautoKimium/pk-input/pk-input.component.ts
+++ b/src/app/components/theme/ProautoKimium/pk-input/pk-input.component.ts
@@ -14,7 +14,7 @@ import {
 } from '@angular/forms';
 import { InputTextModule } from 'primeng/inputtext';
 
-import { mascararDecimal } from '../../../../domain/utils/decimal-br';
+import { mascararDecimal, formatarDecimal } from '../../../../domain/utils/decimal-br';
 
 export type PkInputType = 'text' | 'email' | 'password' | 'number' | 'tel' | 'search';
 
@@ -68,7 +68,13 @@ export class PkInputComponent implements ControlValueAccessor, Validator {
   writeValue(val: any): void {
     const casas = this.pkDecimals();
     if (casas !== null) {
-      this.innerValue = mascararDecimal(String(val ?? ''), casas);
+      // Número e texto entram por caminhos diferentes, e tratar os dois igual
+      // é errado por uma ordem de grandeza: a máscara só olha os dígitos, então
+      // o número 10 viraria '0,10' e 3,5 viraria '0,35'. Passa despercebido
+      // porque um preço de duas casas — 3,79 — acerta por coincidência.
+      this.innerValue = typeof val === 'number'
+        ? formatarDecimal(val, casas)
+        : mascararDecimal(String(val ?? ''), casas);
       this.cdr.markForCheck();
       return;
     }


### PR DESCRIPTION
writeValue tratava numero e texto pelo mesmo caminho, e a mascara olha
so os digitos: o numero 10 virava 0,10 e 3,5 virava 0,35 - uma e duas
ordens de grandeza de diferenca num campo de preco.

Passava despercebido porque um preco de duas casas acerta por
coincidencia: 3.79 vira '3,79' pelos dois caminhos. E o valor que
alguem escolheria para conferir a mao.

Nenhuma tela de hoje passa numero - as duas calculadoras guardam texto -
entao isto e armadilha para quem usar pkDecimals num controle numerico,
que e o jeito obvio de ligar um campo de preco.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjMkoQ2peSXbkNSyTK14pq
