### PR TITLE
fix(rh): botao "Ver Niveis" some, e ordem de nivel/hierarquia ja vem sugerida

### DIFF
--- a/src/app/components/auth/rh/career-structure/career-structure-botao-ver-niveis.spec.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure-botao-ver-niveis.spec.ts
@@ -1,0 +1,110 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+
+import { CareerStructureComponent } from './career-structure.component';
+import { PositionStore, PositionLevelStore } from '../../../../infrastructure/state/position.store';
+
+/**
+ * **O botão "Ver Níveis" não aparecia.**
+ *
+ * O template usa a diretiva `pButton`, e o `ButtonModule` não estava na lista
+ * de `imports` do componente. Diretiva desconhecida em componente standalone é
+ * **aviso, não erro**: o build passa, o `<button>` vai para a tela sem o
+ * rótulo e sem o ícone — que são inputs da diretiva — e sai um botão vazio.
+ *
+ * O `.action-btn.p-button` do SCSS prova a intenção: a regra foi escrita para
+ * o botão do PrimeNG. O que faltava era só o import.
+ *
+ * Por isso o teste pergunta ao DOM, e não ao TypeScript: era exatamente o tipo
+ * de defeito que compila.
+ */
+describe('CareerStructureComponent · o botão Ver Níveis', () => {
+
+  const CARGOS = [
+    { id: 'cargo-1', name: 'Desenvolvedor' },
+    { id: 'cargo-2', name: 'Analista' },
+  ];
+
+  async function montar() {
+    await TestBed.configureTestingModule({
+      imports: [CareerStructureComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+        {
+          provide: PositionStore,
+          useValue: {
+            items: signal(CARGOS),
+            loading: signal(false),
+            load: () => {},
+            refresh: () => {},
+          },
+        },
+        {
+          provide: PositionLevelStore,
+          useValue: {
+            levelsOf: () => [],
+            isLoading: () => false,
+            load: () => {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CareerStructureComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  /** **O teste que pega o defeito.** */
+  it('mostra o rótulo "Ver Níveis" na tela', async () => {
+    const fixture = await montar();
+
+    const botoes = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll('button'),
+    ) as HTMLButtonElement[];
+
+    const verNiveis = botoes.filter(b => (b.textContent ?? '').includes('Ver Níveis'));
+
+    expect(verNiveis.length)
+      .withContext('um por cargo — sem a diretiva, o botão sai vazio e o texto some')
+      .toBe(CARGOS.length);
+  });
+
+  /**
+   * A diretiva do PrimeNG é quem põe a classe `p-button`. Sem ela, o
+   * `.action-btn.p-button` do SCSS não casa e o botão fica sem estilo nenhum.
+   */
+  it('o botão recebe a classe que o SCSS da tela espera', async () => {
+    const fixture = await montar();
+
+    const botao = (fixture.nativeElement as HTMLElement)
+      .querySelector('button.action-btn') as HTMLButtonElement | null;
+
+    expect(botao).withContext('o botão precisa existir').not.toBeNull();
+    expect(botao!.classList)
+      .withContext('`.action-btn.p-button` do SCSS depende desta classe')
+      .toContain('p-button');
+  });
+
+  it('e leva o ícone que a diretiva monta', async () => {
+    const fixture = await montar();
+
+    const icone = (fixture.nativeElement as HTMLElement)
+      .querySelector('button.action-btn .pi-list');
+
+    expect(icone).not.toBeNull();
+  });
+});

--- a/src/app/components/auth/rh/career-structure/career-structure-ordem-sugerida.spec.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure-ordem-sugerida.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+
+import { CareerStructureComponent } from './career-structure.component';
+import { PositionStore, PositionLevelStore } from '../../../../infrastructure/state/position.store';
+
+/**
+ * **A ordem do novo nível já vem sugerida.**
+ *
+ * O campo abria vazio, e quem cadastrava digitava 1 de novo — então Júnior e
+ * Pleno terminavam os dois na ordem 1, e a lista deixava de ter ordem.
+ *
+ * É **sugestão, não trava**: o campo continua editável, porque encaixar um
+ * nível no meio da escala é uma coisa legítima de se querer fazer.
+ */
+describe('CareerStructureComponent · a ordem sugerida do nível', () => {
+
+  const CARGO = { id: 'cargo-1', name: 'Desenvolvedor' };
+
+  const nivel = (name: string, levelOrder: number) =>
+    ({ id: `n-${name}`, name, levelOrder, positionId: CARGO.id }) as never;
+
+  async function montar(niveis: unknown[]) {
+    await TestBed.configureTestingModule({
+      imports: [CareerStructureComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+        {
+          provide: PositionStore,
+          useValue: {
+            items: signal([CARGO]), loading: signal(false),
+            load: () => {}, refresh: () => {},
+          },
+        },
+        {
+          provide: PositionLevelStore,
+          useValue: {
+            levelsOf: () => niveis,
+            isLoading: () => false,
+            load: () => {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(CareerStructureComponent);
+    const tela = fixture.componentInstance;
+    fixture.detectChanges();
+
+    tela.selectPosition(CARGO as never);
+    return tela;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('o primeiro nível de um cargo nasce na ordem 1', async () => {
+    const tela = await montar([]);
+
+    tela.openLevelForm();
+
+    expect(tela.levelForm.get('levelOrder')!.value).toBe(1);
+  });
+
+  /** **O teste que pega o defeito:** era aqui que saía outro 1. */
+  it('com um nível cadastrado, sugere a próxima ordem', async () => {
+    const tela = await montar([nivel('Júnior', 1)]);
+
+    tela.openLevelForm();
+
+    expect(tela.levelForm.get('levelOrder')!.value)
+      .withContext('Júnior está na 1; Pleno não pode nascer na 1 também')
+      .toBe(2);
+  });
+
+  it('soma a partir da MAIOR ordem, não da quantidade de níveis', async () => {
+    const tela = await montar([nivel('Júnior', 1), nivel('Sênior', 7)]);
+
+    tela.openLevelForm();
+
+    expect(tela.levelForm.get('levelOrder')!.value)
+      .withContext('dois níveis, mas a escala já vai até 7')
+      .toBe(8);
+  });
+
+  it('não se confunde com a ordem em que os níveis chegam', async () => {
+    const tela = await montar([nivel('Sênior', 3), nivel('Júnior', 1)]);
+
+    tela.openLevelForm();
+
+    expect(tela.levelForm.get('levelOrder')!.value).toBe(4);
+  });
+
+  /** Sugestão, não imposição: dá para encaixar um nível no meio da escala. */
+  it('a ordem continua editável', async () => {
+    const tela = await montar([nivel('Júnior', 1)]);
+
+    tela.openLevelForm();
+    tela.levelForm.get('levelOrder')!.setValue(1);
+
+    expect(tela.levelForm.get('levelOrder')!.value).toBe(1);
+    expect(tela.levelForm.get('levelOrder')!.enabled).toBeTrue();
+  });
+});

--- a/src/app/components/auth/rh/career-structure/career-structure.component.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MessageService } from 'primeng/api';
 import { Toast } from 'primeng/toast';
+import { ButtonModule } from 'primeng/button';
 import { TableModule } from 'primeng/table';
 import { SelectModule } from 'primeng/select';
 import { DatePickerModule } from 'primeng/datepicker';
@@ -28,7 +29,7 @@ import { FormScreenComponent } from '../../shared/form-screen/form-screen.compon
   selector: 'app-career-structure',
   standalone: true,
   imports: [
-    CommonModule, ReactiveFormsModule, TableModule, SelectModule, DatePickerModule, Toast,
+    CommonModule, ReactiveFormsModule, ButtonModule, TableModule, SelectModule, DatePickerModule, Toast,
     PkButtonComponent, PkDialogComponent, PkTableComponent, PkInputComponent,
     ToolbarComponent, FormScreenComponent,
   ],
@@ -168,8 +169,31 @@ export class CareerStructureComponent implements OnInit, TabDirtyCheck {
     return this.levelForm.get('adjustmentType')?.value === 'FIXED';
   }
 
+  /**
+   * A proxima ordem livre da escala do cargo — 1 quando ainda nao ha nenhum.
+   *
+   * Vem da MAIOR ordem, e nao da quantidade de niveis: escala com buracos
+   * (1, 3, 7) e comum, e contar quantos existem sugeriria uma ordem que ja
+   * esta ocupada.
+   */
+  readonly proximaOrdem = computed(() => {
+    const ordens = this.levels()
+      .map(nivel => nivel.levelOrder)
+      .filter((ordem): ordem is number => typeof ordem === 'number');
+
+    return ordens.length ? Math.max(...ordens) + 1 : 1;
+  });
+
+  /**
+   * A ordem ja vem preenchida — **sugestao, nao trava.**
+   *
+   * O campo abria vazio e quem cadastrava digitava 1 de novo, entao Junior e
+   * Pleno terminavam os dois na ordem 1 e a lista deixava de ter ordem. O
+   * campo continua editavel porque encaixar um nivel no meio da escala e uma
+   * coisa legitima de se querer fazer.
+   */
   openLevelForm(): void {
-    this.levelForm.reset({ adjustmentType: 'FIXED' });
+    this.levelForm.reset({ adjustmentType: 'FIXED', levelOrder: this.proximaOrdem() });
     this.mode.set('level');
   }
 

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies-ordem-sugerida.spec.ts
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies-ordem-sugerida.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+
+import { OrgStructureHierarchiesComponent } from './org-structure-hierarchies.component';
+import { HierarchyStore } from '../../../../infrastructure/state/org-structure.store';
+import { Hierarchy } from '../../../../domain/models/hr/org-structure.model';
+
+/**
+ * **A ordem da nova hierarquia já vem sugerida.**
+ *
+ * Mesmo defeito dos níveis de cargo: o campo abria vazio, e quem cadastrava
+ * digitava 1 — então duas hierarquias terminavam na mesma posição e a escala
+ * deixava de ordenar.
+ *
+ * Aqui pesa mais que nos níveis: o combo de hierarquia do cadastro de
+ * funcionário é ordenado por `levelOrder`, então empate vira ordem arbitrária
+ * numa lista que as pessoas leem esperando Diretor acima de Analista.
+ */
+describe('OrgStructureHierarchiesComponent · a ordem sugerida', () => {
+
+  const hierarquia = (name: string, levelOrder: number): Hierarchy =>
+    ({ id: `h-${name}`, name, levelOrder });
+
+  async function montar(existentes: Hierarchy[]) {
+    await TestBed.configureTestingModule({
+      imports: [OrgStructureHierarchiesComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        MessageService,
+        {
+          provide: HierarchyStore,
+          useValue: {
+            items: signal(existentes),
+            loading: signal(false),
+            load: () => {},
+            refresh: () => {},
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(OrgStructureHierarchiesComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('a primeira hierarquia nasce na ordem 1', async () => {
+    const tela = await montar([]);
+
+    tela.openForm();
+
+    expect(tela.form.get('levelOrder')!.value).toBe(1);
+  });
+
+  /** **O teste que pega o defeito.** */
+  it('com hierarquias cadastradas, sugere a próxima ordem', async () => {
+    const tela = await montar([
+      hierarquia('Diretor', 1),
+      hierarquia('Gerente', 2),
+    ]);
+
+    tela.openForm();
+
+    expect(tela.form.get('levelOrder')!.value).toBe(3);
+  });
+
+  it('soma a partir da MAIOR ordem, não da quantidade', async () => {
+    const tela = await montar([
+      hierarquia('Diretor', 1),
+      hierarquia('Analista', 6),
+    ]);
+
+    tela.openForm();
+
+    expect(tela.form.get('levelOrder')!.value)
+      .withContext('duas hierarquias, mas a escala já vai até 6')
+      .toBe(7);
+  });
+
+  /** Sugestão, não imposição — dá para encaixar um nível no meio da escala. */
+  it('a ordem continua editável', async () => {
+    const tela = await montar([hierarquia('Diretor', 1)]);
+
+    tela.openForm();
+    tela.form.get('levelOrder')!.setValue(1);
+
+    expect(tela.form.get('levelOrder')!.value).toBe(1);
+    expect(tela.form.get('levelOrder')!.enabled).toBeTrue();
+  });
+});

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject, signal } from '@angular/core';
+import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MessageService } from 'primeng/api';
@@ -50,8 +50,31 @@ export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
     this.store.refresh();
   }
 
+  /**
+   * A proxima ordem livre da escala — 1 quando ainda nao ha hierarquia.
+   *
+   * Vem da MAIOR ordem, e nao da quantidade: escala com buracos (1, 3, 7) e
+   * comum, e contar quantas existem sugeriria uma posicao ja ocupada.
+   */
+  readonly proximaOrdem = computed(() => {
+    const ordens = this.hierarchies()
+      .map(hierarquia => hierarquia.levelOrder)
+      .filter((ordem): ordem is number => typeof ordem === 'number');
+
+    return ordens.length ? Math.max(...ordens) + 1 : 1;
+  });
+
+  /**
+   * A ordem ja vem preenchida — **sugestao, nao trava.**
+   *
+   * O campo abria vazio e quem cadastrava repetia o 1, entao duas hierarquias
+   * ficavam na mesma posicao. Pesa mais aqui do que nos niveis: o combo de
+   * hierarquia do cadastro de funcionario e ordenado por `levelOrder`, e
+   * empate vira ordem arbitraria numa lista que as pessoas leem esperando
+   * Diretor acima de Analista.
+   */
   openForm(): void {
-    this.form.reset();
+    this.form.reset({ levelOrder: this.proximaOrdem() });
     this.mode.set('form');
   }
 


### PR DESCRIPTION
Duas coisas que ele viu na tela de Cargos & Niveis.

1) O botao "Ver Niveis" nao renderizava. O template usa a diretiva `pButton`
   e o `ButtonModule` nao estava nos `imports` do componente. Diretiva
   desconhecida em standalone e AVISO, nao erro: o build passa, e o botao vai
   para a tela sem rotulo e sem icone, porque os dois sao inputs da diretiva.
   O `.action-btn.p-button` do SCSS ja provava a intencao — faltava o import.

2) A ordem do novo nivel abria vazia, e quem cadastrava digitava 1 de novo:
   Junior e Pleno terminavam os dois na ordem 1. Agora vem preenchida com a
   proxima livre. Mesma coisa na tela de Hierarquias, onde pesa mais: o combo
   do cadastro de funcionario ordena por `levelOrder`, e empate vira ordem
   arbitraria numa lista que se le esperando Diretor acima de Analista.

   A sugestao sai da MAIOR ordem, nao da quantidade — escala com buracos
   (1, 3, 7) e comum, e contar quantos existem sugeriria posicao ocupada.
   O campo continua editavel: encaixar um nivel no meio da escala e legitimo.

Os testes do botao perguntam ao DOM, nao ao TypeScript — era um defeito que
compilava. Sem o import eles falham com "Expected 0 to be 2": o botao existe
e esta vazio.
