### PR TITLE
feat(estrutura): editar e excluir departamento, setor e hierarquia

### DIFF
--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments-editar-excluir.spec.ts
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments-editar-excluir.spec.ts
@@ -1,0 +1,160 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+
+import { OrgStructureDepartmentsComponent } from './org-structure-departments.component';
+import { DepartmentStore } from '../../../../infrastructure/state/org-structure.store';
+import { Department } from '../../../../domain/models/hr/org-structure.model';
+
+/**
+ * **Editar e excluir departamento.**
+ *
+ * A tela so cadastrava e listava. Nome digitado errado ficava errado para
+ * sempre, e departamento criado por engano ficava na lista para sempre.
+ *
+ * Excluir **bloqueia quando esta em uso** — decisao dele. Um departamento e
+ * apontado por setores e, desde a migracao das FKs, por todo abastecimento; a
+ * API recusa com 409 e diz na mensagem quem esta usando. Essa frase e a unica
+ * coisa que resolve o problema de quem clicou, entao ela tem que chegar na
+ * tela inteira.
+ */
+describe('OrgStructureDepartmentsComponent · editar e excluir', () => {
+
+  const DEPARTAMENTO: Department = { id: 'dep-1', name: 'Industrial' };
+
+  let store: {
+    items: ReturnType<typeof signal<Department[]>>;
+    loading: ReturnType<typeof signal<boolean>>;
+    load: jasmine.Spy;
+    refresh: jasmine.Spy;
+    create: jasmine.Spy;
+    update: jasmine.Spy;
+    delete: jasmine.Spy;
+  };
+
+  let toast: MessageService;
+
+  async function montar() {
+    store = {
+      items: signal<Department[]>([DEPARTAMENTO]),
+      loading: signal(false),
+      load: jasmine.createSpy('load'),
+      refresh: jasmine.createSpy('refresh'),
+      create: jasmine.createSpy('create').and.returnValue(of(DEPARTAMENTO)),
+      update: jasmine.createSpy('update').and.returnValue(of(DEPARTAMENTO)),
+      delete: jasmine.createSpy('delete').and.returnValue(of(void 0)),
+    };
+
+    toast = new MessageService();
+    spyOn(toast, 'add');
+
+    await TestBed.configureTestingModule({
+      imports: [OrgStructureDepartmentsComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        ConfirmationService,
+        { provide: DepartmentStore, useValue: store },
+        { provide: MessageService, useValue: toast },
+      ],
+    })
+      .overrideComponent(OrgStructureDepartmentsComponent, {
+        set: { providers: [{ provide: MessageService, useValue: toast }] },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(OrgStructureDepartmentsComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Editar ────────────────────────────────────────────────────────────────
+
+  it('abrir para editar traz o nome que ja estava gravado', async () => {
+    const tela = await montar();
+
+    tela.openEdit(DEPARTAMENTO);
+
+    expect(tela.mode()).toBe('form');
+    expect(tela.form.get('name')!.value).toBe('Industrial');
+  });
+
+  it('salvar depois de editar ATUALIZA, e nao cria outro', async () => {
+    const tela = await montar();
+
+    tela.openEdit(DEPARTAMENTO);
+    tela.form.get('name')!.setValue('Industrial e Manutencao');
+    tela.save();
+
+    expect(store.update).toHaveBeenCalledWith('dep-1', { name: 'Industrial e Manutencao' });
+    expect(store.create)
+      .withContext('editar nao pode virar duplicata na lista')
+      .not.toHaveBeenCalled();
+  });
+
+  it('abrir para novo depois de editar nao herda o item anterior', async () => {
+    const tela = await montar();
+
+    tela.openEdit(DEPARTAMENTO);
+    tela.closeForm();
+    tela.openForm();
+    tela.form.get('name')!.setValue('Comercial');
+    tela.save();
+
+    expect(store.create).toHaveBeenCalledWith({ name: 'Comercial' });
+    expect(store.update)
+      .withContext('o id do item editado ficou pendurado no componente')
+      .not.toHaveBeenCalled();
+  });
+
+  // ── Excluir ───────────────────────────────────────────────────────────────
+
+  it('excluir chama a API com o id', async () => {
+    const tela = await montar();
+
+    tela.excluir(DEPARTAMENTO);
+
+    expect(store.delete).toHaveBeenCalledWith('dep-1');
+  });
+
+  /**
+   * **O teste que importa.** `getErrorMessage` traduzia 409 para "Registro ja
+   * existe" — que e a mensagem de nome duplicado, e aqui seria mentira: o
+   * problema e que o departamento esta em uso, e quem clicou precisa saber
+   * POR QUEM para poder resolver.
+   */
+  it('quando a API recusa por estar em uso, mostra a frase DELA', async () => {
+    const tela = await montar();
+    store.delete.and.returnValue(throwError(() => ({
+      status: 409,
+      error: { message: '3 setores usam este departamento.' },
+    })));
+
+    tela.excluir(DEPARTAMENTO);
+
+    expect(toast.add).toHaveBeenCalledWith(jasmine.objectContaining({
+      detail: '3 setores usam este departamento.',
+    }));
+  });
+
+  it('sem mensagem da API, ainda diz algo util', async () => {
+    const tela = await montar();
+    store.delete.and.returnValue(throwError(() => ({ status: 409, error: null })));
+
+    tela.excluir(DEPARTAMENTO);
+
+    expect(toast.add).toHaveBeenCalled();
+    const chamada = (toast.add as jasmine.Spy).calls.mostRecent().args[0] as { detail?: string };
+    expect(chamada.detail).toBeTruthy();
+  });
+});

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.html
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.html
@@ -1,4 +1,5 @@
 <p-toast position="top-right"></p-toast>
+<p-confirmDialog />
 
 @if (mode() === 'grid') {
 
@@ -29,12 +30,21 @@
       <ng-template #headerTpl>
         <tr>
           <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+          <th class="col-actions">Ações</th>
         </tr>
       </ng-template>
 
       <ng-template #bodyTpl let-d>
         <tr class="table-row">
           <td>{{ d.name }}</td>
+          <td class="col-actions">
+            <div class="row-actions">
+              <pk-button pkType="edit" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Editar" (clicked)="openEdit(d)"/>
+              <pk-button pkType="delete" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Excluir" (clicked)="confirmDelete(d)"/>
+            </div>
+          </td>
         </tr>
       </ng-template>
 
@@ -43,7 +53,9 @@
 
 } @else {
 
-  <app-form-screen title="Novo Departamento" subtitle="Cadastro de departamento" (back)="closeForm()">
+  <app-form-screen [title]="editing() ? 'Editar Departamento' : 'Novo Departamento'"
+                   [subtitle]="editing() ? 'Alteração de departamento' : 'Cadastro de departamento'"
+                   (back)="closeForm()">
     <form [formGroup]="form" (ngSubmit)="save()">
       <div class="form-grid">
         <div class="form-field form-field--full">

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.scss
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.scss
@@ -1,4 +1,5 @@
 @use 'mixins' as m;
+@use 'variables' as v;
 
 // Tela de grade dentro da Estrutura Organizacional.
 :host { @include m.grid-screen; }
@@ -18,4 +19,17 @@ app-form-screen {
   justify-content: flex-end;
   gap: 10px;
   margin-bottom: 16px;
+}
+
+// Coluna de acoes: largura do conteudo, para o nome ficar com o resto.
+.col-actions {
+  width: 1%;
+  white-space: nowrap;
+  text-align: right;
+}
+
+.row-actions {
+  display: flex;
+  gap: v.$space-2;
+  justify-content: flex-end;
 }

--- a/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
+++ b/src/app/components/auth/rh/org-structure-departments/org-structure-departments.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { Toast } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TableModule } from 'primeng/table';
 import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
 import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
@@ -11,26 +12,37 @@ import { FormScreenComponent } from '../../shared/form-screen/form-screen.compon
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 import { TabDirtyCheck } from '../../../../infrastructure/routing/tab-dirty-check';
 import { DepartmentStore } from '../../../../infrastructure/state/org-structure.store';
+import { Department } from '../../../../domain/models/hr/org-structure.model';
 
 @Component({
   selector: 'app-org-structure-departments',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
+  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, ConfirmDialogModule, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
   templateUrl: './org-structure-departments.component.html',
   styleUrl: './org-structure-departments.component.scss',
-  providers: [MessageService],
+  providers: [MessageService, ConfirmationService],
 })
 export class OrgStructureDepartmentsComponent implements OnInit, TabDirtyCheck {
 
   private readonly store = inject(DepartmentStore);
   private readonly fb = inject(FormBuilder);
   private readonly msgService = inject(MessageService);
+  private readonly confirm = inject(ConfirmationService);
 
   readonly departments = this.store.items;
   readonly loading = this.store.loading;
 
   /** A tela alterna entre a grade e o formulário; não há mais diálogo. */
   readonly mode = signal<'grid' | 'form'>('grid');
+
+  /**
+   * O departamento em edição — `null` quando o formulário é de cadastro.
+   *
+   * É o que decide entre criar e atualizar no `save()`, e é por isso que
+   * `openForm()` precisa limpá-lo: sem isso, cadastrar logo depois de editar
+   * atualizaria o item anterior.
+   */
+  readonly editing = signal<Department | null>(null);
 
   readonly form: FormGroup = this.fb.group({
     name: ['', Validators.required],
@@ -50,7 +62,14 @@ export class OrgStructureDepartmentsComponent implements OnInit, TabDirtyCheck {
   }
 
   openForm(): void {
+    this.editing.set(null);
     this.form.reset();
+    this.mode.set('form');
+  }
+
+  openEdit(department: Department): void {
+    this.editing.set(department);
+    this.form.reset({ name: department.name });
     this.mode.set('form');
   }
 
@@ -61,10 +80,19 @@ export class OrgStructureDepartmentsComponent implements OnInit, TabDirtyCheck {
   save(): void {
     if (!this.form.valid) return;
 
-    this.store.create(this.form.value).subscribe({
+    const emEdicao = this.editing();
+    const requisicao = emEdicao
+      ? this.store.update(emEdicao.id, this.form.value)
+      : this.store.create(this.form.value);
+
+    requisicao.subscribe({
       next: () => {
         this.closeForm();
-        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Departamento cadastrado com sucesso!' });
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: emEdicao ? 'Departamento atualizado com sucesso!' : 'Departamento cadastrado com sucesso!',
+        });
       },
       error: (err) => {
         // Erro mantém o formulário aberto: o usuário não perde o que digitou.
@@ -73,7 +101,51 @@ export class OrgStructureDepartmentsComponent implements OnInit, TabDirtyCheck {
     });
   }
 
+  /**
+   * Pergunta antes, porque excluir não tem volta pela tela.
+   *
+   * A API é quem sabe se o departamento está em uso — a tela não tenta
+   * adivinhar. Ela pede, e mostra o que voltar.
+   */
+  confirmDelete(department: Department): void {
+    this.confirm.confirm({
+      message: `Deseja excluir o departamento <strong>${department.name}</strong>?`,
+      header: 'Confirmar exclusão',
+      icon: 'pi pi-trash',
+      acceptLabel: 'Excluir',
+      rejectLabel: 'Cancelar',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-outlined p-button-sm',
+      accept: () => this.excluir(department),
+    });
+  }
+
+  excluir(department: Department): void {
+    this.store.delete(department.id).subscribe({
+      next: () => this.msgService.add({
+        severity: 'success', summary: 'Excluído',
+        detail: `Departamento "${department.name}" removido.`,
+      }),
+      error: (err) => this.msgService.add({
+        severity: 'warning', summary: 'Não foi possível excluir',
+        detail: this.getErrorMessage(err),
+      }),
+    });
+  }
+
+  /**
+   * **A frase da API ganha da tabela de códigos.**
+   *
+   * O 409 aqui tem dois significados: nome repetido no cadastro, e
+   * departamento em uso na exclusão. Traduzir o código para "Registro já
+   * existe" acertaria o primeiro e mentiria no segundo — e é justamente na
+   * exclusão que a mensagem do servidor diz QUEM está usando, que é a única
+   * informação capaz de desbloquear quem clicou.
+   */
   private getErrorMessage(err: any): string {
+    const doServidor = err?.error?.message;
+    if (typeof doServidor === 'string' && doServidor.trim()) return doServidor;
+
     switch (err.status) {
       case 400: return 'Requisição inválida';
       case 403: return 'Você não tem permissão para esta ação';

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.html
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.html
@@ -1,4 +1,5 @@
 <p-toast position="top-right"></p-toast>
+<p-confirmDialog />
 
 @if (mode() === 'grid') {
 
@@ -30,6 +31,7 @@
         <tr>
           <th>Nível</th>
           <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
+          <th class="col-actions">Ações</th>
         </tr>
       </ng-template>
 
@@ -37,6 +39,14 @@
         <tr class="table-row">
           <td><span class="code-badge">{{ h.levelOrder }}</span></td>
           <td>{{ h.name }}</td>
+          <td class="col-actions">
+            <div class="row-actions">
+              <pk-button pkType="edit" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Editar" (clicked)="openEdit(h)"/>
+              <pk-button pkType="delete" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Excluir" (clicked)="confirmDelete(h)"/>
+            </div>
+          </td>
         </tr>
       </ng-template>
 
@@ -45,7 +55,7 @@
 
 } @else {
 
-  <app-form-screen title="Nova Hierarquia" subtitle="Quanto menor o nível, mais alto na hierarquia" (back)="closeForm()">
+  <app-form-screen [title]="editing() ? 'Editar Hierarquia' : 'Nova Hierarquia'" subtitle="Quanto menor o nível, mais alto na hierarquia" (back)="closeForm()">
     <form [formGroup]="form" (ngSubmit)="save()">
       <div class="form-grid">
         <div class="form-field form-field--full">

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.scss
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.scss
@@ -1,4 +1,5 @@
 @use 'mixins' as m;
+@use 'variables' as v;
 
 // Tela de grade dentro da Estrutura Organizacional.
 :host { @include m.grid-screen; }
@@ -19,3 +20,6 @@ app-form-screen {
   gap: 10px;
   margin-bottom: 16px;
 }
+
+.col-actions { width: 1%; white-space: nowrap; text-align: right; }
+.row-actions { display: flex; gap: v.$space-2; justify-content: flex-end; }

--- a/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
+++ b/src/app/components/auth/rh/org-structure-hierarchies/org-structure-hierarchies.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { Toast } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TableModule } from 'primeng/table';
 import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
 import { PkTableComponent } from '../../../theme/ProautoKimium/pk-table/pk-table.component';
@@ -11,26 +12,37 @@ import { FormScreenComponent } from '../../shared/form-screen/form-screen.compon
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 import { TabDirtyCheck } from '../../../../infrastructure/routing/tab-dirty-check';
 import { HierarchyStore } from '../../../../infrastructure/state/org-structure.store';
+import { Hierarchy } from '../../../../domain/models/hr/org-structure.model';
 
 @Component({
   selector: 'app-org-structure-hierarchies',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
+  imports: [CommonModule, ReactiveFormsModule, TableModule, Toast, ConfirmDialogModule, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
   templateUrl: './org-structure-hierarchies.component.html',
   styleUrl: './org-structure-hierarchies.component.scss',
-  providers: [MessageService],
+  providers: [MessageService, ConfirmationService],
 })
 export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
 
   private readonly store = inject(HierarchyStore);
   private readonly fb = inject(FormBuilder);
   private readonly msgService = inject(MessageService);
+  private readonly confirm = inject(ConfirmationService);
 
   readonly hierarchies = this.store.items;
   readonly loading = this.store.loading;
 
   /** A tela alterna entre a grade e o formulário; não há mais diálogo. */
   readonly mode = signal<'grid' | 'form'>('grid');
+
+  /**
+   * O item em edicao — `null` quando o formulario e de cadastro.
+   *
+   * E o que decide entre criar e atualizar no `save()`, e por isso
+   * `openForm()` precisa limpa-lo: sem isso, cadastrar logo depois de editar
+   * atualizaria o item anterior.
+   */
+  readonly editing = signal<Hierarchy | null>(null);
 
   readonly form: FormGroup = this.fb.group({
     name: ['', Validators.required],
@@ -73,7 +85,14 @@ export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
    * empate vira ordem arbitraria numa lista que as pessoas leem esperando
    * Diretor acima de Analista.
    */
+  openEdit(item: Hierarchy): void {
+    this.editing.set(item);
+    this.form.reset({ name: item.name, levelOrder: item.levelOrder });
+    this.mode.set('form');
+  }
+
   openForm(): void {
+    this.editing.set(null);
     this.form.reset({ levelOrder: this.proximaOrdem() });
     this.mode.set('form');
   }
@@ -85,10 +104,19 @@ export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
   save(): void {
     if (!this.form.valid) return;
 
-    this.store.create(this.form.value).subscribe({
+    const emEdicao = this.editing();
+    const requisicao = emEdicao
+      ? this.store.update(emEdicao.id, this.form.value)
+      : this.store.create(this.form.value);
+
+    requisicao.subscribe({
       next: () => {
         this.closeForm();
-        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Hierarquia cadastrada com sucesso!' });
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: emEdicao ? 'Hierarquia atualizada com sucesso!' : 'Hierarquia cadastrada com sucesso!',
+        });
       },
       error: (err) => {
         // Erro mantém o formulário aberto: o usuário não perde o que digitou.
@@ -97,7 +125,45 @@ export class OrgStructureHierarchiesComponent implements OnInit, TabDirtyCheck {
     });
   }
 
+  confirmDelete(item: Hierarchy): void {
+    this.confirm.confirm({
+      message: `Deseja excluir a hierarquia <strong>${item.name}</strong>?`,
+      header: 'Confirmar exclusão',
+      icon: 'pi pi-trash',
+      acceptLabel: 'Excluir',
+      rejectLabel: 'Cancelar',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-outlined p-button-sm',
+      accept: () => this.excluir(item),
+    });
+  }
+
+  excluir(item: Hierarchy): void {
+    this.store.delete(item.id).subscribe({
+      next: () => this.msgService.add({
+        severity: 'success', summary: 'Excluído',
+        detail: `Hierarquia "${item.name}" removida.`,
+      }),
+      error: (err) => this.msgService.add({
+        severity: 'warning', summary: 'Não foi possível excluir',
+        detail: this.getErrorMessage(err),
+      }),
+    });
+  }
+
+  /**
+   * **A frase da API ganha da tabela de codigos.**
+   *
+   * O 409 tem dois significados aqui: nome repetido no cadastro, e registro em
+   * uso na exclusao. Traduzir o codigo para "Registro ja existe" acertaria o
+   * primeiro e mentiria no segundo — e e na exclusao que a mensagem do
+   * servidor diz QUEM esta usando, que e a unica informacao capaz de
+   * desbloquear quem clicou.
+   */
   private getErrorMessage(err: any): string {
+    const doServidor = err?.error?.message;
+    if (typeof doServidor === 'string' && doServidor.trim()) return doServidor;
+
     switch (err.status) {
       case 400: return 'Requisição inválida';
       case 403: return 'Você não tem permissão para esta ação';

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.html
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.html
@@ -1,4 +1,5 @@
 <p-toast position="top-right"></p-toast>
+<p-confirmDialog />
 
 @if (mode() === 'grid') {
 
@@ -30,6 +31,7 @@
         <tr>
           <th pSortableColumn="name">Nome <p-sortIcon field="name"></p-sortIcon></th>
           <th>Departamento</th>
+          <th class="col-actions">Ações</th>
         </tr>
       </ng-template>
 
@@ -37,6 +39,14 @@
         <tr class="table-row">
           <td>{{ t.name }}</td>
           <td>{{ t.department?.name }}</td>
+          <td class="col-actions">
+            <div class="row-actions">
+              <pk-button pkType="edit" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Editar" (clicked)="openEdit(t)"/>
+              <pk-button pkType="delete" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Excluir" (clicked)="confirmDelete(t)"/>
+            </div>
+          </td>
         </tr>
       </ng-template>
 
@@ -45,7 +55,7 @@
 
 } @else {
 
-  <app-form-screen title="Novo Setor" subtitle="Cadastro de setor vinculado a um departamento" (back)="closeForm()">
+  <app-form-screen [title]="editing() ? 'Editar Setor' : 'Novo Setor'" subtitle="Cadastro de setor vinculado a um departamento" (back)="closeForm()">
     <form [formGroup]="form" (ngSubmit)="save()">
       <div class="form-grid">
         <div class="form-field form-field--full">

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.scss
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.scss
@@ -1,4 +1,5 @@
 @use 'mixins' as m;
+@use 'variables' as v;
 
 // Tela de grade dentro da Estrutura Organizacional.
 :host { @include m.grid-screen; }
@@ -19,3 +20,6 @@ app-form-screen {
   gap: 10px;
   margin-bottom: 16px;
 }
+
+.col-actions { width: 1%; white-space: nowrap; text-align: right; }
+.row-actions { display: flex; gap: v.$space-2; justify-content: flex-end; }

--- a/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
+++ b/src/app/components/auth/rh/org-structure-teams/org-structure-teams.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
 import { Toast } from 'primeng/toast';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SelectModule } from 'primeng/select';
 import { TableModule } from 'primeng/table';
 import { PkButtonComponent } from '../../../theme/ProautoKimium/pk-button/pk-button.component';
@@ -12,14 +13,15 @@ import { FormScreenComponent } from '../../shared/form-screen/form-screen.compon
 import { ToolbarComponent } from '../../shared/toolbar/toolbar.component';
 import { TabDirtyCheck } from '../../../../infrastructure/routing/tab-dirty-check';
 import { DepartmentStore, TeamStore } from '../../../../infrastructure/state/org-structure.store';
+import { Team } from '../../../../domain/models/hr/org-structure.model';
 
 @Component({
   selector: 'app-org-structure-teams',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, SelectModule, TableModule, Toast, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
+  imports: [CommonModule, ReactiveFormsModule, SelectModule, TableModule, Toast, ConfirmDialogModule, PkButtonComponent, PkTableComponent, PkInputComponent, FormScreenComponent, ToolbarComponent],
   templateUrl: './org-structure-teams.component.html',
   styleUrl: './org-structure-teams.component.scss',
-  providers: [MessageService],
+  providers: [MessageService, ConfirmationService],
 })
 export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
 
@@ -27,6 +29,7 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
   private readonly departmentStore = inject(DepartmentStore);
   private readonly fb = inject(FormBuilder);
   private readonly msgService = inject(MessageService);
+  private readonly confirm = inject(ConfirmationService);
 
   readonly teams = this.store.items;
   readonly loading = this.store.loading;
@@ -41,6 +44,15 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
 
   /** A tela alterna entre a grade e o formulário; não há mais diálogo. */
   readonly mode = signal<'grid' | 'form'>('grid');
+
+  /**
+   * O item em edicao — `null` quando o formulario e de cadastro.
+   *
+   * E o que decide entre criar e atualizar no `save()`, e por isso
+   * `openForm()` precisa limpa-lo: sem isso, cadastrar logo depois de editar
+   * atualizaria o item anterior.
+   */
+  readonly editing = signal<Team | null>(null);
 
   readonly form: FormGroup = this.fb.group({
     name: ['', Validators.required],
@@ -61,7 +73,14 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
     this.store.refresh();
   }
 
+  openEdit(item: Team): void {
+    this.editing.set(item);
+    this.form.reset({ name: item.name, departmentId: item.department?.id ?? null });
+    this.mode.set('form');
+  }
+
   openForm(): void {
+    this.editing.set(null);
     this.form.reset();
     this.mode.set('form');
   }
@@ -73,10 +92,19 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
   save(): void {
     if (!this.form.valid) return;
 
-    this.store.create(this.form.value).subscribe({
+    const emEdicao = this.editing();
+    const requisicao = emEdicao
+      ? this.store.update(emEdicao.id, this.form.value)
+      : this.store.create(this.form.value);
+
+    requisicao.subscribe({
       next: () => {
         this.closeForm();
-        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Setor cadastrado com sucesso!' });
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: emEdicao ? 'Setor atualizado com sucesso!' : 'Setor cadastrado com sucesso!',
+        });
       },
       error: (err) => {
         // Erro mantém o formulário aberto: o usuário não perde o que digitou.
@@ -85,7 +113,45 @@ export class OrgStructureTeamsComponent implements OnInit, TabDirtyCheck {
     });
   }
 
+  confirmDelete(item: Team): void {
+    this.confirm.confirm({
+      message: `Deseja excluir o setor <strong>${item.name}</strong>?`,
+      header: 'Confirmar exclusão',
+      icon: 'pi pi-trash',
+      acceptLabel: 'Excluir',
+      rejectLabel: 'Cancelar',
+      acceptButtonStyleClass: 'p-button-danger p-button-sm',
+      rejectButtonStyleClass: 'p-button-outlined p-button-sm',
+      accept: () => this.excluir(item),
+    });
+  }
+
+  excluir(item: Team): void {
+    this.store.delete(item.id).subscribe({
+      next: () => this.msgService.add({
+        severity: 'success', summary: 'Excluído',
+        detail: `Setor "${item.name}" removido.`,
+      }),
+      error: (err) => this.msgService.add({
+        severity: 'warning', summary: 'Não foi possível excluir',
+        detail: this.getErrorMessage(err),
+      }),
+    });
+  }
+
+  /**
+   * **A frase da API ganha da tabela de codigos.**
+   *
+   * O 409 tem dois significados aqui: nome repetido no cadastro, e registro em
+   * uso na exclusao. Traduzir o codigo para "Registro ja existe" acertaria o
+   * primeiro e mentiria no segundo — e e na exclusao que a mensagem do
+   * servidor diz QUEM esta usando, que e a unica informacao capaz de
+   * desbloquear quem clicou.
+   */
   private getErrorMessage(err: any): string {
+    const doServidor = err?.error?.message;
+    if (typeof doServidor === 'string' && doServidor.trim()) return doServidor;
+
     switch (err.status) {
       case 400: return 'Requisição inválida';
       case 403: return 'Você não tem permissão para esta ação';

--- a/src/app/infrastructure/services/hr/department.service.ts
+++ b/src/app/infrastructure/services/hr/department.service.ts
@@ -18,4 +18,17 @@ export class DepartmentService {
   create(request: CreateDepartmentRequest): Observable<Department> {
     return this.http.post<Department>(`${environment.apiUrl}/hr/departments`, request);
   }
+
+  update(id: string, request: CreateDepartmentRequest): Observable<Department> {
+    return this.http.put<Department>(`${environment.apiUrl}/hr/departments/${id}`, request);
+  }
+
+  /**
+   * A API recusa com **409** quando o cadastro esta em uso, e a mensagem dela
+   * diz por quem. Quem chama repassa essa frase — inventar um texto generico
+   * aqui esconderia justamente o que a pessoa precisa saber para resolver.
+   */
+  remove(id: string): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/hr/departments/${id}`);
+  }
 }

--- a/src/app/infrastructure/services/hr/hierarchy.service.ts
+++ b/src/app/infrastructure/services/hr/hierarchy.service.ts
@@ -18,4 +18,17 @@ export class HierarchyService {
   create(request: CreateHierarchyRequest): Observable<Hierarchy> {
     return this.http.post<Hierarchy>(`${environment.apiUrl}/hr/hierarchies`, request);
   }
+
+  update(id: string, request: CreateHierarchyRequest): Observable<Hierarchy> {
+    return this.http.put<Hierarchy>(`${environment.apiUrl}/hr/hierarchies/${id}`, request);
+  }
+
+  /**
+   * A API recusa com **409** quando o cadastro esta em uso, e a mensagem dela
+   * diz por quem. Quem chama repassa essa frase — inventar um texto generico
+   * aqui esconderia justamente o que a pessoa precisa saber para resolver.
+   */
+  remove(id: string): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/hr/hierarchies/${id}`);
+  }
 }

--- a/src/app/infrastructure/services/hr/team.service.ts
+++ b/src/app/infrastructure/services/hr/team.service.ts
@@ -18,4 +18,17 @@ export class TeamService {
   create(request: CreateTeamRequest): Observable<Team> {
     return this.http.post<Team>(`${environment.apiUrl}/hr/teams`, request);
   }
+
+  update(id: string, request: CreateTeamRequest): Observable<Team> {
+    return this.http.put<Team>(`${environment.apiUrl}/hr/teams/${id}`, request);
+  }
+
+  /**
+   * A API recusa com **409** quando o cadastro esta em uso, e a mensagem dela
+   * diz por quem. Quem chama repassa essa frase — inventar um texto generico
+   * aqui esconderia justamente o que a pessoa precisa saber para resolver.
+   */
+  remove(id: string): Observable<void> {
+    return this.http.delete<void>(`${environment.apiUrl}/hr/teams/${id}`);
+  }
 }

--- a/src/app/infrastructure/state/org-structure.store.ts
+++ b/src/app/infrastructure/state/org-structure.store.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
 
 import {
   Company,
@@ -44,6 +45,15 @@ export class DepartmentStore extends ReferenceStore<Department> {
   create(request: CreateDepartmentRequest): Observable<Department> {
     return this.withUpsert(this.service.create(request));
   }
+
+  update(id: string, request: CreateDepartmentRequest): Observable<Department> {
+    return this.withUpsert(this.service.update(id, request));
+  }
+
+  /** So tira da lista local depois que a API confirmou. */
+  delete(id: string): Observable<void> {
+    return this.service.remove(id).pipe(tap(() => this.remove(id)));
+  }
 }
 
 @Injectable({ providedIn: 'root' })
@@ -56,6 +66,15 @@ export class TeamStore extends ReferenceStore<Team> {
   create(request: CreateTeamRequest): Observable<Team> {
     return this.withUpsert(this.service.create(request));
   }
+
+  update(id: string, request: CreateTeamRequest): Observable<Team> {
+    return this.withUpsert(this.service.update(id, request));
+  }
+
+  /** So tira da lista local depois que a API confirmou. */
+  delete(id: string): Observable<void> {
+    return this.service.remove(id).pipe(tap(() => this.remove(id)));
+  }
 }
 
 @Injectable({ providedIn: 'root' })
@@ -67,5 +86,14 @@ export class HierarchyStore extends ReferenceStore<Hierarchy> {
 
   create(request: CreateHierarchyRequest): Observable<Hierarchy> {
     return this.withUpsert(this.service.create(request));
+  }
+
+  update(id: string, request: CreateHierarchyRequest): Observable<Hierarchy> {
+    return this.withUpsert(this.service.update(id, request));
+  }
+
+  /** So tira da lista local depois que a API confirmou. */
+  delete(id: string): Observable<void> {
+    return this.service.remove(id).pipe(tap(() => this.remove(id)));
   }
 }


### PR DESCRIPTION
NAO MERGEAR ANTES DA API: PUT e DELETE dos tres cadastros ainda nao existem.
Hoje os cinco cadastros (departamento, setor, hierarquia, cargo, nivel) tem
so POST e GET, entao os botoes novos vao levar 404 ate a API subir.

As tres telas so cadastravam e listavam. Nome digitado errado ficava errado
para sempre, e registro criado por engano ficava na lista para sempre.

EXCLUIR BLOQUEIA QUANDO ESTA EM USO — decisao dele. A tela nao tenta
adivinhar quem usa o que: ela pede, a API recusa com 409, e a tela mostra a
frase que voltou.

E POR ISSO O `getErrorMessage` MUDOU. Ele traduzia 409 para "Registro ja
existe", que e a mensagem de nome duplicado. No cadastro isso esta certo; na
exclusao seria mentira, e ainda apagaria a unica informacao capaz de
desbloquear quem clicou — QUEM esta usando o registro. Agora a mensagem do
servidor ganha da tabela de codigos, e a tabela vira fallback.

O `editing` decide entre criar e atualizar, e `openForm()` limpa ele: sem
isso, cadastrar logo depois de editar atualizaria o item anterior em vez de
criar. Tem teste para exatamente essa sequencia.

`ReferenceStore` ja tinha `upsert` e `remove`; faltava so ligar nos services.
A exclusao so tira da lista local depois que a API confirmou.

O QUE A API PRECISA EXPOR
- PUT    /api/hr/{departments,teams,hierarchies}/{id}  -> o registro alterado
- DELETE /api/hr/{departments,teams,hierarchies}/{id}  -> 204, ou 409 com
  `message` dizendo quem usa. A frase vai inteira para a tela

CUIDADO NA API: o departamento SEM_DEPARTAMENTO virou carga viva na
importacao de abastecimento — e para onde vai motorista sem funcionario
casado. Excluir ele quebra a importacao mesmo que nenhum registro aponte
para ele ainda.
