### PR TITLE
feat(cargos): alterar o valor base de um nivel

### DIFF
--- a/src/app/components/auth/rh/career-structure/career-structure-editar-nivel.spec.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure-editar-nivel.spec.ts
@@ -1,0 +1,179 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MessageService } from 'primeng/api';
+import { of, throwError } from 'rxjs';
+
+import { CareerStructureComponent } from './career-structure.component';
+import { PositionStore, PositionLevelStore } from '../../../../infrastructure/state/position.store';
+import { PositionLevel } from '../../../../domain/models/hr/career.model';
+
+/**
+ * **Alterar o valor base de um nível.**
+ *
+ * A tela só cadastrava nível. Salário base digitado errado — ou simplesmente
+ * desatualizado — não tinha como ser corrigido: a saída era criar outro nível
+ * e conviver com o errado na lista.
+ *
+ * **O detalhe que manda no desenho é a cascata.** Nível percentual resolve o
+ * salário sobre o nível imediatamente anterior (`PositionLevelSalaryResolver`
+ * na API), então mudar o valor base do Júnior muda o salário calculado de
+ * Pleno e Sênior junto. Trocar só a linha editada na tela deixaria as outras
+ * mostrando salário velho — numa tela de salário, que é onde menos se pode
+ * mostrar número errado.
+ */
+describe('CareerStructureComponent · editar o nível', () => {
+
+  const CARGO = { id: 'cargo-1', name: 'Desenvolvedor' };
+
+  const JUNIOR: PositionLevel = {
+    id: 'nivel-1', name: 'Júnior', levelOrder: 1, positionId: CARGO.id,
+    adjustmentType: 'FIXED', fixedAmount: 3000, percentageIncrease: null,
+    resolvedSalary: 3000,
+  };
+
+  let levelStore: {
+    levelsOf: jasmine.Spy;
+    isLoading: jasmine.Spy;
+    load: jasmine.Spy;
+    create: jasmine.Spy;
+    update: jasmine.Spy;
+  };
+
+  let toast: MessageService;
+
+  async function montar() {
+    levelStore = {
+      levelsOf: jasmine.createSpy('levelsOf').and.returnValue([JUNIOR]),
+      isLoading: jasmine.createSpy('isLoading').and.returnValue(false),
+      load: jasmine.createSpy('load'),
+      create: jasmine.createSpy('create').and.returnValue(of(JUNIOR)),
+      update: jasmine.createSpy('update').and.returnValue(of(JUNIOR)),
+    };
+
+    toast = new MessageService();
+    spyOn(toast, 'add');
+
+    await TestBed.configureTestingModule({
+      imports: [CareerStructureComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: PositionStore,
+          useValue: {
+            items: signal([CARGO]), loading: signal(false),
+            load: () => {}, refresh: () => {},
+          },
+        },
+        { provide: PositionLevelStore, useValue: levelStore },
+        { provide: MessageService, useValue: toast },
+      ],
+    })
+      .overrideComponent(CareerStructureComponent, {
+        set: { providers: [{ provide: MessageService, useValue: toast }] },
+      })
+      .compileComponents();
+
+    const fixture = TestBed.createComponent(CareerStructureComponent);
+    const tela = fixture.componentInstance;
+    fixture.detectChanges();
+
+    tela.selectPosition(CARGO as never);
+    return tela;
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('abrir para editar traz o que já estava gravado', async () => {
+    const tela = await montar();
+
+    tela.openEditLevel(JUNIOR);
+
+    expect(tela.mode()).toBe('level');
+    expect(tela.levelForm.get('name')!.value).toBe('Júnior');
+    expect(tela.levelForm.get('levelOrder')!.value).toBe(1);
+    expect(tela.levelForm.get('adjustmentType')!.value).toBe('FIXED');
+    expect(tela.levelForm.get('fixedAmount')!.value).toBe(3000);
+  });
+
+  it('salvar depois de editar ATUALIZA, e não cria outro nível', async () => {
+    const tela = await montar();
+
+    tela.openEditLevel(JUNIOR);
+    tela.levelForm.get('fixedAmount')!.setValue(3500);
+    tela.saveLevel();
+
+    expect(levelStore.update).toHaveBeenCalledWith('nivel-1', jasmine.objectContaining({
+      name: 'Júnior',
+      levelOrder: 1,
+      positionId: CARGO.id,
+      adjustmentType: 'FIXED',
+      fixedAmount: 3500,
+    }));
+    expect(levelStore.create)
+      .withContext('corrigir o valor não pode virar um nível duplicado')
+      .not.toHaveBeenCalled();
+  });
+
+  /** **O teste que pega a cascata.** */
+  it('depois de salvar, recarrega os níveis do cargo', async () => {
+    const tela = await montar();
+    levelStore.load.calls.reset();
+
+    tela.openEditLevel(JUNIOR);
+    tela.levelForm.get('fixedAmount')!.setValue(3500);
+    tela.saveLevel();
+
+    expect(levelStore.load)
+      .withContext('nível percentual resolve sobre o anterior: os de cima mudaram junto')
+      .toHaveBeenCalledWith(CARGO.id, true);
+  });
+
+  it('percentual guarda o percentual e zera o valor fixo', async () => {
+    const tela = await montar();
+
+    tela.openEditLevel(JUNIOR);
+    tela.levelForm.patchValue({ adjustmentType: 'PERCENTAGE', percentageIncrease: 15 });
+    tela.saveLevel();
+
+    expect(levelStore.update).toHaveBeenCalledWith('nivel-1', jasmine.objectContaining({
+      adjustmentType: 'PERCENTAGE',
+      percentageIncrease: 15,
+      fixedAmount: null,
+    }));
+  });
+
+  it('abrir para novo depois de editar não herda o nível anterior', async () => {
+    const tela = await montar();
+
+    tela.openEditLevel(JUNIOR);
+    tela.openLevelForm();
+    tela.levelForm.patchValue({ name: 'Pleno', fixedAmount: 5000 });
+    tela.saveLevel();
+
+    expect(levelStore.create).toHaveBeenCalled();
+    expect(levelStore.update)
+      .withContext('o id do nível editado ficou pendurado no componente')
+      .not.toHaveBeenCalled();
+  });
+
+  it('erro ao salvar mantém o formulário aberto', async () => {
+    const tela = await montar();
+    levelStore.update.and.returnValue(throwError(() => ({ status: 400, error: null })));
+
+    tela.openEditLevel(JUNIOR);
+    tela.saveLevel();
+
+    expect(tela.mode())
+      .withContext('fechar apagaria o que a pessoa acabou de digitar')
+      .toBe('level');
+    expect(toast.add).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/auth/rh/career-structure/career-structure.component.html
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.html
@@ -88,6 +88,7 @@
             <th>Tipo</th>
             <th>Valor</th>
             <th>Salário calculado</th>
+            <th class="col-actions">Ações</th>
           </tr>
         </ng-template>
 
@@ -114,6 +115,10 @@
               }
             </td>
             <td><strong>{{ l.resolvedSalary | currency:'BRL' }}</strong></td>
+            <td class="col-actions">
+              <pk-button pkType="edit" [pkIconOnly]="true" pkSize="sm"
+                         pkTooltip="Editar nível" (clicked)="openEditLevel(l)"/>
+            </td>
           </tr>
         </ng-template>
 
@@ -142,7 +147,7 @@
 } @else {
 
   <app-form-screen
-    title="Novo Nível"
+    [title]="editingLevel() ? 'Editar Nível' : 'Novo Nível'"
     [subtitle]="'Cargo: ' + (selectedPosition()?.name ?? '')"
     (back)="closeForm()">
     <form [formGroup]="levelForm" (ngSubmit)="saveLevel()">

--- a/src/app/components/auth/rh/career-structure/career-structure.component.scss
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.scss
@@ -145,3 +145,6 @@
   align-items: center;
   gap: 8px;
 }
+
+// Coluna de acoes: largura do conteudo, para o nome do nivel ficar com o resto.
+.col-actions { width: 1%; white-space: nowrap; text-align: right; }

--- a/src/app/components/auth/rh/career-structure/career-structure.component.ts
+++ b/src/app/components/auth/rh/career-structure/career-structure.component.ts
@@ -66,6 +66,15 @@ export class CareerStructureComponent implements OnInit, TabDirtyCheck {
   });
   levelForm: FormGroup;
 
+  /**
+   * O nivel em edicao — `null` quando o formulario e de cadastro.
+   *
+   * Decide entre criar e atualizar no `saveLevel()`, e por isso
+   * `openLevelForm()` limpa ele: sem isso, cadastrar logo depois de editar
+   * atualizaria o nivel anterior.
+   */
+  readonly editingLevel = signal<PositionLevel | null>(null);
+
   // Dissídio
   adjustmentDialogVisible = false;
   adjustmentForm: FormGroup;
@@ -193,7 +202,20 @@ export class CareerStructureComponent implements OnInit, TabDirtyCheck {
    * coisa legitima de se querer fazer.
    */
   openLevelForm(): void {
+    this.editingLevel.set(null);
     this.levelForm.reset({ adjustmentType: 'FIXED', levelOrder: this.proximaOrdem() });
+    this.mode.set('level');
+  }
+
+  openEditLevel(level: PositionLevel): void {
+    this.editingLevel.set(level);
+    this.levelForm.reset({
+      name: level.name,
+      levelOrder: level.levelOrder,
+      adjustmentType: level.adjustmentType,
+      fixedAmount: level.fixedAmount,
+      percentageIncrease: level.percentageIncrease,
+    });
     this.mode.set('level');
   }
 
@@ -203,17 +225,37 @@ export class CareerStructureComponent implements OnInit, TabDirtyCheck {
 
     const { name, levelOrder, adjustmentType, fixedAmount, percentageIncrease } = this.levelForm.value;
 
-    this.levelStore.create({
+    const requisicao = {
       name,
       levelOrder,
       positionId: position.id,
       adjustmentType,
       fixedAmount: adjustmentType === 'FIXED' ? fixedAmount : null,
       percentageIncrease: adjustmentType === 'PERCENTAGE' ? percentageIncrease : null,
-    }).subscribe({
+    };
+
+    const emEdicao = this.editingLevel();
+
+    (emEdicao
+      ? this.levelStore.update(emEdicao.id, requisicao)
+      : this.levelStore.create(requisicao)
+    ).subscribe({
       next: () => {
         this.closeForm();
-        this.msgService.add({ severity: 'success', summary: 'Sucesso', detail: 'Nível cadastrado com sucesso!' });
+
+        // **Recarrega o cargo inteiro, e nao so a linha que voltou.**
+        //
+        // Nivel percentual resolve o salario sobre o anterior, entao mudar o
+        // valor base do Junior muda o salario calculado de Pleno e Senior
+        // junto. Atualizar so a linha editada deixaria as outras mostrando
+        // salario velho — numa tela de salario.
+        this.levelStore.load(position.id, true);
+
+        this.msgService.add({
+          severity: 'success',
+          summary: 'Sucesso',
+          detail: emEdicao ? 'Nível atualizado com sucesso!' : 'Nível cadastrado com sucesso!',
+        });
       },
       error: (err) => {
         this.msgService.add({ severity: 'warning', summary: 'Erro', detail: this.getErrorMessage(err) });

--- a/src/app/infrastructure/services/hr/position-level.service.ts
+++ b/src/app/infrastructure/services/hr/position-level.service.ts
@@ -20,4 +20,8 @@ export class PositionLevelService {
   create(request: CreatePositionLevelRequest): Observable<PositionLevel> {
     return this.http.post<PositionLevel>(`${environment.apiUrl}/hr/position-levels`, request);
   }
+
+  update(id: string, request: CreatePositionLevelRequest): Observable<PositionLevel> {
+    return this.http.put<PositionLevel>(`${environment.apiUrl}/hr/position-levels/${id}`, request);
+  }
 }

--- a/src/app/infrastructure/state/position.store.ts
+++ b/src/app/infrastructure/state/position.store.ts
@@ -66,6 +66,18 @@ export class PositionLevelStore {
     return this.service.create(request).pipe(tap(level => this.upsert(level)));
   }
 
+  /**
+   * **So faz upsert do nivel editado — quem recarrega a lista e a tela.**
+   *
+   * Nivel percentual resolve o salario sobre o nivel imediatamente anterior,
+   * entao mexer no valor base de um muda o salario calculado de todos os que
+   * vem depois. O upsert daqui atualiza uma linha so; a tela pede `load(id,
+   * true)` para trazer a cascata inteira.
+   */
+  update(id: string, request: CreatePositionLevelRequest): Observable<PositionLevel> {
+    return this.service.update(id, request).pipe(tap(level => this.upsert(level)));
+  }
+
   upsert(level: PositionLevel): void {
     this.byPosition.update(map => {
       const current = map[level.positionId] ?? [];


### PR DESCRIPTION
NAO MERGEAR ANTES DA API: `PUT /api/hr/position-levels/{id}` ainda nao
existe. O cadastro de nivel hoje so tem POST e GET, entao o botao de editar
leva 404 ate a API subir.

A tela so cadastrava nivel. Valor base digitado errado — ou so desatualizado
— nao tinha como ser corrigido: a saida era criar outro nivel e conviver com
o errado na lista.

O DETALHE QUE MANDA NO DESENHO E A CASCATA. Nivel percentual resolve o
salario sobre o nivel imediatamente anterior (PositionLevelSalaryResolver na
API), entao mudar o valor base do Junior muda o salario calculado de Pleno e
Senior junto. Por isso, depois de salvar, a tela recarrega os niveis do cargo
inteiro em vez de so trocar a linha que voltou: atualizar uma linha deixaria
as outras mostrando salario velho, numa tela de salario.

O `editingLevel` decide entre criar e atualizar, e `openLevelForm()` limpa
ele — sem isso, cadastrar logo depois de editar atualizaria o nivel anterior.
Tem teste para essa sequencia.

Trocar para percentual zera o valor fixo e vice-versa, como o cadastro ja
fazia.

O QUE A API PRECISA EXPOR
- PUT /api/hr/position-levels/{id}, mesmo corpo do POST, devolvendo o nivel
  com o `resolvedSalary` recalculado
