### PR TITLE
fix(topbar): busca do celular abre por cima da barra em vez de cortar

### DIFF
--- a/src/app/layouts/auth-layout/topbar/topbar-busca-celular.spec.ts
+++ b/src/app/layouts/auth-layout/topbar/topbar-busca-celular.spec.ts
@@ -1,0 +1,200 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { TopbarComponent } from './topbar.component';
+
+/**
+ * **A busca do celular abre por cima da topbar.**
+ *
+ * O campo tinha largura fixa de 130px no celular, mas o respiro interno
+ * continuava o do desktop — 32px de cada lado. Medido: sobravam 64px para um
+ * placeholder que precisa de 95px, e o texto cortava.
+ *
+ * A lista de resultados cortava pelo mesmo motivo, e pior: ancorada pela
+ * direita e com 340px de largura, presa a um `.search` de 130px no meio da
+ * barra, a borda esquerda dela caía **fora da tela**.
+ *
+ * Alargar o campo no lugar não resolvia — num aparelho de 320px não há espaço
+ * para dar. A topbar inteira é a única largura que existe em qualquer celular.
+ */
+describe('TopbarComponent · a busca no celular', () => {
+
+  /** Abaixo de $bp-md (768px), que é onde a busca vira lupa. */
+  const LARGURA_CELULAR = 390;
+
+  let fixture: ComponentFixture<TopbarComponent>;
+  let topbar: TopbarComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TopbarComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TopbarComponent);
+    topbar = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const elemento = (seletor: string) =>
+    fixture.nativeElement.querySelector(seletor) as HTMLElement | null;
+
+  /**
+   * Roda o trecho com a moldura do Karma na largura de um celular, para que as
+   * regras de `@media` do SCSS realmente casem — e devolve a largura original
+   * depois, mesmo se a expectativa falhar.
+   */
+  async function noCelular(trecho: () => Promise<void>): Promise<void> {
+    const moldura = window.frameElement as HTMLElement | null;
+    if (!moldura) {
+      pending('a suíte não está rodando dentro do iframe do Karma; sem ele o @media não muda');
+      return;
+    }
+
+    const antes = moldura.style.width;
+    moldura.style.width = `${LARGURA_CELULAR}px`;
+    await new Promise(requestAnimationFrame);
+
+    try {
+      await trecho();
+    } finally {
+      moldura.style.width = antes;
+      await new Promise(requestAnimationFrame);
+    }
+  }
+
+  it('nasce fechada', () => {
+    expect(topbar.searchOpen()).toBeFalse();
+  });
+
+  it('tem a lupa que abre a busca, com o estado anunciado para leitores de tela', () => {
+    const lupa = elemento('.search-trigger');
+
+    expect(lupa).withContext('a lupa é o que ocupa o lugar do campo no celular').not.toBeNull();
+    expect(lupa!.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('a lupa abre a busca', async () => {
+    elemento('.search-trigger')!.click();
+    await fixture.whenStable();
+
+    expect(topbar.searchOpen()).toBeTrue();
+    expect(elemento('.search')!.classList).toContain('is-open');
+    expect(elemento('.search-trigger')!.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('Cancelar fecha a busca e apaga o que foi escrito', async () => {
+    topbar.openSearch();
+    topbar.onSearchInput('rela');
+    await fixture.whenStable();
+
+    elemento('.search__cancel')!.click();
+    await fixture.whenStable();
+
+    expect(topbar.searchOpen()).withContext('a folha fecha').toBeFalse();
+    expect(topbar.searchQuery()).withContext('e não guarda a busca anterior').toBe('');
+    expect(topbar.showResults()).toBeFalse();
+  });
+
+  it('Esc fecha a busca, e não só limpa o texto', () => {
+    topbar.openSearch();
+    topbar.onSearchInput('rela');
+
+    topbar.onSearchKeydown(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    expect(topbar.searchOpen()).toBeFalse();
+  });
+
+  /**
+   * Se `goToResult` só limpasse o texto, a folha ficaria aberta por cima da
+   * tela para onde a pessoa acabou de navegar.
+   */
+  it('escolher um resultado fecha a busca', () => {
+    topbar.openSearch();
+    topbar.onSearchInput('rela');
+
+    topbar.goToResult({ label: 'Qualquer', breadcrumb: 'Qualquer', icon: 'pi pi-file', routerLink: ['/'] } as never);
+
+    expect(topbar.searchOpen()).toBeFalse();
+  });
+
+  it('tocar fora fecha a busca', () => {
+    topbar.openSearch();
+
+    topbar.onDocumentClick({ target: document.body } as unknown as MouseEvent);
+
+    expect(topbar.searchOpen()).toBeFalse();
+  });
+
+  /**
+   * **O teste que pega o defeito de verdade.**
+   *
+   * Não pergunta ao CSS gerado, pergunta ao navegador: com a busca aberta, o
+   * espaço que sobra para o texto tem que caber o placeholder. É a mesma conta
+   * que provou o defeito — largura do campo menos respiro menos bordas.
+   *
+   * **O estreitamento não é detalhe, é o teste.** O `@media` responde à largura
+   * da janela, e a janela do Karma é de desktop: sem encolher a moldura, a
+   * regra do celular nunca casa e o teste passa mesmo com o defeito de volta.
+   * Foi o que aconteceu na primeira versão dele.
+   */
+  it('aberta, o campo cabe o texto do placeholder', async () => {
+    await noCelular(async () => {
+      topbar.openSearch();
+      await fixture.whenStable();
+
+      const campo = elemento('.search__input') as HTMLInputElement;
+      const estilo = getComputedStyle(campo);
+
+      const util = campo.getBoundingClientRect().width
+        - parseFloat(estilo.paddingLeft) - parseFloat(estilo.paddingRight)
+        - parseFloat(estilo.borderLeftWidth) - parseFloat(estilo.borderRightWidth);
+
+      const sonda = document.createElement('span');
+      sonda.textContent = campo.placeholder;
+      sonda.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap';
+      sonda.style.font = estilo.font;
+      document.body.appendChild(sonda);
+      const texto = sonda.getBoundingClientRect().width;
+      sonda.remove();
+
+      expect(util)
+        .withContext(`o placeholder "${campo.placeholder}" precisa de ${texto.toFixed(1)}px`)
+        .toBeGreaterThanOrEqual(texto);
+    });
+  });
+
+  /**
+   * A lista de resultados tem que caber na tela pelas DUAS pontas. Ela é
+   * ancorada pela direita e tinha largura fixa de 340px; presa a um `.search`
+   * estreito no meio da barra, a borda esquerda dela ficava em x negativo.
+   */
+  it('aberta, a lista de resultados fica dentro da tela', async () => {
+    await noCelular(async () => {
+      topbar.openSearch();
+      topbar.onSearchInput('a');
+      await fixture.whenStable();
+
+      const lista = fixture.nativeElement.querySelector('.search__dropdown') as HTMLElement;
+      expect(lista).withContext('a lista precisa estar aberta para ser medida').not.toBeNull();
+
+      const caixa = lista.getBoundingClientRect();
+
+      expect(caixa.left)
+        .withContext(`a borda esquerda da lista caiu em ${caixa.left.toFixed(1)}px`)
+        .toBeGreaterThanOrEqual(0);
+
+      expect(caixa.right)
+        .withContext(`a borda direita passou de ${LARGURA_CELULAR}px`)
+        .toBeLessThanOrEqual(LARGURA_CELULAR);
+    });
+  });
+});

--- a/src/app/layouts/auth-layout/topbar/topbar.component.html
+++ b/src/app/layouts/auth-layout/topbar/topbar.component.html
@@ -22,26 +22,40 @@
   <!-- Direita: busca + ações -->
   <div class="topbar__right">
 
-    <div class="search">
-      <i class="pi pi-search search__icon" aria-hidden="true"></i>
-      <input type="text"
-             class="search__input"
-             placeholder="Buscar página..."
-             role="combobox"
-             aria-label="Buscar página"
-             [attr.aria-expanded]="showResults()"
-             aria-controls="topbar-search-results"
-             autocomplete="off"
-             [ngModel]="searchQuery()"
-             (ngModelChange)="onSearchInput($event)"
-             (focus)="onSearchFocus()"
-             (keydown)="onSearchKeydown($event)" />
+    <!-- Só no celular: abre a busca por cima da topbar (ver .search.is-open) -->
+    <button type="button"
+            class="icon-btn search-trigger"
+            aria-label="Buscar página"
+            [attr.aria-expanded]="searchOpen()"
+            (click)="openSearch()">
+      <i class="pi pi-search"></i>
+    </button>
 
-      @if (searchQuery()) {
-        <button type="button" class="search__clear" aria-label="Limpar busca" tabindex="-1" (click)="clearSearch()">
-          <i class="pi pi-times"></i>
-        </button>
-      }
+    <div class="search" [class.is-open]="searchOpen()">
+      <div class="search__field">
+        <i class="pi pi-search search__icon" aria-hidden="true"></i>
+        <input type="text"
+               #searchInput
+               class="search__input"
+               placeholder="Buscar página..."
+               role="combobox"
+               aria-label="Buscar página"
+               [attr.aria-expanded]="showResults()"
+               aria-controls="topbar-search-results"
+               autocomplete="off"
+               [ngModel]="searchQuery()"
+               (ngModelChange)="onSearchInput($event)"
+               (focus)="onSearchFocus()"
+               (keydown)="onSearchKeydown($event)" />
+
+        @if (searchQuery()) {
+          <button type="button" class="search__clear" aria-label="Limpar busca" tabindex="-1" (click)="clearSearch()">
+            <i class="pi pi-times"></i>
+          </button>
+        }
+      </div>
+
+      <button type="button" class="search__cancel" (click)="closeSearch()">Cancelar</button>
 
       @if (showResults()) {
         <div class="search__dropdown" id="topbar-search-results" role="listbox">

--- a/src/app/layouts/auth-layout/topbar/topbar.component.scss
+++ b/src/app/layouts/auth-layout/topbar/topbar.component.scss
@@ -112,7 +112,43 @@
 // ─── Busca ──────────────────────────────────────────────────────────────────
 .search {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: v.$space-2;
   width: 260px;
+}
+
+// A lupa e o × se ancoram no CAMPO, não no `.search` — que no celular deixa de
+// ser do tamanho do campo e vira a faixa inteira da topbar.
+.search__field {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+// Aparece só no celular: é o que ocupa o lugar do campo quando ele está fechado.
+.search-trigger {
+  display: none;
+}
+
+// Idem — só existe com a busca aberta por cima da topbar.
+.search__cancel {
+  display: none;
+  flex: 0 0 auto;
+  padding: 0 v.$space-1;
+  border: 0;
+  background: transparent;
+  color: var(--app-primary);
+  font-family: v.$font-body;
+  font-size: v.$font-size-sm;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--app-primary);
+    outline-offset: 2px;
+    border-radius: v.$radius-sm;
+  }
 }
 
 .search__icon {
@@ -356,13 +392,50 @@
   .topbar { padding-left: v.$space-2; padding-right: v.$space-2; }
   .user__name { display: none; }
   .user__chevron { display: none; }
-  .search { width: 150px; }
-  .search__dropdown { width: min(340px, calc(100vw - #{v.$space-6})); }
+
+  .search-trigger { display: inline-flex; }
+
+  // Fechada, a busca não ocupa lugar nenhum: quem fica na barra é a lupa.
+  .search { display: none; }
+
+  // Aberta, ela cobre a topbar inteira — a única largura que existe em
+  // qualquer aparelho. Alargar o campo no lugar dele não resolveria: num
+  // celular de 320px não há espaço para dar.
+  .search.is-open {
+    display: flex;
+    position: absolute;
+    top: env(safe-area-inset-top);
+    left: 0;
+    right: 0;
+    width: auto;
+    height: var(--topbar-h);
+    padding: 0 v.$space-2;
+    background: var(--app-surface);
+    z-index: 2;
+    animation: search-abre v.$transition-base ease-out;
+  }
+
+  .search__cancel { display: block; }
+
+  // **Os resultados cortavam pelo mesmo motivo do campo.** A lista é ancorada
+  // pela direita (`right: 0`) e tem 340px; presa a um `.search` de 130px no
+  // meio da barra, a borda esquerda dela caía fora da tela. Agora ela acompanha
+  // a faixa aberta, e as duas pontas ficam à vista.
+  .search__dropdown {
+    left: v.$space-2;
+    right: v.$space-2;
+    width: auto;
+    max-height: 60vh;
+  }
 }
 
 @media (max-width: v.$bp-xs) {
   .topbar__brand { display: none; }
-  .search { width: 130px; }
+}
+
+@keyframes search-abre {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -371,4 +444,8 @@
     transition: none;
   }
   .icon-btn:active { transform: none; }
+
+  // A busca abre igual, só sem o deslize. A animação é enfeite; o que importa
+  // é o campo estar lá, e ele está.
+  .search.is-open { animation: none; }
 }

--- a/src/app/layouts/auth-layout/topbar/topbar.component.ts
+++ b/src/app/layouts/auth-layout/topbar/topbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, ElementRef, inject, output, signal } from '@angular/core';
+import { Component, HostListener, ElementRef, inject, output, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -38,6 +38,21 @@ export class TopbarComponent {
   /** Item destacado pelas setas do teclado; -1 = nenhum. */
   readonly activeIndex = signal(-1);
 
+  /**
+   * **Só o celular liga isto.** No desktop o campo está sempre visível e este
+   * sinal não muda nada — quem decide é o `@media` do SCSS, não o TypeScript.
+   *
+   * O campo encolhia junto com a tela mas o respiro interno continuava o do
+   * desktop (32px de cada lado), então sobravam 64px para um texto que precisa
+   * de 95px: o placeholder cortava. Alargar o campo não resolvia em toda tela —
+   * num celular de 320px não há espaço para dar. Aqui a busca vira uma lupa e,
+   * ao tocar, ocupa a topbar inteira, que é largura que existe em qualquer
+   * aparelho.
+   */
+  readonly searchOpen = signal(false);
+
+  private readonly searchInput = viewChild<ElementRef<HTMLInputElement>>('searchInput');
+
   readonly userMenuOpen = signal(false);
 
   constructor() {
@@ -49,6 +64,23 @@ export class TopbarComponent {
   }
 
   // ── Busca ─────────────────────────────────────────────────────────────────
+
+  /**
+   * O foco vai num `setTimeout` porque o campo ainda está `display: none`
+   * quando este método roda: o sinal só vira CSS depois que o Angular
+   * renderiza, e `focus()` em elemento não exibido não faz nada — sem erro
+   * nenhum, o teclado simplesmente não sobe.
+   */
+  openSearch(): void {
+    this.searchOpen.set(true);
+    setTimeout(() => this.searchInput()?.nativeElement.focus());
+  }
+
+  /** Fecha a busca do celular e apaga o que estava escrito. */
+  closeSearch(): void {
+    this.clearSearch();
+    this.searchOpen.set(false);
+  }
 
   onSearchInput(value: string): void {
     this.searchQuery.set(value);
@@ -88,7 +120,7 @@ export class TopbarComponent {
       }
 
       case 'Escape':
-        this.clearSearch();
+        this.closeSearch();
         break;
     }
   }
@@ -99,7 +131,7 @@ export class TopbarComponent {
     } else if (item.url) {
       window.open(item.url, item.target ?? '_self');
     }
-    this.clearSearch();
+    this.closeSearch();
   }
 
   clearSearch(): void {
@@ -134,6 +166,7 @@ export class TopbarComponent {
     if (this.elRef.nativeElement.contains(event.target)) return;
     this.showResults.set(false);
     this.userMenuOpen.set(false);
+    this.searchOpen.set(false);
   }
 
   private updateBreadcrumb(): void {


### PR DESCRIPTION
O campo encolhia para 130px no celular, mas o respiro interno continuava o
do desktop — 32px de cada lado. Medido no navegador: sobravam 57px para um
placeholder que precisa de 100px, e o texto cortava.

A lista de resultados cortava pelo mesmo motivo, e pior. Ela e ancorada
pela direita e tinha 340px de largura; presa a um `.search` de 130px no
meio da barra, a borda esquerda dela ficava em -126px — fora da tela.

Alargar o campo no lugar dele nao resolvia: num aparelho de 320px nao ha
espaco para dar. Entao no celular a busca vira uma lupa e, ao tocar, ocupa
a topbar inteira, com Cancelar ao lado. A lista acompanha essa faixa. E a
unica largura que existe em qualquer aparelho.

Esc, tocar fora e escolher um resultado fecham a folha — antes o Esc so
limpava o texto, e escolher um resultado deixava a folha aberta por cima
da tela para onde a pessoa tinha acabado de navegar.

O `.search__field` e novo: a lupa e o × precisavam se ancorar no campo, e
nao no `.search`, que agora e a faixa inteira.
