### PR TITLE
fix(bottom-nav): o quinto atalho procura a proxima tela, em vez de desistir

### DIFF
--- a/src/app/infrastructure/services/telas-recentes.service.ts
+++ b/src/app/infrastructure/services/telas-recentes.service.ts
@@ -56,12 +56,17 @@ export class TelasRecentesService {
       .slice(0, QUANTAS_RECENTES));
 
   /**
-   * A tela de hábito, para o atalho da barra de baixo. Empate de visitas
+   * As telas em ordem de hábito — mais visitadas primeiro. Empate de visitas
    * desempata pelo acesso mais recente.
+   *
+   * **É a lista inteira, e não só a primeira, de propósito.** A barra de baixo
+   * precisa da mais usada *que ainda não esteja nela*: entregar só o topo
+   * fazia a Início — onde o app abre, e por isso quase sempre a campeã de
+   * visitas num celular — esconder o atalho que a barra existe para mostrar.
    */
-  readonly maisUsada = computed<TelaRecente | undefined>(() =>
+  readonly porHabito = computed<TelaRecente[]>(() =>
     [...this.registro()]
-      .sort((a, b) => b.visitas - a.visitas || b.ultimoAcesso - a.ultimoAcesso)[0]);
+      .sort((a, b) => b.visitas - a.visitas || b.ultimoAcesso - a.ultimoAcesso));
 
   constructor() {
     this.restaurar();

--- a/src/app/layouts/auth-layout/bottom-nav/bottom-nav-atalho-de-habito.spec.ts
+++ b/src/app/layouts/auth-layout/bottom-nav/bottom-nav-atalho-de-habito.spec.ts
@@ -1,0 +1,130 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+import { BottomNavComponent } from './bottom-nav.component';
+import { MenuService } from '../../../infrastructure/services/menu.service';
+import { NotificationService } from '../../../infrastructure/services/notification.service';
+import { TelasRecentesService, TelaRecente } from '../../../infrastructure/services/telas-recentes.service';
+import { AppMenuItem } from '../menu.config';
+
+/**
+ * **O quinto atalho da barra de baixo.**
+ *
+ * A barra tem quatro fixos e um quinto lugar para o hábito: a tela que a pessoa
+ * mais abre. A regra antiga pegava a mais visitada e desistia se ela já
+ * estivesse entre os fixos — **sem procurar a seguinte**.
+ *
+ * Isso matava o quinto lugar no celular. A Início está no `APP_MENU`, então
+ * cada visita a ela conta; e a Início é onde o app abre e onde o login cai,
+ * então ela é quase sempre a mais visitada de um celular. O resultado é que a
+ * presença dela na barra escondia o atalho que a barra existia para mostrar.
+ *
+ * E quando aparecia, piscava: com o registro zerado, uma visita a outra tela
+ * empatava e ganhava no desempate por recência — depois duas voltas à Início
+ * faziam o atalho sumir de novo.
+ */
+describe('BottomNavComponent · o quinto atalho', () => {
+
+  const FIXOS: AppMenuItem[] = [
+    { label: 'Início', icon: 'pi pi-home', routerLink: ['home'] },
+    { label: 'Documentos', icon: 'pi pi-folder', routerLink: ['documentos'] },
+    { label: 'Notificações', icon: 'pi pi-bell', routerLink: ['notificacoes'] },
+    { label: 'Perfil', icon: 'pi pi-user', routerLink: ['perfil'] },
+  ];
+
+  const tela = (path: string, label: string, visitas: number, quando = 0): TelaRecente => ({
+    path, label, icon: 'pi pi-file', breadcrumb: label, visitas, ultimoAcesso: quando,
+  });
+
+  /** Monta a barra com um registro de telas recentes controlado pelo teste. */
+  async function montar(registro: TelaRecente[]): Promise<BottomNavComponent> {
+    const ordenado = [...registro]
+      .sort((a, b) => b.visitas - a.visitas || b.ultimoAcesso - a.ultimoAcesso);
+
+    const recentes = { porHabito: signal(ordenado) };
+
+    await TestBed.configureTestingModule({
+      imports: [BottomNavComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: MenuService, useValue: { mobileItems: () => FIXOS } },
+        { provide: NotificationService, useValue: { unreadCount: signal(0) } },
+        { provide: TelasRecentesService, useValue: recentes },
+      ],
+    }).compileComponents();
+
+    return TestBed.createComponent(BottomNavComponent).componentInstance;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('sem histórico nenhum, mostra só os quatro fixos', async () => {
+    const barra = await montar([]);
+
+    expect(barra.items().length).toBe(4);
+  });
+
+  /** **O teste que pega o defeito.** */
+  it('a Início ser a mais visitada não pode esconder o quinto atalho', async () => {
+    const barra = await montar([
+      tela('/home', 'Início', 40),
+      tela('/programacao', 'Programação', 12),
+      tela('/estoque', 'Estoque', 3),
+    ]);
+
+    expect(barra.items().length)
+      .withContext('a Início já está na barra; o hábito seguinte é que merece o lugar')
+      .toBe(5);
+
+    expect(barra.items()[4].label).toBe('Programação');
+  });
+
+  it('pula quantos fixos forem precisos até achar uma tela de fora', async () => {
+    const barra = await montar([
+      tela('/home', 'Início', 40),
+      tela('/notificacoes', 'Notificações', 30),
+      tela('/perfil', 'Perfil', 20),
+      tela('/documentos', 'Documentos', 10),
+      tela('/estoque', 'Estoque', 2),
+    ]);
+
+    expect(barra.items().length).toBe(5);
+    expect(barra.items()[4].label).toBe('Estoque');
+  });
+
+  it('se TUDO que a pessoa abre já está na barra, não inventa um quinto', async () => {
+    const barra = await montar([
+      tela('/home', 'Início', 40),
+      tela('/documentos', 'Documentos', 10),
+    ]);
+
+    expect(barra.items().length).toBe(4);
+  });
+
+  /**
+   * O atalho não pode trocar a cada navegação: uma barra que muda de item é
+   * pior que uma barra fixa. Duas visitas à Início não mexem no quinto lugar.
+   */
+  it('não pisca quando a pessoa volta para a Início', async () => {
+    const antes = await montar([
+      tela('/home', 'Início', 1, 100),
+      tela('/programacao', 'Programação', 1, 200),
+    ]);
+
+    expect(antes.items()[4].label).toBe('Programação');
+
+    TestBed.resetTestingModule();
+
+    const depois = await montar([
+      tela('/home', 'Início', 3, 300),
+      tela('/programacao', 'Programação', 1, 200),
+    ]);
+
+    expect(depois.items().length)
+      .withContext('a Início subiu, mas o hábito de fora continua sendo Programação')
+      .toBe(5);
+    expect(depois.items()[4].label).toBe('Programação');
+  });
+});

--- a/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.ts
+++ b/src/app/layouts/auth-layout/bottom-nav/bottom-nav.component.ts
@@ -57,9 +57,17 @@ export class BottomNavComponent {
     { initialValue: this.router.url });
 
   /**
-   * Os atalhos fixos mais o de hábito. O quinto entra só quando a pessoa já
-   * tem histórico e ele não repete um dos fixos — barra com item repetido
-   * desperdiça o espaço mais valioso da tela.
+   * Os atalhos fixos mais o de hábito.
+   *
+   * O quinto é a tela mais visitada **que ainda não está na barra** — repetir
+   * um fixo desperdiçaria o espaço mais valioso da tela.
+   *
+   * **Procurar a seguinte, e não desistir na primeira, é o ponto.** Antes isto
+   * olhava só a campeã de visitas e devolvia os quatro fixos quando ela já
+   * estava ali. Como a Início está no menu, cada visita a ela conta — e é onde
+   * o app abre e onde o login cai, então num celular ela é quase sempre a
+   * campeã. O quinto lugar simplesmente nunca aparecia; e quando aparecia,
+   * piscava, porque duas voltas à Início bastavam para retomar a liderança.
    */
   readonly items = computed<ItemDaBarra[]>(() => {
     const fixos = this.menuService.mobileItems().map(item => this.paraItem(
@@ -68,11 +76,10 @@ export class BottomNavComponent {
       item.routerLink ?? [],
       item.routerLink?.[0] === 'notificacoes'));
 
-    const habito = this.telasRecentes.maisUsada();
-    if (!habito) return fixos;
+    const habito = this.telasRecentes.porHabito()
+      .find(tela => !fixos.some(fixo => fixo.path === tela.path));
 
-    const jaEstaNaBarra = fixos.some(fixo => fixo.path === habito.path);
-    if (jaEstaNaBarra) return fixos;
+    if (!habito) return fixos;
 
     return [...fixos, this.paraItem(
       habito.label,


### PR DESCRIPTION
A barra tem quatro fixos e um quinto lugar para o habito. A regra pegava a
tela mais visitada e devolvia so os quatro quando ela ja estava na barra —
sem procurar a seguinte.

Isso matava o quinto lugar no celular. A Inicio esta no APP_MENU, entao
cada visita a ela conta; e a Inicio e onde o app abre e onde o login cai,
o que faz dela a campea de visitas de quase todo celular. A presenca dela
na barra escondia o atalho que a barra existe para mostrar.

E quando aparecia, piscava: com o registro zerado, uma visita a outra tela
empatava e ganhava no desempate por recencia; duas voltas a Inicio e o
atalho sumia de novo. Barra que muda de item e pior que barra fixa.

Agora pega a mais visitada QUE AINDA NAO ESTA na barra. Para isso o
servico expoe `porHabito` (a lista ordenada) no lugar de `maisUsada` (so o
topo) — era a unica consumidora.

Ele viu o defeito ao comparar o celular com a visualizacao mobile do
computador: cinco itens la, quatro no aparelho. O historico fica em
localStorage por usuario e por aparelho, entao os dois contam separado.
